### PR TITLE
Test padding for apply and undo alias

### DIFF
--- a/test/base_client_test.go
+++ b/test/base_client_test.go
@@ -132,13 +132,10 @@ func TestIntegrationBaseClient_TransactionSender(t *testing.T) {
 	defer client.Close()
 	assert.NoError(t, err, "clients.Dial should not return an error")
 
-	block, err := client.BlockByNumber(context.Background(), nil)
-	assert.NoError(t, err, "BlockByNumber should not return an error")
-
-	tx, _, err := client.TransactionByHash(context.Background(), block.Transactions[0].Hash)
+	tx, _, err := client.TransactionByHash(context.Background(), L2DepositTx)
 	assert.NoError(t, err, "TransactionByHash should not return an error")
 
-	sender, err := client.TransactionSender(context.Background(), tx, block.Hash, 0)
+	sender, err := client.TransactionSender(context.Background(), tx, *tx.BlockHash, uint(tx.TransactionIndex))
 
 	assert.NoError(t, err, "TransactionSender should not return an error")
 	assert.NotNil(t, sender, "TransactionSender should return a non-nil sender")

--- a/test/base_client_test.go
+++ b/test/base_client_test.go
@@ -120,10 +120,7 @@ func TestIntegrationBaseClient_TransactionByHash(t *testing.T) {
 	defer client.Close()
 	assert.NoError(t, err, "clients.Dial should not return an error")
 
-	block, err := client.BlockByNumber(context.Background(), nil)
-	assert.NoError(t, err, "BlockByNumber should not return an error")
-
-	tx, isPending, err := client.TransactionByHash(context.Background(), block.Transactions[0].Hash)
+	tx, isPending, err := client.TransactionByHash(context.Background(), L2DepositTx)
 
 	assert.NoError(t, err, "TransactionByHash should not return an error")
 	assert.NotNil(t, tx, "TransactionByHash should return a non-nil transaction")

--- a/utils/contract_test.go
+++ b/utils/contract_test.go
@@ -14,10 +14,24 @@ func TestApplyL1ToL2Alias(t *testing.T) {
 	assert.Equal(t, expected, l2ContractAddress, "Addresses should be the same")
 }
 
+func TestApplyL1ToL2AliasZeroAddress(t *testing.T) {
+	l1ContractAddress := common.HexToAddress("0xeeeeffffffffffffffffffffffffffffffffeeef")
+	l2ContractAddress := ApplyL1ToL2Alias(l1ContractAddress)
+	expected := common.HexToAddress("0x0000000000000000000000000000000000000000")
+	assert.Equal(t, expected, l2ContractAddress, "Addresses should be the same")
+}
+
 func TestUndoL1ToL2Alias(t *testing.T) {
 	l2ContractAddress := common.HexToAddress("0x813A42B8205E5DedCd3374e5f4419843ADa77FFC")
 	l1ContractAddress := UndoL1ToL2Alias(l2ContractAddress)
 	expected := common.HexToAddress("0x702942B8205E5dEdCD3374E5f4419843adA76Eeb")
+	assert.Equal(t, expected, l1ContractAddress, "Addresses should be the same")
+}
+
+func TestUndoL1ToL2AliasZeroAddress(t *testing.T) {
+	l2ContractAddress := common.HexToAddress("0x1111000000000000000000000000000000001111")
+	l1ContractAddress := UndoL1ToL2Alias(l2ContractAddress)
+	expected := common.HexToAddress("0x0000000000000000000000000000000000000000")
 	assert.Equal(t, expected, l1ContractAddress, "Addresses should be the same")
 }
 


### PR DESCRIPTION
# What :computer: 
* Add additional tests for `utils.ApplyL1ToL2Alias` and `utils.UndoL1ToL2Alias` to cover cases where padding needs to be done because the bytes are smaller than 20 bytes.