### PR TITLE
fix(accounts): use correct token when trasfering and withdrawing ETH

### DIFF
--- a/accounts/wallet_l1.go
+++ b/accounts/wallet_l1.go
@@ -406,7 +406,7 @@ func (a *WalletL1) FullRequiredDepositFee(ctx context.Context, msg DepositCallMs
 	}
 
 	if a.isEthBasedChain {
-		selfBalanceETH, balanceErr := a.BalanceL1(nil, utils.LegacyEthAddress)
+		selfBalanceETH, balanceErr := a.BalanceL1(nil, utils.EthAddressInContracts)
 		if balanceErr != nil {
 			return nil, balanceErr
 		}
@@ -414,7 +414,7 @@ func (a *WalletL1) FullRequiredDepositFee(ctx context.Context, msg DepositCallMs
 		// the account needs to have a sufficient ETH balance.
 		if baseCost.Cmp(new(big.Int).Add(selfBalanceETH, dummyAmount)) >= 0 {
 			recommendedETHBalance := utils.L1RecommendedMinEthDepositGasLimit
-			if msg.Token != utils.LegacyEthAddress {
+			if msg.Token == utils.EthAddressInContracts {
 				recommendedETHBalance = utils.L1RecommendedMinErc20DepositGasLimit
 			}
 			recommendedETHBalance.Mul(recommendedETHBalance, gasPriceForEstimation)


### PR DESCRIPTION
# What :computer: 
* Use correct token address when transfering and withdrawing ETH on non-eth-based chain.