### PR TITLE
feat: redesign `Signer` and replace `BaseSigner` with `ECDSASigner`

### DIFF
--- a/accounts/util.go
+++ b/accounts/util.go
@@ -38,11 +38,11 @@ func ensureTransactOpts(auth *TransactOpts) *TransactOpts {
 	return auth
 }
 
-func newTransactorWithSigner(signer *Signer, chainID *big.Int) (*bind.TransactOpts, error) {
+func newTransactorWithSigner(signer *ECDSASigner, chainID *big.Int) (*bind.TransactOpts, error) {
 	if chainID == nil {
 		return nil, bind.ErrNoChainID
 	}
-	keyAddr := (*signer).Address()
+	keyAddr := signer.Address()
 	latestSigner := types.LatestSignerForChainID(chainID)
 	return &bind.TransactOpts{
 		From: keyAddr,
@@ -50,7 +50,7 @@ func newTransactorWithSigner(signer *Signer, chainID *big.Int) (*bind.TransactOp
 			if address != keyAddr {
 				return nil, bind.ErrNotAuthorized
 			}
-			signature, err := (*signer).SignHash(latestSigner.Hash(tx).Bytes())
+			signature, err := signer.SignMessage(context.Background(), latestSigner.Hash(tx).Bytes())
 			if err != nil {
 				return nil, err
 			}

--- a/accounts/wallet.go
+++ b/accounts/wallet.go
@@ -28,12 +28,11 @@ func NewWallet(rawPrivateKey []byte, clientL2 *clients.Client, clientL1 *ethclie
 	if err != nil {
 		return nil, err
 	}
-	signer, err := NewBaseSignerFromRawPrivateKey(rawPrivateKey, chainID.Int64())
+	signer, err := NewECDSASignerFromRawPrivateKey(rawPrivateKey, chainID)
 	if err != nil {
 		return nil, err
 	}
-	s := Signer(signer)
-	return NewWalletFromSigner(&s, clientL2, clientL1)
+	return NewWalletFromSigner(signer, clientL2, clientL1)
 }
 
 // NewWalletFromSigner creates an instance of Wallet associated with the account provided by the signer.
@@ -42,7 +41,7 @@ func NewWallet(rawPrivateKey []byte, clientL2 *clients.Client, clientL1 *ethclie
 // require communication with the network.
 // A runner that contains only a signer can be configured to communicate with L2 and L1 networks by
 // using Wallet.Connect and Wallet.ConnectL1, respectively.
-func NewWalletFromSigner(signer *Signer, clientL2 *clients.Client, clientL1 *ethclient.Client) (*Wallet, error) {
+func NewWalletFromSigner(signer *ECDSASigner, clientL2 *clients.Client, clientL1 *ethclient.Client) (*Wallet, error) {
 	if signer == nil {
 		return nil, errors.New("signer must be provided")
 	}
@@ -73,38 +72,35 @@ func NewWalletFromSigner(signer *Signer, clientL2 *clients.Client, clientL1 *eth
 // NewWalletFromMnemonic creates a new instance of Wallet based on the provided mnemonic phrase.
 // The clientL2 and clientL1 parameters are optional, and can be configured with Wallet.Connect
 // and Wallet.ConnectL1, respectively.
-func NewWalletFromMnemonic(mnemonic string, chainId int64, clientL2 *clients.Client, clientL1 *ethclient.Client) (*Wallet, error) {
-	signer, err := NewBaseSignerFromMnemonic(mnemonic, chainId)
+func NewWalletFromMnemonic(mnemonic string, chainId *big.Int, clientL2 *clients.Client, clientL1 *ethclient.Client) (*Wallet, error) {
+	signer, err := NewECDSASignerFromMnemonic(mnemonic, chainId)
 	if err != nil {
 		return nil, err
 	}
-	s := Signer(signer)
-	return NewWalletFromSigner(&s, clientL2, clientL1)
+	return NewWalletFromSigner(signer, clientL2, clientL1)
 }
 
 // NewWalletFromRawPrivateKey creates a new instance of Wallet based on the provided private key
 // of the account and chain ID.
 // The clientL2 and clientL1 parameters are optional, and can be configured with Wallet.Connect
 // and Wallet.ConnectL1, respectively.
-func NewWalletFromRawPrivateKey(rawPk []byte, chainId int64, clientL2 *clients.Client, clientL1 *ethclient.Client) (*Wallet, error) {
-	signer, err := NewBaseSignerFromRawPrivateKey(rawPk, chainId)
+func NewWalletFromRawPrivateKey(rawPk []byte, chainId *big.Int, clientL2 *clients.Client, clientL1 *ethclient.Client) (*Wallet, error) {
+	signer, err := NewECDSASignerFromRawPrivateKey(rawPk, chainId)
 	if err != nil {
 		return nil, err
 	}
-	s := Signer(signer)
-	return NewWalletFromSigner(&s, clientL2, clientL1)
+	return NewWalletFromSigner(signer, clientL2, clientL1)
 }
 
 // NewRandomWallet creates an instance of Wallet with a randomly generated account.
 // The clientL2 and clientL1 parameters are optional, and can be configured with Wallet.Connect
 // and Wallet.ConnectL1, respectively.
-func NewRandomWallet(chainId int64, clientL2 *clients.Client, clientL1 *ethclient.Client) (*Wallet, error) {
+func NewRandomWallet(chainId *big.Int, clientL2 *clients.Client, clientL1 *ethclient.Client) (*Wallet, error) {
 	signer, err := NewRandomBaseSigner(chainId)
 	if err != nil {
 		return nil, err
 	}
-	s := Signer(signer)
-	return NewWalletFromSigner(&s, clientL2, clientL1)
+	return NewWalletFromSigner(signer, clientL2, clientL1)
 }
 
 // Nonce returns the account nonce of the associated account.
@@ -121,12 +117,10 @@ func (w *Wallet) PendingNonce(ctx context.Context) (uint64, error) {
 
 // Connect returns a new instance of Wallet with the provided client for the L2 network.
 func (w *Wallet) Connect(client *clients.Client) (*Wallet, error) {
-	s := w.Signer()
-	return NewWalletFromSigner(&s, client, w.clientL1)
+	return NewWalletFromSigner(w.Signer(), client, w.clientL1)
 }
 
 // ConnectL1 returns a new instance of Wallet with the provided client for the L1 network.
 func (w *Wallet) ConnectL1(client *ethclient.Client) (*Wallet, error) {
-	s := w.Signer()
-	return NewWalletFromSigner(&s, w.clientL2, client)
+	return NewWalletFromSigner(w.Signer(), w.clientL2, client)
 }

--- a/accounts/wallet_l2.go
+++ b/accounts/wallet_l2.go
@@ -23,7 +23,7 @@ import (
 // L2 network for the associated account.
 type WalletL2 struct {
 	client    *clients.Client
-	signer    *Signer
+	signer    *ECDSASigner
 	auth      *bind.TransactOpts
 	baseToken common.Address
 
@@ -40,19 +40,18 @@ func NewWalletL2(rawPrivateKey []byte, client *clients.Client) (*WalletL2, error
 	if err != nil {
 		return nil, err
 	}
-	signer, err := NewBaseSignerFromRawPrivateKey(rawPrivateKey, chainID.Int64())
+	signer, err := NewECDSASignerFromRawPrivateKey(rawPrivateKey, chainID)
 	if err != nil {
 		return nil, err
 	}
-	s := Signer(signer)
-	return NewWalletL2FromSigner(&s, client)
+	return NewWalletL2FromSigner(signer, client)
 }
 
 // NewWalletL2FromSigner creates an instance of WalletL2.
 // The client can be optional; if it is not provided, only AdapterL2.SignTransaction,
 // AdapterL2.Address, AdapterL2.Signer can be performed, as the rest of the
 // functionalities require communication to the network.
-func NewWalletL2FromSigner(signer *Signer, client *clients.Client) (*WalletL2, error) {
+func NewWalletL2FromSigner(signer *ECDSASigner, client *clients.Client) (*WalletL2, error) {
 	if client == nil {
 		return &WalletL2{signer: signer}, nil
 	}
@@ -92,74 +91,74 @@ func NewWalletL2FromSigner(signer *Signer, client *clients.Client) (*WalletL2, e
 }
 
 // Address returns the address of the associated account.
-func (a *WalletL2) Address() common.Address {
-	return a.auth.From
+func (w *WalletL2) Address() common.Address {
+	return w.auth.From
 }
 
 // Signer returns the signer of the associated account.
-func (a *WalletL2) Signer() Signer {
-	return *a.signer
+func (w *WalletL2) Signer() *ECDSASigner {
+	return w.signer
 }
 
 // Balance returns the balance of the specified token that can be either base token or any ERC20 token.
 // The block number can be nil, in which case the balance is taken from the latest known block.
-func (a *WalletL2) Balance(ctx context.Context, token common.Address, at *big.Int) (*big.Int, error) {
+func (w *WalletL2) Balance(ctx context.Context, token common.Address, at *big.Int) (*big.Int, error) {
 	if token == utils.LegacyEthAddress || token == utils.EthAddressInContracts {
 		var err error
-		token, err = a.client.L2TokenAddress(ctx, token)
+		token, err = w.client.L2TokenAddress(ctx, token)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	if token == utils.L2BaseTokenAddress {
-		return a.client.BalanceAt(ensureContext(ctx), a.Address(), at)
+		return w.client.BalanceAt(ensureContext(ctx), w.Address(), at)
 	}
-	erc20Token, err := erc20.NewIERC20(token, a.client)
+	erc20Token, err := erc20.NewIERC20(token, w.client)
 	if err != nil {
 		return nil, err
 	}
 	return erc20Token.BalanceOf(&bind.CallOpts{
-		From:        a.Address(),
+		From:        w.Address(),
 		BlockNumber: at,
 		Context:     ensureContext(ctx),
-	}, a.Address())
+	}, w.Address())
 }
 
 // AllBalances returns all balances for confirmed tokens given by an associated account.
-func (a *WalletL2) AllBalances(ctx context.Context) (map[common.Address]*big.Int, error) {
-	return a.client.AllAccountBalances(ensureContext(ctx), a.Address())
+func (w *WalletL2) AllBalances(ctx context.Context) (map[common.Address]*big.Int, error) {
+	return w.client.AllAccountBalances(ensureContext(ctx), w.Address())
 }
 
 // L2BridgeContracts returns L2 bridge contracts.
-func (a *WalletL2) L2BridgeContracts(_ context.Context) (*types.L2BridgeContracts, error) {
-	return &types.L2BridgeContracts{Erc20: a.defaultL2Bridge, Shared: a.sharedL2Bridge}, nil
+func (w *WalletL2) L2BridgeContracts(_ context.Context) (*types.L2BridgeContracts, error) {
+	return &types.L2BridgeContracts{Erc20: w.defaultL2Bridge, Shared: w.sharedL2Bridge}, nil
 }
 
 // DeploymentNonce returns the deployment nonce of the account.
-func (a *WalletL2) DeploymentNonce(opts *CallOpts) (*big.Int, error) {
-	callOpts := ensureCallOpts(opts).ToCallOpts(a.auth.From)
-	nonceHolder, err := nonceholder.NewINonceHolder(utils.NonceHolderAddress, a.client)
+func (w *WalletL2) DeploymentNonce(opts *CallOpts) (*big.Int, error) {
+	callOpts := ensureCallOpts(opts).ToCallOpts(w.auth.From)
+	nonceHolder, err := nonceholder.NewINonceHolder(utils.NonceHolderAddress, w.client)
 	if err != nil {
 		return nil, err
 	}
-	return nonceHolder.GetDeploymentNonce(callOpts, a.Address())
+	return nonceHolder.GetDeploymentNonce(callOpts, w.Address())
 }
 
 // IsBaseToken returns whether the token is the base token.
-func (a *WalletL2) IsBaseToken(ctx context.Context, token common.Address) (bool, error) {
-	return a.client.IsBaseToken(ensureContext(ctx), token)
+func (w *WalletL2) IsBaseToken(ctx context.Context, token common.Address) (bool, error) {
+	return w.client.IsBaseToken(ensureContext(ctx), token)
 }
 
 // Withdraw initiates the withdrawal process which withdraws ETH or any ERC20
 // token from the associated account on L2 network to the target account on L1
 // network.
-func (a *WalletL2) Withdraw(auth *TransactOpts, tx WithdrawalTransaction) (*ethTypes.Transaction, error) {
-	opts := ensureTransactOpts(auth).ToTransactOpts(a.Address(), a.auth.Signer)
+func (w *WalletL2) Withdraw(auth *TransactOpts, tx WithdrawalTransaction) (*ethTypes.Transaction, error) {
+	opts := ensureTransactOpts(auth).ToTransactOpts(w.Address(), w.auth.Signer)
 
 	if tx.Token == utils.LegacyEthAddress || tx.Token == utils.EthAddressInContracts {
 		var err error
-		tx.Token, err = a.client.L2TokenAddress(opts.Context, tx.Token)
+		tx.Token, err = w.client.L2TokenAddress(opts.Context, tx.Token)
 		if err != nil {
 			return nil, err
 		}
@@ -172,7 +171,7 @@ func (a *WalletL2) Withdraw(auth *TransactOpts, tx WithdrawalTransaction) (*ethT
 			opts.Value = tx.Amount
 		}
 
-		eth, ethTokenErr := ethtoken.NewIEthToken(utils.L2BaseTokenAddress, a.client)
+		eth, ethTokenErr := ethtoken.NewIEthToken(utils.L2BaseTokenAddress, w.client)
 		if ethTokenErr != nil {
 			return nil, ethTokenErr
 		}
@@ -183,9 +182,9 @@ func (a *WalletL2) Withdraw(auth *TransactOpts, tx WithdrawalTransaction) (*ethT
 		return withdrawTx, nil
 	} else {
 		if tx.BridgeAddress == nil {
-			tx.BridgeAddress = &a.sharedL2BridgeAddress
+			tx.BridgeAddress = &w.sharedL2BridgeAddress
 		}
-		bridge, bridgeErr := l2bridge.NewIL2Bridge(*tx.BridgeAddress, a.client)
+		bridge, bridgeErr := l2bridge.NewIL2Bridge(*tx.BridgeAddress, w.client)
 		if bridgeErr != nil {
 			return nil, bridgeErr
 		}
@@ -198,12 +197,12 @@ func (a *WalletL2) Withdraw(auth *TransactOpts, tx WithdrawalTransaction) (*ethT
 }
 
 // EstimateGasWithdraw estimates the amount of gas required for a withdrawal transaction.
-func (a *WalletL2) EstimateGasWithdraw(ctx context.Context, msg WithdrawalCallMsg) (uint64, error) {
-	return a.client.EstimateGasWithdraw(ensureContext(ctx), msg.ToWithdrawalCallMsg(a.Address()))
+func (w *WalletL2) EstimateGasWithdraw(ctx context.Context, msg WithdrawalCallMsg) (uint64, error) {
+	return w.client.EstimateGasWithdraw(ensureContext(ctx), msg.ToWithdrawalCallMsg(w.Address()))
 }
 
 // Transfer moves the base token or any ERC20 token from the associated account to the target account.
-func (a *WalletL2) Transfer(auth *TransactOpts, tx TransferTransaction) (*ethTypes.Transaction, error) {
+func (w *WalletL2) Transfer(auth *TransactOpts, tx TransferTransaction) (*ethTypes.Transaction, error) {
 	// returns types.Transaction
 	// check the type of the transaction
 
@@ -211,14 +210,14 @@ func (a *WalletL2) Transfer(auth *TransactOpts, tx TransferTransaction) (*ethTyp
 
 	if tx.Token == utils.LegacyEthAddress || tx.Token == utils.EthAddressInContracts {
 		var err error
-		tx.Token, err = a.client.L2TokenAddress(opts.Context, tx.Token)
+		tx.Token, err = w.client.L2TokenAddress(opts.Context, tx.Token)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	if opts.GasLimit == 0 {
-		gas, gasErr := a.client.EstimateGasTransfer(opts.Context, tx.ToTransferCallMsg(a.Address(), opts))
+		gas, gasErr := w.client.EstimateGasTransfer(opts.Context, tx.ToTransferCallMsg(w.Address(), opts))
 		if gasErr != nil {
 			return nil, gasErr
 		}
@@ -226,19 +225,19 @@ func (a *WalletL2) Transfer(auth *TransactOpts, tx TransferTransaction) (*ethTyp
 	}
 
 	if tx.Token == utils.L2BaseTokenAddress {
-		return a.transferBaseToken(opts, tx)
+		return w.transferBaseToken(opts, tx)
 	}
-	token, err := erc20.NewIERC20(tx.Token, a.client)
+	token, err := erc20.NewIERC20(tx.Token, w.client)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load erc20 contract: %w", err)
 	}
 	opts.Value = big.NewInt(0)
-	return token.Transfer(opts.ToTransactOpts(a.Address(), a.auth.Signer), tx.To, tx.Amount)
+	return token.Transfer(opts.ToTransactOpts(w.Address(), w.auth.Signer), tx.To, tx.Amount)
 }
 
 // EstimateGasTransfer estimates the amount of gas required for a transfer transaction.
-func (a *WalletL2) EstimateGasTransfer(ctx context.Context, msg TransferCallMsg) (uint64, error) {
-	return a.client.EstimateGasTransfer(ensureContext(ctx), msg.ToTransferCallMsg(a.Address()))
+func (w *WalletL2) EstimateGasTransfer(ctx context.Context, msg TransferCallMsg) (uint64, error) {
+	return w.client.EstimateGasTransfer(ensureContext(ctx), msg.ToTransferCallMsg(w.Address()))
 }
 
 // CallContract executes a message call for EIP-712 transaction, which is
@@ -247,8 +246,8 @@ func (a *WalletL2) EstimateGasTransfer(ctx context.Context, msg TransferCallMsg)
 // blockNumber selects the block height at which the call runs. It can be nil, in
 // which case the code is taken from the latest known block. Note that state from
 // very old blocks might not be available.
-func (a *WalletL2) CallContract(ctx context.Context, msg CallMsg, blockNumber *big.Int) ([]byte, error) {
-	return a.client.CallContractL2(ensureContext(ctx), msg.ToCallMsg(a.Address()), blockNumber)
+func (w *WalletL2) CallContract(ctx context.Context, msg CallMsg, blockNumber *big.Int) ([]byte, error) {
+	return w.client.CallContractL2(ensureContext(ctx), msg.ToCallMsg(w.Address()), blockNumber)
 }
 
 // PopulateTransaction is designed for users who prefer a simplified approach by
@@ -256,19 +255,19 @@ func (a *WalletL2) CallContract(ctx context.Context, msg CallMsg, blockNumber *b
 // required fields are Transaction.To and either Transaction.Data or
 // Transaction.Value (or both, if the method is payable). Any other fields that
 // are not set will be prepared by this method.
-func (a *WalletL2) PopulateTransaction(ctx context.Context, tx Transaction) (*types.Transaction, error) {
+func (w *WalletL2) PopulateTransaction(ctx context.Context, tx Transaction) (*types.Transaction, error) {
 	if tx.ChainID == nil {
-		tx.ChainID = (*a.signer).Domain().ChainId
+		tx.ChainID = w.signer.ChainID()
 	}
 	if tx.Nonce == nil {
-		nonce, err := a.client.NonceAt(ensureContext(ctx), a.Address(), nil)
+		nonce, err := w.client.NonceAt(ensureContext(ctx), w.Address(), nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get nonce: %w", err)
 		}
 		tx.Nonce = new(big.Int).SetUint64(nonce)
 	}
 	if tx.GasFeeCap == nil {
-		gasFeeCap, err := a.client.SuggestGasPrice(ensureContext(ctx))
+		gasFeeCap, err := w.client.SuggestGasPrice(ensureContext(ctx))
 		if err != nil {
 			return nil, fmt.Errorf("failed to SuggestGasPrice: %w", err)
 		}
@@ -281,7 +280,7 @@ func (a *WalletL2) PopulateTransaction(ctx context.Context, tx Transaction) (*ty
 		tx.GasPerPubdata = utils.DefaultGasPerPubdataLimit
 	}
 	if tx.Gas == 0 || tx.GasFeeCap == nil {
-		fee, err := a.client.EstimateFee(ensureContext(ctx), tx.ToCallMsg(a.Address()))
+		fee, err := w.client.EstimateFee(ensureContext(ctx), tx.ToCallMsg(w.Address()))
 		if err != nil {
 			return nil, fmt.Errorf("failed to EstimateFee: %w", err)
 		}
@@ -296,19 +295,19 @@ func (a *WalletL2) PopulateTransaction(ctx context.Context, tx Transaction) (*ty
 	if tx.Data == nil {
 		tx.Data = hexutil.Bytes{}
 	}
-	return tx.ToTransaction712(a.auth.From), nil
+	return tx.ToTransaction712(w.auth.From), nil
 }
 
 // SignTransaction returns a signed transaction that is ready to be broadcast to
 // the network. The input transaction must be a valid transaction with all fields
 // having appropriate values. To obtain a valid transaction, you can use the
 // PopulateTransaction method.
-func (a *WalletL2) SignTransaction(tx *types.Transaction) ([]byte, error) {
+func (w *WalletL2) SignTransaction(tx *types.Transaction) ([]byte, error) {
 	var gas uint64 = 0
 	if tx.Gas != nil {
 		gas = tx.Gas.Uint64()
 	}
-	preparedTx, err := a.PopulateTransaction(context.Background(), Transaction{
+	preparedTx, err := w.PopulateTransaction(context.Background(), Transaction{
 		To:              tx.To,
 		Data:            tx.Data,
 		Value:           tx.Value,
@@ -330,7 +329,7 @@ func (a *WalletL2) SignTransaction(tx *types.Transaction) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	signature, err := (*a.signer).SignTypedData(*typedData)
+	signature, err := w.signer.SignTypedData(context.Background(), typedData)
 	if err != nil {
 		return nil, err
 	}
@@ -339,22 +338,22 @@ func (a *WalletL2) SignTransaction(tx *types.Transaction) ([]byte, error) {
 
 // SendTransaction injects a transaction into the pending pool for execution. Any
 // unset transaction fields are prepared using the PopulateTransaction method.
-func (a *WalletL2) SendTransaction(ctx context.Context, tx *Transaction) (common.Hash, error) {
-	preparedTx, err := a.PopulateTransaction(ensureContext(ctx), *tx)
+func (w *WalletL2) SendTransaction(ctx context.Context, tx *Transaction) (common.Hash, error) {
+	preparedTx, err := w.PopulateTransaction(ensureContext(ctx), *tx)
 	if err != nil {
 		return common.Hash{}, err
 	}
-	rawTx, err := a.SignTransaction(preparedTx)
+	rawTx, err := w.SignTransaction(preparedTx)
 	if err != nil {
 		return common.Hash{}, err
 	}
-	return a.client.SendRawTransaction(ensureContext(ctx), rawTx)
+	return w.client.SendRawTransaction(ensureContext(ctx), rawTx)
 }
 
-func (a *WalletL2) transferBaseToken(auth *TransactOpts, tx TransferTransaction) (*ethTypes.Transaction, error) {
+func (w *WalletL2) transferBaseToken(auth *TransactOpts, tx TransferTransaction) (*ethTypes.Transaction, error) {
 	if auth.GasPrice != nil {
 		if auth.Nonce == nil {
-			nonce, err := a.client.NonceAt(auth.Context, a.Address(), nil)
+			nonce, err := w.client.NonceAt(auth.Context, w.Address(), nil)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get nonce: %w", err)
 			}
@@ -370,20 +369,20 @@ func (a *WalletL2) transferBaseToken(auth *TransactOpts, tx TransferTransaction)
 				Value:    tx.Amount,
 			})
 
-		signedTx, _ := ethTypes.SignTx(transaction, ethTypes.NewLondonSigner((*a.signer).Domain().ChainId), (*a.signer).PrivateKey())
-		err := a.client.SendTransaction(auth.Context, signedTx)
+		signedTx, _ := ethTypes.SignTx(transaction, ethTypes.NewLondonSigner(w.signer.ChainID()), w.signer.PrivateKey())
+		err := w.client.SendTransaction(auth.Context, signedTx)
 		if err != nil {
 			return nil, err
 		}
 		return signedTx, nil
 	} else {
-		preparedTx, err := a.PopulateTransaction(auth.Context, *tx.ToTransaction(auth))
+		preparedTx, err := w.PopulateTransaction(auth.Context, *tx.ToTransaction(auth))
 		if err != nil {
 			return nil, err
 		}
 		transaction := ethTypes.NewTx(
 			&ethTypes.DynamicFeeTx{
-				ChainID:   (*a.signer).Domain().ChainId,
+				ChainID:   w.signer.ChainID(),
 				Nonce:     preparedTx.Nonce.Uint64(),
 				GasTipCap: preparedTx.GasTipCap,
 				GasFeeCap: preparedTx.GasFeeCap,
@@ -391,8 +390,8 @@ func (a *WalletL2) transferBaseToken(auth *TransactOpts, tx TransferTransaction)
 				To:        preparedTx.To,
 				Value:     preparedTx.Value,
 			})
-		signedTx, _ := ethTypes.SignTx(transaction, ethTypes.NewLondonSigner((*a.signer).Domain().ChainId), (*a.signer).PrivateKey())
-		err = a.client.SendTransaction(auth.Context, signedTx)
+		signedTx, _ := ethTypes.SignTx(transaction, ethTypes.NewLondonSigner(w.signer.ChainID()), w.signer.PrivateKey())
+		err = w.client.SendTransaction(auth.Context, signedTx)
 		if err != nil {
 			return nil, err
 		}

--- a/test/account_abstraction_test.go
+++ b/test/account_abstraction_test.go
@@ -53,7 +53,7 @@ func TestIntegration_ApprovalPaymaster(t *testing.T) {
 	token, err := NewToken(tokenAddress, client)
 	assert.NoError(t, err, "NewToken should not return an error")
 
-	opts, err := bind.NewKeyedTransactorWithChainID(wallet.Signer().PrivateKey(), wallet.Signer().Domain().ChainId)
+	opts, err := bind.NewKeyedTransactorWithChainID(wallet.Signer().PrivateKey(), wallet.Signer().ChainID())
 	assert.NoError(t, err, "NewKeyedTransactorWithChainID should not return an error")
 
 	mint, err := token.Mint(opts, wallet.Address(), AirdropAmount)

--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -162,7 +162,7 @@ func deployPaymasterAndToken(wallet *accounts.Wallet, client *clients.Client) {
 		log.Fatal(err)
 	}
 
-	opts, err := bind.NewKeyedTransactorWithChainID(wallet.Signer().PrivateKey(), wallet.Signer().Domain().ChainId)
+	opts, err := bind.NewKeyedTransactorWithChainID(wallet.Signer().PrivateKey(), wallet.Signer().ChainID())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/test/wallet_test.go
+++ b/test/wallet_test.go
@@ -34,7 +34,7 @@ func TestIntegration_NewWalletFromMnemonic(t *testing.T) {
 	chainId, err := client.ChainID(context.Background())
 	assert.NoError(t, err, "ChainID should not return an error")
 
-	wallet, err := accounts.NewWalletFromMnemonic(MNEMONIC, chainId.Int64(), client, ethClient)
+	wallet, err := accounts.NewWalletFromMnemonic(MNEMONIC, chainId, client, ethClient)
 	assert.NoError(t, err, "NewWalletFromMnemonic should not return an error")
 	assert.NotNil(t, wallet, "Wallet should not be nil")
 }
@@ -1337,7 +1337,7 @@ func TestIntegration_EthBasedChain_Wallet_FullRequiredDepositFeeNotEnoughBalance
 	chainId, err := client.ChainID(context.Background())
 	assert.NoError(t, err, "ChainID should not return an error")
 
-	wallet, err := accounts.NewRandomWallet(chainId.Int64(), client, ethClient)
+	wallet, err := accounts.NewRandomWallet(chainId, client, ethClient)
 	assert.NoError(t, err, "NewRandomWallet should not return an error")
 
 	_, err = wallet.FullRequiredDepositFee(context.Background(), accounts.DepositCallMsg{
@@ -1756,7 +1756,7 @@ func TestIntegration_NonEthBasedChain_Wallet_FullRequiredDepositFeeNotEnoughBase
 	chainId, err := client.ChainID(context.Background())
 	assert.NoError(t, err, "ChainID should not return an error")
 
-	wallet, err := accounts.NewRandomWallet(chainId.Int64(), client, ethClient)
+	wallet, err := accounts.NewRandomWallet(chainId, client, ethClient)
 	assert.NoError(t, err, "NewRandomWallet should not return an error")
 
 	_, err = wallet.FullRequiredDepositFee(context.Background(), accounts.DepositCallMsg{
@@ -1913,7 +1913,7 @@ func TestIntegration_NonEthBasedChain_Wallet_FullRequiredDepositFeeTokenNotEnoug
 	l1ChainId, err := ethClient.ChainID(context.Background())
 	assert.NoError(t, err, "ethClient.ChainID should not return an error")
 
-	randomWallet, err := accounts.NewRandomWallet(l2ChainId.Int64(), client, ethClient)
+	randomWallet, err := accounts.NewRandomWallet(l2ChainId, client, ethClient)
 	assert.NoError(t, err, "NewRandomWallet should not return an error")
 
 	amount, ok := new(big.Int).SetString("500000000000000000", 10)


### PR DESCRIPTION
# What :computer: 
* Improve the design of `Signer` interface.
* Replace the `BaseSigner` with `ECDSASigner`, and use `ECDSASigner` in constructors for `Wallet`, `WalletL1`, `WalletL2`.