### PR TITLE
refactor(types): optimize the sizes of `int` and `uint` for onchain structs

### DIFF
--- a/types/block.go
+++ b/types/block.go
@@ -35,25 +35,25 @@ type BatchDetails struct {
 	CommittedAt    time.Time    `json:"committedAt"`    // The timestamp when the block was committed on L1.
 	ExecuteTxHash  *common.Hash `json:"executeTxHash"`  // The transaction hash of the execution on L1.
 	ExecutedAt     time.Time    `json:"executedAt"`     // The timestamp when the block execution was completed on L1.
-	L1GasPrice     uint         `json:"l1GasPrice"`     // L1 gas price at the time of the block's execution.
-	L1TxCount      uint         `json:"l1TxCount"`      // The number of L1 transactions included in the batch.
-	L2FairGasPrice uint         `json:"l2FairGasPrice"` // Fair gas price on L2 at the time of the block's execution.
-	L2TxCount      uint         `json:"l2TxCount"`      // The number of L2 transactions associated with this batch.
-	Number         uint         `json:"number"`         // L1 batch number.
+	L1GasPrice     uint64       `json:"l1GasPrice"`     // L1 gas price at the time of the block's execution.
+	L1TxCount      uint64       `json:"l1TxCount"`      // The number of L1 transactions included in the batch.
+	L2FairGasPrice uint64       `json:"l2FairGasPrice"` // Fair gas price on L2 at the time of the block's execution.
+	L2TxCount      uint64       `json:"l2TxCount"`      // The number of L2 transactions associated with this batch.
+	Number         uint64       `json:"number"`         // L1 batch number.
 	ProveTxHash    *common.Hash `json:"proveTxHash"`    // The transaction hash of the proof submission on L1.
 	ProvenAt       time.Time    `json:"provenAt"`       // The timestamp when the proof was submitted on L1.
 	RootHash       *common.Hash `json:"rootHash"`       // Root hash of the state after processing the batch.
 	Status         string       `json:"status"`         // Current status of the batch (e.g., verified).
-	Timestamp      uint         `json:"timestamp"`      // Unix timestamp when the batch was processed.
+	Timestamp      uint64       `json:"timestamp"`      // Unix timestamp when the batch was processed.
 }
 
 // BlockDetails contains block details.
 type BlockDetails struct {
-	Number         uint         `json:"number"`         // The number of the block.
-	L1BatchNumber  uint         `json:"l1BatchNumber"`  // Corresponding L1 batch number.
-	Timestamp      uint         `json:"timestamp"`      // Unix timestamp when the block was committed.
-	L1TxCount      uint         `json:"l1TxCount"`      // The number of L1 transactions included in the block.
-	L2TxCount      uint         `json:"l2TxCount"`      // The number of L2 transactions included in the block.
+	Number         uint64       `json:"number"`         // The number of the block.
+	L1BatchNumber  uint64       `json:"l1BatchNumber"`  // Corresponding L1 batch number.
+	Timestamp      uint64       `json:"timestamp"`      // Unix timestamp when the block was committed.
+	L1TxCount      uint64       `json:"l1TxCount"`      // The number of L1 transactions included in the block.
+	L2TxCount      uint64       `json:"l2TxCount"`      // The number of L2 transactions included in the block.
 	RootHash       common.Hash  `json:"rootHash"`       // Root hash of the block's state after execution.
 	Status         string       `json:"status"`         // Current status of the block (e.g., verified, executed).
 	CommitTxHash   *common.Hash `json:"commitTxHash"`   // The transaction hash of the commit operation on L1.
@@ -78,7 +78,7 @@ type RawBlockTransaction struct {
 	// General information about the L2 transaction.
 	CommonData struct {
 		L2 struct {
-			Nonce uint `json:"nonce"`
+			Nonce uint64 `json:"nonce"`
 			Fee   struct {
 				GasLimit             hexutil.Big `json:"gas_limit"`
 				MaxFeePerGas         hexutil.Big `json:"max_fee_per_gas"`
@@ -90,7 +90,7 @@ type RawBlockTransaction struct {
 			TransactionType  string         `json:"transactionType"`
 			Input            struct {
 				Hash common.Hash `json:"hash"`
-				Data []uint      `json:"data"`
+				Data []uint64    `json:"data"`
 			} `json:"input"`
 			PaymasterParams struct {
 				Paymaster      common.Address `json:"paymaster"`
@@ -106,7 +106,7 @@ type RawBlockTransaction struct {
 		FactoryDeps     []hexutil.Bytes `json:"factoryDeps"`
 	} `json:"execute"`
 	// Timestamp when the transaction was received, in milliseconds.
-	ReceivedTimestampMs uint `json:"received_timestamp_ms"`
+	ReceivedTimestampMs uint64 `json:"received_timestamp_ms"`
 	// Raw bytes of the transaction as a hexadecimal string.
 	RawBytes hexutil.Bytes `json:"raw_bytes"`
 }

--- a/types/fee.go
+++ b/types/fee.go
@@ -17,14 +17,14 @@ type FeeParams struct {
 	V2 struct {
 		// Settings related to transaction fee computation.
 		Config struct {
-			MinimalL2GasPrice   uint `json:"minimal_l2_gas_price"`  // Minimal gas price on L2.
-			ComputeOverheadPart uint `json:"compute_overhead_part"` // Compute overhead part in fee calculation.
-			PubdataOverheadPart uint `json:"pubdata_overhead_part"` // Public data overhead part in fee calculation.
-			BatchOverheadL1Gas  uint `json:"batch_overhead_l1_gas"` // Overhead in L1 gas for a batch of transactions.
-			MaxGasPerBatch      uint `json:"max_gas_per_batch"`     // Maximum gas allowed per batch.
-			MaxPubdataPerBatch  uint `json:"max_pubdata_per_batch"` // Maximum amount of public data allowed per batch.
+			MinimalL2GasPrice   uint64 `json:"minimal_l2_gas_price"`  // Minimal gas price on L2.
+			ComputeOverheadPart uint64 `json:"compute_overhead_part"` // Compute overhead part in fee calculation.
+			PubdataOverheadPart uint64 `json:"pubdata_overhead_part"` // Public data overhead part in fee calculation.
+			BatchOverheadL1Gas  uint64 `json:"batch_overhead_l1_gas"` // Overhead in L1 gas for a batch of transactions.
+			MaxGasPerBatch      uint64 `json:"max_gas_per_batch"`     // Maximum gas allowed per batch.
+			MaxPubdataPerBatch  uint64 `json:"max_pubdata_per_batch"` // Maximum amount of public data allowed per batch.
 		} `json:"config"`
-		L1GasPrice     uint `json:"l1_gas_price"`     // Current L1 gas price.
-		L1PubdataPrice uint `json:"l1_pubdata_price"` // Price of storing public data on L1.
+		L1GasPrice     uint64 `json:"l1_gas_price"`     // Current L1 gas price.
+		L1PubdataPrice uint64 `json:"l1_pubdata_price"` // Price of storing public data on L1.
 	} `json:"V2"`
 }

--- a/types/network.go
+++ b/types/network.go
@@ -111,8 +111,8 @@ type TransactionDetails struct {
 
 // ProtocolVersion represents the protocol version.
 type ProtocolVersion struct {
-	VersionId uint `json:"version_id"` // Protocol version ID.
-	Timestamp uint `json:"timestamp"`  // Unix timestamp of the version's activation.
+	VersionId uint8  `json:"version_id"` // Protocol version ID.
+	Timestamp uint64 `json:"timestamp"`  // Unix timestamp of the version's activation.
 	// Contains the hashes of various verification keys used in the protocol.
 	VerificationKeysHashes struct {
 		Params struct {

--- a/types/proof.go
+++ b/types/proof.go
@@ -7,14 +7,14 @@ import (
 
 // LogProof represents a log proof for an L2 to L1 transaction.
 type LogProof struct {
-	Id    int           `json:"id"`    // Identifier of the log within the transaction.
+	Id    int32         `json:"id"`    // Identifier of the log within the transaction.
 	Proof []common.Hash `json:"proof"` // Each element represents a piece of the proof for the specified log.
 	Root  common.Hash   `json:"root"`  // Root hash of the proof, anchoring it to a specific state in the blockchain.
 }
 
 // MessageProof represents a log proof for an L2 to L1 transaction.
 type MessageProof struct {
-	Id    int           `json:"id"`    // Identifier of the log within the transaction.
+	Id    int32         `json:"id"`    // Identifier of the log within the transaction.
 	Proof []common.Hash `json:"proof"` // Each element represents a piece of the proof for the specified log.
 	Root  common.Hash   `json:"root"`  // Root hash of the proof, anchoring it to a specific state in the blockchain.
 }
@@ -31,14 +31,14 @@ type StorageProof struct {
 		Value string   `json:"value"` // Value stored in the specified storage key at the time of the specified l1BatchNumber.
 		// A 1-based index representing the position of the tree entry within the Merkle tree.
 		// This index is used to help reconstruct the Merkle path during verification.
-		Index int `json:"index"`
+		Index int32 `json:"index"`
 	} `json:"storageProof"`
 }
 
 // PriorityOpConfirmation represents confirmation data that is part of L2->L1 message
 type PriorityOpConfirmation struct {
 	L1BatchNumber     *big.Int
-	L2MessageIndex    int
+	L2MessageIndex    int32
 	L2TxNumberInBlock *big.Int
 	Proof             []common.Hash
 }

--- a/types/token.go
+++ b/types/token.go
@@ -11,7 +11,7 @@ type Token struct {
 	L2Address common.Address `json:"l2Address"` // Token address on L2.
 	Name      string         `json:"name"`      // Token name.
 	Symbol    string         `json:"symbol"`    // Token symbol.
-	Decimals  uint           `json:"decimals"`  // Number of decimals for the token.
+	Decimals  uint8          `json:"decimals"`  // Number of decimals for the token.
 }
 
 func (t *Token) IsETH() bool {


### PR DESCRIPTION
# What :computer: 
* Optimize the sizes of number types for onchain structs.