### PR TITLE
Rename the fields for default ERC20 bridges in `BridgeContracts`

### DIFF
--- a/accounts/wallet_l1.go
+++ b/accounts/wallet_l1.go
@@ -101,7 +101,7 @@ func NewWalletL1FromSigner(signer *ECDSASigner, clientL1 *ethclient.Client, clie
 	if err != nil {
 		return nil, fmt.Errorf("failed to load IL1SharedBridge: %w", err)
 	}
-	defaultL1Bridge, err := l1bridge.NewIL1Bridge(bridgeContracts.L1Erc20DefaultBridge, clientL1)
+	defaultL1Bridge, err := l1bridge.NewIL1Bridge(bridgeContracts.L1Erc20Bridge, clientL1)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load IL1Bridge: %w", err)
 	}
@@ -144,7 +144,7 @@ func NewWalletL1FromSigner(signer *ECDSASigner, clientL1 *ethclient.Client, clie
 		bridgehub:              iBridgehub,
 		sharedL1BridgeAddress:  bridgeContracts.L1SharedBridge,
 		sharedL1Bridge:         sharedL1Bridge,
-		defaultL1BridgeAddress: bridgeContracts.L1Erc20DefaultBridge,
+		defaultL1BridgeAddress: bridgeContracts.L1Erc20Bridge,
 		defaultL1Bridge:        defaultL1Bridge,
 	}, nil
 }

--- a/accounts/wallet_l2.go
+++ b/accounts/wallet_l2.go
@@ -60,7 +60,7 @@ func NewWalletL2FromSigner(signer *ECDSASigner, client *clients.Client) (*Wallet
 	if err != nil {
 		return nil, err
 	}
-	defaultL2Bridge, err := l2bridge.NewIL2Bridge(bridgeContracts.L2Erc20DefaultBridge, client)
+	defaultL2Bridge, err := l2bridge.NewIL2Bridge(bridgeContracts.L2Erc20Bridge, client)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load IL2Bridge: %w", err)
 	}
@@ -85,7 +85,7 @@ func NewWalletL2FromSigner(signer *ECDSASigner, client *clients.Client) (*Wallet
 		baseToken:              baseToken,
 		sharedL2BridgeAddress:  bridgeContracts.L2SharedBridge,
 		sharedL2Bridge:         sharedL2Bridge,
-		defaultL2BridgeAddress: bridgeContracts.L2Erc20DefaultBridge,
+		defaultL2BridgeAddress: bridgeContracts.L2Erc20Bridge,
 		defaultL2Bridge:        defaultL2Bridge,
 	}, nil
 }

--- a/types/contract.go
+++ b/types/contract.go
@@ -10,12 +10,12 @@ import (
 
 // BridgeContracts represents the addresses of default bridge contracts for both L1 and L2.
 type BridgeContracts struct {
-	L1Erc20DefaultBridge common.Address `json:"l1Erc20DefaultBridge"`  // Default L1Bridge contract address.
-	L2Erc20DefaultBridge common.Address `json:"l2Erc20DefaultBridge"`  // Default L2Bridge contract address.
-	L1WethBridge         common.Address `json:"l1WethBridge"`          // WETH L1Bridge contract address.
-	L2WethBridge         common.Address `json:"l2WethBridge"`          // WETH L2Bridge contract address.
-	L1SharedBridge       common.Address `json:"l1SharedDefaultBridge"` // Default L1SharedBridge contract address.
-	L2SharedBridge       common.Address `json:"l2SharedDefaultBridge"` // Default L2SharedBridge contract address.
+	L1Erc20Bridge  common.Address `json:"l1Erc20DefaultBridge"`  // Default L1Bridge contract address.
+	L2Erc20Bridge  common.Address `json:"l2Erc20DefaultBridge"`  // Default L2Bridge contract address.
+	L1WethBridge   common.Address `json:"l1WethBridge"`          // WETH L1Bridge contract address.
+	L2WethBridge   common.Address `json:"l2WethBridge"`          // WETH L2Bridge contract address.
+	L1SharedBridge common.Address `json:"l1SharedDefaultBridge"` // Default L1SharedBridge contract address.
+	L2SharedBridge common.Address `json:"l2SharedDefaultBridge"` // Default L2SharedBridge contract address.
 }
 
 // L1BridgeContracts represents the L1 bridge contracts.


### PR DESCRIPTION
# What :computer: 
* Rename properties `L1Erc20DefaultBridge` to `L1Erc20Bridge` and `L2Erc20DefaultBridge` to `L2Erc20Bridge` in `BridgeContracts`.