### PR TITLE
Refactor `eip712.Domain` struct

### DIFF
--- a/eip712/domain.go
+++ b/eip712/domain.go
@@ -7,16 +7,6 @@ import (
 	"math/big"
 )
 
-// TypedData represents typed data as defined by EIP-712.
-type TypedData interface {
-	// EIP712Type returns the EIP-712 type.
-	EIP712Type() string
-	// EIP712Types return the supported types.
-	EIP712Types() []apitypes.Type
-	// EIP712Message returns the EIP-712 message.
-	EIP712Message() (apitypes.TypedDataMessage, error)
-}
-
 // Domain represents the domain parameters used for EIP-712 signing.
 type Domain struct {
 	Name              string          `json:"name"`              // Name of the domain.

--- a/eip712/domain.go
+++ b/eip712/domain.go
@@ -15,11 +15,13 @@ type Domain struct {
 	VerifyingContract *common.Address `json:"verifyingContract"` // Address of the verifying contract for the domain.
 }
 
-func (d *Domain) EIP712Type() string {
+// Type returns the name of the domain field.
+func (d *Domain) Type() string {
 	return "EIP712Domain"
 }
 
-func (d *Domain) EIP712Types() []apitypes.Type {
+// Types returns the domain field types.
+func (d *Domain) Types() []apitypes.Type {
 	types := []apitypes.Type{
 		{Name: "name", Type: "string"},
 		{Name: "version", Type: "string"},
@@ -31,7 +33,8 @@ func (d *Domain) EIP712Types() []apitypes.Type {
 	return types
 }
 
-func (d *Domain) EIP712Domain() apitypes.TypedDataDomain {
+// TypedData returns domain typed data.
+func (d *Domain) TypedData() apitypes.TypedDataDomain {
 	domain := apitypes.TypedDataDomain{
 		Name:    d.Name,
 		Version: d.Version,
@@ -48,6 +51,7 @@ const (
 	DomainDefaultVersion = `2`
 )
 
+// ZkSyncEraEIP712Domain represents the EIP-712 domain for ZKsync Era.
 func ZkSyncEraEIP712Domain(chainId int64) *Domain {
 	return &Domain{
 		Name:              DomainDefaultName,

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -150,11 +150,11 @@ func (tx *Transaction) TypedData() (*apitypes.TypedData, error) {
 	}
 	return &apitypes.TypedData{
 		Types: apitypes.Types{
-			"Transaction":       tx.types(),
-			domain.EIP712Type(): domain.EIP712Types(),
+			"Transaction": tx.types(),
+			domain.Type(): domain.Types(),
 		},
 		PrimaryType: "Transaction",
-		Domain:      domain.EIP712Domain(),
+		Domain:      domain.TypedData(),
 		Message:     message,
 	}, nil
 }


### PR DESCRIPTION
# What :computer: 
* Remove `TypedData` interface.
* `eip712.Domain` methos have been renamed to to be more convenient.