### PR TITLE
Refactor: `TransferCallMsg` and `WithdrawalCallMsg` in `clients` package

### DIFF
--- a/clients/client.go
+++ b/clients/client.go
@@ -1065,9 +1065,9 @@ func (c *Client) EstimateGasWithdraw(ctx context.Context, msg WithdrawalCallMsg)
 		if errBridge != nil {
 			return 0, fmt.Errorf("failed to getBridgeContracts: %w", errBridge)
 		}
-		callMsg, err = msg.ToZkCallMsg(&contracts.L2SharedBridge)
+		callMsg, err = msg.ToCallMsg(&contracts.L2SharedBridge)
 	} else {
-		callMsg, err = msg.ToZkCallMsg(nil)
+		callMsg, err = msg.ToCallMsg(nil)
 		if err != nil {
 			return 0, err
 		}

--- a/clients/client.go
+++ b/clients/client.go
@@ -1039,7 +1039,7 @@ func (c *Client) EstimateGasL1(ctx context.Context, msg types.CallMsg) (uint64, 
 
 // EstimateGasTransfer estimates the amount of gas required for a transfer transaction.
 func (c *Client) EstimateGasTransfer(ctx context.Context, msg TransferCallMsg) (uint64, error) {
-	callMsg, err := msg.ToZkCallMsg()
+	callMsg, err := msg.ToCallMsg()
 	if err != nil {
 		return 0, err
 	}

--- a/clients/client.go
+++ b/clients/client.go
@@ -1195,10 +1195,6 @@ func (c *Client) getBlock(ctx context.Context, method string, args ...interface{
 	if block.TxHash == ethTypes.EmptyTxsHash && len(block.Transactions) > 0 {
 		return nil, errors.New("server returned non-empty transaction list but block header indicates no transactions")
 	}
-	// TODO use this validation when transaction root is fixed on zksync node
-	//if head.TxHash != ethTypes.EmptyTxsHash && len(body.Transactions) == 0 {
-	//	return nil, errors.New("server returned empty transaction list but block header indicates transactions")
-	//}
 	// Load uncles because they are not included in the block response.
 	var uncles []*ethTypes.Header
 	if len(block.Uncles) > 0 {

--- a/clients/types.go
+++ b/clients/types.go
@@ -130,6 +130,12 @@ type WithdrawalCallMsg struct {
 	GasTipCap *big.Int // EIP-1559 tip per gas.
 
 	PaymasterParams *types.PaymasterParams // The paymaster parameters.
+	// GasPerPubdata denotes the maximum amount of gas the user is willing
+	// to pay for a single byte of pubdata.
+	GasPerPubdata *big.Int
+	// CustomSignature is used for the cases in which the signer's account
+	// is not an EOA.
+	CustomSignature hexutil.Bytes
 }
 
 func (m *WithdrawalCallMsg) ToCallMsg(defaultL2Bridge *common.Address) (*ethereum.CallMsg, error) {
@@ -186,6 +192,11 @@ func (m *WithdrawalCallMsg) ToZkCallMsg(defaultL2Bridge *common.Address) (*types
 		return nil, err
 	}
 
+	gasPerPubdata := m.GasPerPubdata
+	if gasPerPubdata == nil {
+		gasPerPubdata = utils.DefaultGasPerPubdataLimit
+	}
+
 	return &types.CallMsg{
 		From:            msg.From,
 		To:              msg.To,
@@ -195,8 +206,9 @@ func (m *WithdrawalCallMsg) ToZkCallMsg(defaultL2Bridge *common.Address) (*types
 		GasTipCap:       msg.GasTipCap,
 		Value:           msg.Value,
 		Data:            msg.Data,
-		GasPerPubdata:   utils.DefaultGasPerPubdataLimit,
+		GasPerPubdata:   gasPerPubdata,
 		PaymasterParams: m.PaymasterParams,
+		CustomSignature: m.CustomSignature,
 	}, nil
 }
 

--- a/clients/types.go
+++ b/clients/types.go
@@ -36,7 +36,7 @@ type TransferCallMsg struct {
 	CustomSignature hexutil.Bytes
 }
 
-func (m *TransferCallMsg) ToCallMsg() (*ethereum.CallMsg, error) {
+func (m *TransferCallMsg) ToL1CallMsg() (*ethereum.CallMsg, error) {
 	var (
 		value *big.Int
 		data  []byte
@@ -72,7 +72,7 @@ func (m *TransferCallMsg) ToCallMsg() (*ethereum.CallMsg, error) {
 	}, nil
 }
 
-func (m *TransferCallMsg) ToZkCallMsg() (*types.CallMsg, error) {
+func (m *TransferCallMsg) ToCallMsg() (*types.CallMsg, error) {
 	var (
 		value         *big.Int
 		data          []byte

--- a/clients/types.go
+++ b/clients/types.go
@@ -138,7 +138,7 @@ type WithdrawalCallMsg struct {
 	CustomSignature hexutil.Bytes
 }
 
-func (m *WithdrawalCallMsg) ToCallMsg(defaultL2Bridge *common.Address) (*ethereum.CallMsg, error) {
+func (m *WithdrawalCallMsg) ToL1CallMsg(defaultL2Bridge *common.Address) (*ethereum.CallMsg, error) {
 	if m.Token == utils.L2BaseTokenAddress {
 		ethTokenAbi, err := ethtoken.IEthTokenMetaData.GetAbi()
 		if err != nil {
@@ -186,8 +186,8 @@ func (m *WithdrawalCallMsg) ToCallMsg(defaultL2Bridge *common.Address) (*ethereu
 	}
 }
 
-func (m *WithdrawalCallMsg) ToZkCallMsg(defaultL2Bridge *common.Address) (*types.CallMsg, error) {
-	msg, err := m.ToCallMsg(defaultL2Bridge)
+func (m *WithdrawalCallMsg) ToCallMsg(defaultL2Bridge *common.Address) (*types.CallMsg, error) {
+	msg, err := m.ToL1CallMsg(defaultL2Bridge)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# What :computer: 
* Extend `TransferCallMsg` and `WithdrawalCallMsg` with `GasPerPubdata` and `CustomSignature` fields which can we used in estimation for transfer and withdrawal transactions.
* Rename the methods to be more convenient.