### PR TITLE
Refactor: `TransferCallMsg` and `WithdrawalCallMsg` in `accounts` package

### DIFF
--- a/accounts/types.go
+++ b/accounts/types.go
@@ -345,19 +345,26 @@ type WithdrawalCallMsg struct {
 	GasPrice  *big.Int // Wei <-> gas exchange ratio.
 	GasFeeCap *big.Int // EIP-1559 fee cap per gas.
 	GasTipCap *big.Int // EIP-1559 tip per gas.
+
+	PaymasterParams *types.PaymasterParams // The paymaster parameters.
+	// GasPerPubdata denotes the maximum amount of gas the user is willing
+	// to pay for a single byte of pubdata.
+	GasPerPubdata *big.Int
 }
 
 func (m *WithdrawalCallMsg) ToWithdrawalCallMsg(from common.Address) clients.WithdrawalCallMsg {
 	return clients.WithdrawalCallMsg{
-		To:            m.To,
-		Amount:        m.Amount,
-		Token:         m.Token,
-		BridgeAddress: m.BridgeAddress,
-		From:          from,
-		Gas:           m.Gas,
-		GasPrice:      m.GasPrice,
-		GasFeeCap:     m.GasFeeCap,
-		GasTipCap:     m.GasTipCap,
+		To:              m.To,
+		Amount:          m.Amount,
+		Token:           m.Token,
+		BridgeAddress:   m.BridgeAddress,
+		From:            from,
+		Gas:             m.Gas,
+		GasPrice:        m.GasPrice,
+		GasFeeCap:       m.GasFeeCap,
+		GasTipCap:       m.GasTipCap,
+		PaymasterParams: m.PaymasterParams,
+		GasPerPubdata:   m.GasPerPubdata,
 	}
 }
 

--- a/accounts/types.go
+++ b/accounts/types.go
@@ -379,18 +379,25 @@ type TransferCallMsg struct {
 	GasPrice  *big.Int // Wei <-> gas exchange ratio.
 	GasFeeCap *big.Int // EIP-1559 fee cap per gas.
 	GasTipCap *big.Int // EIP-1559 tip per gas.
+
+	PaymasterParams *types.PaymasterParams // The paymaster parameters.
+	// GasPerPubdata denotes the maximum amount of gas the user is willing
+	// to pay for a single byte of pubdata.
+	GasPerPubdata *big.Int
 }
 
 func (m *TransferCallMsg) ToTransferCallMsg(from common.Address) clients.TransferCallMsg {
 	return clients.TransferCallMsg{
-		To:        m.To,
-		Amount:    m.Amount,
-		Token:     m.Token,
-		From:      from,
-		Gas:       m.Gas,
-		GasPrice:  m.GasPrice,
-		GasFeeCap: m.GasFeeCap,
-		GasTipCap: m.GasTipCap,
+		To:              m.To,
+		Amount:          m.Amount,
+		Token:           m.Token,
+		From:            from,
+		Gas:             m.Gas,
+		GasPrice:        m.GasPrice,
+		GasFeeCap:       m.GasFeeCap,
+		GasTipCap:       m.GasTipCap,
+		PaymasterParams: m.PaymasterParams,
+		GasPerPubdata:   m.GasPerPubdata,
 	}
 }
 


### PR DESCRIPTION
# What :computer: 
* Extend `TransferCallMsg` and `WithdrawalCallMsg` with `GasPerPubdata` and `PaymasterParams` fields which can we used in estimation for transfer and withdrawal transactions.
