### PR TITLE
Feat:  use zksync transaction for transfer and withdrawal

### DIFF
--- a/test/account_abstraction_test.go
+++ b/test/account_abstraction_test.go
@@ -82,14 +82,14 @@ func TestIntegration_ApprovalPaymaster(t *testing.T) {
 	assert.NotNil(t, paymasterAddress, "Contract should be deployed")
 
 	// ===== Transfer some base token to paymaster, so it can pay fee with it =====
-	transferTx, err := wallet.Transfer(nil, accounts.TransferTransaction{
+	transferTxHash, err := wallet.Transfer(nil, accounts.TransferTransaction{
 		To:     paymasterAddress,
 		Amount: big.NewInt(1_000_000_000_000_000_000),
 		Token:  utils.L2BaseTokenAddress,
 	})
 	assert.NoError(t, err, "Transfer should not return an error")
 
-	_, err = client.WaitMined(context.Background(), transferTx.Hash())
+	_, err = client.WaitMined(context.Background(), transferTxHash)
 	assert.NoError(t, err, "client.WaitMined should not return an error")
 
 	// Read token and base token balances from user and paymaster accounts

--- a/test/base_client_test.go
+++ b/test/base_client_test.go
@@ -819,14 +819,14 @@ func TestIntegrationBaseClient_WaitMined(t *testing.T) {
 	w, err := accounts.NewWallet(common.Hex2Bytes(PrivateKey1), client, nil)
 	assert.NoError(t, err, "NewWallet should not return an error")
 
-	tx, err := w.Transfer(nil, accounts.TransferTransaction{
+	txHash, err := w.Transfer(nil, accounts.TransferTransaction{
 		To:     Address2,
 		Amount: big.NewInt(7_000_000_000),
 		Token:  utils.LegacyEthAddress,
 	})
 	assert.NoError(t, err, "Transfer should not return an error")
 
-	txReceipt, err := client.WaitMined(context.Background(), tx.Hash())
+	txReceipt, err := client.WaitMined(context.Background(), txHash)
 	assert.NoError(t, err, "client.WaitMined should not return an error")
 
 	assert.NotNil(t, txReceipt.BlockHash, "Transaction should be mined")
@@ -840,14 +840,14 @@ func TestIntegrationBaseClient_WaitFinalized(t *testing.T) {
 	w, err := accounts.NewWallet(common.Hex2Bytes(PrivateKey1), client, nil)
 	assert.NoError(t, err, "NewWallet should not return an error")
 
-	tx, err := w.Transfer(nil, accounts.TransferTransaction{
+	txHash, err := w.Transfer(nil, accounts.TransferTransaction{
 		To:     Address2,
 		Amount: big.NewInt(7_000_000_000),
 		Token:  utils.LegacyEthAddress,
 	})
 	assert.NoError(t, err, "Transfer should not return an error")
 
-	txReceipt, err := client.WaitFinalized(context.Background(), tx.Hash())
+	txReceipt, err := client.WaitFinalized(context.Background(), txHash)
 	assert.NoError(t, err, "client.WaitMined should not return an error")
 
 	assert.NotNil(t, txReceipt.BlockHash, "Transaction should be mined")

--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -65,7 +65,7 @@ func deployMultisigAccount(wallet *accounts.Wallet, client *clients.Client) {
 	}
 
 	// transfer ETH to multisig account
-	transferTx, err := wallet.Transfer(nil, accounts.TransferTransaction{
+	transferTxHash, err := wallet.Transfer(nil, accounts.TransferTransaction{
 		To:     multisigAccountAddress,
 		Amount: big.NewInt(2_000_000_000_000_000_000),
 		Token:  utils.LegacyEthAddress,
@@ -74,13 +74,13 @@ func deployMultisigAccount(wallet *accounts.Wallet, client *clients.Client) {
 		log.Fatal(err)
 	}
 
-	_, err = client.WaitMined(context.Background(), transferTx.Hash())
+	_, err = client.WaitMined(context.Background(), transferTxHash)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// transfer token to multisig account
-	transferTx, err = wallet.Transfer(nil, accounts.TransferTransaction{
+	transferTxHash, err = wallet.Transfer(nil, accounts.TransferTransaction{
 		To:     multisigAccountAddress,
 		Amount: big.NewInt(20),
 		Token:  L2Dai,
@@ -89,13 +89,13 @@ func deployMultisigAccount(wallet *accounts.Wallet, client *clients.Client) {
 		log.Fatal(err)
 	}
 
-	_, err = client.WaitMined(context.Background(), transferTx.Hash())
+	_, err = client.WaitMined(context.Background(), transferTxHash)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// transfer approval token to multisig account
-	transferTx, err = wallet.Transfer(nil, accounts.TransferTransaction{
+	transferTxHash, err = wallet.Transfer(nil, accounts.TransferTransaction{
 		To:     multisigAccountAddress,
 		Amount: big.NewInt(5),
 		Token:  ApprovalToken,
@@ -104,14 +104,14 @@ func deployMultisigAccount(wallet *accounts.Wallet, client *clients.Client) {
 		log.Fatal(err)
 	}
 
-	_, err = client.WaitMined(context.Background(), transferTx.Hash())
+	_, err = client.WaitMined(context.Background(), transferTxHash)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	if !IsEthBasedChain {
 		// transfer base token to multisig account
-		transferTx, err = wallet.Transfer(nil, accounts.TransferTransaction{
+		transferTxHash, err = wallet.Transfer(nil, accounts.TransferTransaction{
 			To:     multisigAccountAddress,
 			Amount: big.NewInt(2_000_000_000_000_000_000),
 			Token:  utils.L2BaseTokenAddress,
@@ -120,7 +120,7 @@ func deployMultisigAccount(wallet *accounts.Wallet, client *clients.Client) {
 			log.Fatal(err)
 		}
 
-		_, err = client.WaitMined(context.Background(), transferTx.Hash())
+		_, err = client.WaitMined(context.Background(), transferTxHash)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -207,7 +207,7 @@ func deployPaymasterAndToken(wallet *accounts.Wallet, client *clients.Client) {
 	}
 
 	// transfer base token to paymaster so it could pay fee
-	transferTx, err := wallet.Transfer(nil, accounts.TransferTransaction{
+	transferTxHash, err := wallet.Transfer(nil, accounts.TransferTransaction{
 		To:     paymasterAddress,
 		Amount: big.NewInt(2_000_000_000_000_000_000),
 		Token:  utils.L2BaseTokenAddress,
@@ -216,7 +216,7 @@ func deployPaymasterAndToken(wallet *accounts.Wallet, client *clients.Client) {
 		log.Fatal(err)
 	}
 
-	_, err = client.WaitMined(context.Background(), transferTx.Hash())
+	_, err = client.WaitMined(context.Background(), transferTxHash)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
# What :computer: 
* `WalletL2` and `Wallet` for `transfer` and `withdraw` methods use zksync transaction in order to provide utilization of zksync features.