### PR TITLE
Refactor: `TransactOpts` in `accounts` package

### DIFF
--- a/accounts/deployer.go
+++ b/accounts/deployer.go
@@ -16,7 +16,7 @@ func NewDeployer(adapter *WalletL2) *Deployer {
 }
 
 // Deploy deploys smart contract using CREATE2 opcode.
-func (a *Deployer) Deploy(auth *TransactOpts, tx Create2Transaction) (common.Hash, error) {
+func (a *Deployer) Deploy(auth *TransactOptsL1, tx Create2Transaction) (common.Hash, error) {
 	opts := ensureTransactOpts(auth)
 	preparedTx, err := tx.ToTransaction(DeployContract, opts)
 	if err != nil {
@@ -26,7 +26,7 @@ func (a *Deployer) Deploy(auth *TransactOpts, tx Create2Transaction) (common.Has
 }
 
 // DeployWithCreate deploys smart contract using CREATE opcode.
-func (a *Deployer) DeployWithCreate(auth *TransactOpts, tx CreateTransaction) (common.Hash, error) {
+func (a *Deployer) DeployWithCreate(auth *TransactOptsL1, tx CreateTransaction) (common.Hash, error) {
 	opts := ensureTransactOpts(auth)
 	preparedTx, err := tx.ToTransaction(DeployContract, opts)
 	if err != nil {
@@ -36,7 +36,7 @@ func (a *Deployer) DeployWithCreate(auth *TransactOpts, tx CreateTransaction) (c
 }
 
 // DeployAccount deploys smart account using CREATE2 opcode.
-func (a *Deployer) DeployAccount(auth *TransactOpts, tx Create2Transaction) (common.Hash, error) {
+func (a *Deployer) DeployAccount(auth *TransactOptsL1, tx Create2Transaction) (common.Hash, error) {
 	opts := ensureTransactOpts(auth)
 	preparedTx, err := tx.ToTransaction(DeployAccount, opts)
 	if err != nil {
@@ -46,7 +46,7 @@ func (a *Deployer) DeployAccount(auth *TransactOpts, tx Create2Transaction) (com
 }
 
 // DeployAccountWithCreate deploys smart account using CREATE opcode.
-func (a *Deployer) DeployAccountWithCreate(auth *TransactOpts, tx CreateTransaction) (common.Hash, error) {
+func (a *Deployer) DeployAccountWithCreate(auth *TransactOptsL1, tx CreateTransaction) (common.Hash, error) {
 	opts := ensureTransactOpts(auth)
 	preparedTx, err := tx.ToTransaction(DeployAccount, opts)
 	if err != nil {

--- a/accounts/deployer.go
+++ b/accounts/deployer.go
@@ -16,7 +16,7 @@ func NewDeployer(adapter *WalletL2) *Deployer {
 }
 
 // Deploy deploys smart contract using CREATE2 opcode.
-func (a *Deployer) Deploy(auth *TransactOptsL1, tx Create2Transaction) (common.Hash, error) {
+func (a *Deployer) Deploy(auth *TransactOpts, tx Create2Transaction) (common.Hash, error) {
 	opts := ensureTransactOpts(auth)
 	preparedTx, err := tx.ToTransaction(DeployContract, opts)
 	if err != nil {
@@ -26,7 +26,7 @@ func (a *Deployer) Deploy(auth *TransactOptsL1, tx Create2Transaction) (common.H
 }
 
 // DeployWithCreate deploys smart contract using CREATE opcode.
-func (a *Deployer) DeployWithCreate(auth *TransactOptsL1, tx CreateTransaction) (common.Hash, error) {
+func (a *Deployer) DeployWithCreate(auth *TransactOpts, tx CreateTransaction) (common.Hash, error) {
 	opts := ensureTransactOpts(auth)
 	preparedTx, err := tx.ToTransaction(DeployContract, opts)
 	if err != nil {
@@ -36,7 +36,7 @@ func (a *Deployer) DeployWithCreate(auth *TransactOptsL1, tx CreateTransaction) 
 }
 
 // DeployAccount deploys smart account using CREATE2 opcode.
-func (a *Deployer) DeployAccount(auth *TransactOptsL1, tx Create2Transaction) (common.Hash, error) {
+func (a *Deployer) DeployAccount(auth *TransactOpts, tx Create2Transaction) (common.Hash, error) {
 	opts := ensureTransactOpts(auth)
 	preparedTx, err := tx.ToTransaction(DeployAccount, opts)
 	if err != nil {
@@ -46,7 +46,7 @@ func (a *Deployer) DeployAccount(auth *TransactOptsL1, tx Create2Transaction) (c
 }
 
 // DeployAccountWithCreate deploys smart account using CREATE opcode.
-func (a *Deployer) DeployAccountWithCreate(auth *TransactOptsL1, tx CreateTransaction) (common.Hash, error) {
+func (a *Deployer) DeployAccountWithCreate(auth *TransactOpts, tx CreateTransaction) (common.Hash, error) {
 	opts := ensureTransactOpts(auth)
 	preparedTx, err := tx.ToTransaction(DeployAccount, opts)
 	if err != nil {

--- a/accounts/smart_account.go
+++ b/accounts/smart_account.go
@@ -191,7 +191,7 @@ func (a *SmartAccount) SignTypedData(ctx context.Context, typedData apitypes.Typ
 // Withdraw initiates the withdrawal process which withdraws ETH or any ERC20
 // token from the associated account on L2 network to the target account on L1
 // network.
-func (a *SmartAccount) Withdraw(auth *TransactOpts, tx WithdrawalTransaction) (common.Hash, error) {
+func (a *SmartAccount) Withdraw(auth *TransactOptsL1, tx WithdrawalTransaction) (common.Hash, error) {
 	from := a.Address()
 
 	opts := ensureTransactOpts(auth)
@@ -270,7 +270,7 @@ func (a *SmartAccount) Withdraw(auth *TransactOpts, tx WithdrawalTransaction) (c
 }
 
 // Transfer moves the ETH or any ERC20 token from the associated account to the target account.
-func (a *SmartAccount) Transfer(auth *TransactOpts, tx TransferTransaction) (common.Hash, error) {
+func (a *SmartAccount) Transfer(auth *TransactOptsL1, tx TransferTransaction) (common.Hash, error) {
 	from := a.Address()
 
 	opts := ensureTransactOpts(auth)
@@ -353,7 +353,7 @@ func (a *SmartAccount) cacheData(ctx context.Context) error {
 	return nil
 }
 
-func (a *SmartAccount) insertGasPrice(opts *TransactOpts) {
+func (a *SmartAccount) insertGasPrice(opts *TransactOptsL1) {
 	if opts.GasPrice != nil {
 		opts.GasFeeCap = opts.GasPrice
 		opts.GasTipCap = nil

--- a/accounts/smart_account.go
+++ b/accounts/smart_account.go
@@ -191,11 +191,11 @@ func (a *SmartAccount) SignTypedData(ctx context.Context, typedData apitypes.Typ
 // Withdraw initiates the withdrawal process which withdraws ETH or any ERC20
 // token from the associated account on L2 network to the target account on L1
 // network.
-func (a *SmartAccount) Withdraw(auth *TransactOptsL1, tx WithdrawalTransaction) (common.Hash, error) {
+func (a *SmartAccount) Withdraw(auth *TransactOpts, tx WithdrawalTransaction) (common.Hash, error) {
 	from := a.Address()
 
 	opts := ensureTransactOpts(auth)
-	a.insertGasPrice(opts)
+	insertGasPrice(opts)
 	err := a.cacheData(opts.Context)
 	if err != nil {
 		return common.Hash{}, err
@@ -236,7 +236,7 @@ func (a *SmartAccount) Withdraw(auth *TransactOptsL1, tx WithdrawalTransaction) 
 			From:            &from,
 			ChainID:         a.chainId,
 			GasPerPubdata:   utils.DefaultGasPerPubdataLimit,
-			PaymasterParams: tx.PaymasterParams,
+			PaymasterParams: opts.PaymasterParams,
 		})
 	}
 
@@ -265,16 +265,16 @@ func (a *SmartAccount) Withdraw(auth *TransactOptsL1, tx WithdrawalTransaction) 
 		ChainID:         a.chainId,
 		From:            &from,
 		GasPerPubdata:   utils.DefaultGasPerPubdataLimit,
-		PaymasterParams: tx.PaymasterParams,
+		PaymasterParams: opts.PaymasterParams,
 	})
 }
 
 // Transfer moves the ETH or any ERC20 token from the associated account to the target account.
-func (a *SmartAccount) Transfer(auth *TransactOptsL1, tx TransferTransaction) (common.Hash, error) {
+func (a *SmartAccount) Transfer(auth *TransactOpts, tx TransferTransaction) (common.Hash, error) {
 	from := a.Address()
 
 	opts := ensureTransactOpts(auth)
-	a.insertGasPrice(opts)
+	insertGasPrice(opts)
 	err := a.cacheData(opts.Context)
 	if err != nil {
 		return common.Hash{}, err
@@ -298,7 +298,7 @@ func (a *SmartAccount) Transfer(auth *TransactOptsL1, tx TransferTransaction) (c
 			ChainID:         a.chainId,
 			From:            &from,
 			GasPerPubdata:   utils.DefaultGasPerPubdataLimit,
-			PaymasterParams: tx.PaymasterParams,
+			PaymasterParams: opts.PaymasterParams,
 		})
 	}
 
@@ -323,7 +323,7 @@ func (a *SmartAccount) Transfer(auth *TransactOptsL1, tx TransferTransaction) (c
 		ChainID:         a.chainId,
 		From:            &from,
 		GasPerPubdata:   utils.DefaultGasPerPubdataLimit,
-		PaymasterParams: tx.PaymasterParams,
+		PaymasterParams: opts.PaymasterParams,
 	})
 }
 
@@ -351,14 +351,6 @@ func (a *SmartAccount) cacheData(ctx context.Context) error {
 		a.sharedL2BridgeAddress = bridges.L2SharedBridge
 	}
 	return nil
-}
-
-func (a *SmartAccount) insertGasPrice(opts *TransactOptsL1) {
-	if opts.GasPrice != nil {
-		opts.GasFeeCap = opts.GasPrice
-		opts.GasTipCap = nil
-		opts.GasPrice = nil
-	}
 }
 
 func (a *SmartAccount) isBaseToken(ctx context.Context, token common.Address) (bool, error) {

--- a/accounts/types.go
+++ b/accounts/types.go
@@ -937,7 +937,7 @@ type CreateTransaction struct {
 	Dependencies [][]byte // The bytecode of dependent smart contracts or smart accounts.
 }
 
-func (t *CreateTransaction) ToTransaction(deploymentType DeploymentType, opts *TransactOptsL1) (*Transaction, error) {
+func (t *CreateTransaction) ToTransaction(deploymentType DeploymentType, opts *TransactOpts) (*Transaction, error) {
 	var (
 		data []byte
 		err  error
@@ -968,18 +968,24 @@ func (t *CreateTransaction) ToTransaction(deploymentType DeploymentType, opts *T
 
 	auth := opts
 	if auth == nil {
-		auth = &TransactOptsL1{Context: context.Background()}
+		auth = &TransactOpts{Context: context.Background()}
+	}
+
+	gasPerPubdata := auth.GasPerPubdata
+	if gasPerPubdata == nil {
+		gasPerPubdata = utils.DefaultGasPerPubdataLimit
 	}
 
 	return &Transaction{
-		To:            &utils.ContractDeployerAddress,
-		Data:          data,
-		Nonce:         auth.Nonce,
-		GasFeeCap:     auth.GasFeeCap,
-		GasTipCap:     auth.GasTipCap,
-		Gas:           auth.GasLimit,
-		GasPerPubdata: utils.DefaultGasPerPubdataLimit,
-		FactoryDeps:   factoryDeps,
+		To:              &utils.ContractDeployerAddress,
+		Data:            data,
+		Nonce:           auth.Nonce,
+		GasFeeCap:       auth.GasFeeCap,
+		GasTipCap:       auth.GasTipCap,
+		Gas:             auth.GasLimit,
+		GasPerPubdata:   gasPerPubdata,
+		PaymasterParams: auth.PaymasterParams,
+		FactoryDeps:     factoryDeps,
 	}, nil
 }
 
@@ -992,7 +998,7 @@ type Create2Transaction struct {
 	Dependencies [][]byte // The bytecode of dependent smart contracts or smart accounts.
 }
 
-func (t *Create2Transaction) ToTransaction(deploymentType DeploymentType, opts *TransactOptsL1) (*Transaction, error) {
+func (t *Create2Transaction) ToTransaction(deploymentType DeploymentType, opts *TransactOpts) (*Transaction, error) {
 	var (
 		data []byte
 		err  error
@@ -1023,18 +1029,24 @@ func (t *Create2Transaction) ToTransaction(deploymentType DeploymentType, opts *
 
 	auth := opts
 	if auth == nil {
-		auth = &TransactOptsL1{Context: context.Background()}
+		auth = &TransactOpts{Context: context.Background()}
+	}
+
+	gasPerPubdata := auth.GasPerPubdata
+	if gasPerPubdata == nil {
+		gasPerPubdata = utils.DefaultGasPerPubdataLimit
 	}
 
 	return &Transaction{
-		To:            &utils.ContractDeployerAddress,
-		Data:          data,
-		Nonce:         auth.Nonce,
-		GasFeeCap:     auth.GasFeeCap,
-		GasTipCap:     auth.GasTipCap,
-		Gas:           auth.GasLimit,
-		GasPerPubdata: utils.DefaultGasPerPubdataLimit,
-		FactoryDeps:   factoryDeps,
+		To:              &utils.ContractDeployerAddress,
+		Data:            data,
+		Nonce:           auth.Nonce,
+		GasFeeCap:       auth.GasFeeCap,
+		GasTipCap:       auth.GasTipCap,
+		Gas:             auth.GasLimit,
+		GasPerPubdata:   gasPerPubdata,
+		PaymasterParams: auth.PaymasterParams,
+		FactoryDeps:     factoryDeps,
 	}, nil
 }
 

--- a/accounts/types.go
+++ b/accounts/types.go
@@ -717,10 +717,9 @@ func (t *Transaction) ToCallMsg(from common.Address) types.CallMsg {
 // TransferTransaction represents a transfer transaction on L2
 // initiated by the account associated with AdapterL2.
 type TransferTransaction struct {
-	To              common.Address         // The address of the recipient.
-	Amount          *big.Int               // The amount of the token to transfer.
-	Token           common.Address         // The address of the token. ETH by default.
-	PaymasterParams *types.PaymasterParams // The paymaster parameters.
+	To     common.Address // The address of the recipient.
+	Amount *big.Int       // The amount of the token to transfer.
+	Token  common.Address // The address of the token. ETH by default.
 }
 
 func (t *TransferTransaction) ToTransaction(opts *TransactOptsL1) *Transaction {
@@ -750,10 +749,9 @@ func (t *TransferTransaction) ToTransferCallMsg(from common.Address, opts *Trans
 // WithdrawalTransaction represents a withdrawal transaction on L1 from L2
 // initiated by the account associated with AdapterL2.
 type WithdrawalTransaction struct {
-	To              common.Address         // The address that will receive the withdrawn tokens on L1.
-	Token           common.Address         // The address of the token to withdraw.
-	Amount          *big.Int               // The amount of the token to withdraw.
-	PaymasterParams *types.PaymasterParams // The paymaster parameters.
+	To     common.Address // The address that will receive the withdrawn tokens on L1.
+	Token  common.Address // The address of the token to withdraw.
+	Amount *big.Int       // The amount of the token to withdraw.
 
 	// The address of the bridge contract to be used. Defaults to the default ZKsync bridge
 	// (either L2EthBridge or L2Erc20Bridge).

--- a/accounts/types.go
+++ b/accounts/types.go
@@ -631,6 +631,25 @@ func (t *TransactOptsL1) ToTransactOpts(from common.Address, signer bind.SignerF
 	}
 }
 
+// TransactOpts contains common data required to create a valid transaction on L2
+// using the account associated with WalletL2 and Deployer.
+// Its primary purpose is to enrich bind.TransactOpts with ZKsync features,
+// wherein the 'From' and 'Signer' fields are linked to the associated account.
+type TransactOpts struct {
+	Nonce     *big.Int        // Nonce to use for the transaction execution (nil = use pending state).
+	Value     *big.Int        // Funds to transfer along the transaction (nil = 0 = no funds).
+	GasPrice  *big.Int        // Gas price to use for the transaction execution (nil = gas price oracle).
+	GasFeeCap *big.Int        // Gas fee cap to use for the 1559 transaction execution (nil = gas price oracle).
+	GasTipCap *big.Int        // Gas priority fee cap to use for the 1559 transaction execution (nil = gas price oracle).
+	GasLimit  uint64          // Gas limit to set for the transaction execution (0 = estimate).
+	Context   context.Context // Network context to support cancellation and timeouts (nil = no timeout).
+
+	PaymasterParams *types.PaymasterParams // The paymaster parameters.
+	// GasPerPubdata denotes the maximum amount of gas the user is willing
+	// to pay for a single byte of pubdata.
+	GasPerPubdata *big.Int
+}
+
 // Transaction is similar to types.Transaction but does not include the From field. This design is intended for use
 // with entities which already have an associated account. The From field is bound to
 // their associated account, and thus, it is not included in this type.
@@ -897,10 +916,10 @@ func (t *DepositTransaction) PopulateEmptyFields(from common.Address) {
 		t.Token = utils.LegacyEthAddress
 	}
 	if t.ApproveERC20 && t.ApproveAuth == nil {
-		t.ApproveAuth = ensureTransactOpts(t.ApproveAuth)
+		t.ApproveAuth = ensureTransactOptsL1(t.ApproveAuth)
 	}
 	if t.ApproveBaseERC20 && t.ApproveBaseAuth == nil {
-		t.ApproveAuth = ensureTransactOpts(t.ApproveBaseAuth)
+		t.ApproveAuth = ensureTransactOptsL1(t.ApproveBaseAuth)
 	}
 }
 

--- a/accounts/util.go
+++ b/accounts/util.go
@@ -26,9 +26,9 @@ func ensureCallOpts(opts *CallOpts) *CallOpts {
 	return opts
 }
 
-func ensureTransactOpts(auth *TransactOpts) *TransactOpts {
+func ensureTransactOpts(auth *TransactOptsL1) *TransactOptsL1 {
 	if auth == nil {
-		return &TransactOpts{
+		return &TransactOptsL1{
 			Context: context.Background(),
 		}
 	}

--- a/accounts/util.go
+++ b/accounts/util.go
@@ -26,9 +26,21 @@ func ensureCallOpts(opts *CallOpts) *CallOpts {
 	return opts
 }
 
-func ensureTransactOpts(auth *TransactOptsL1) *TransactOptsL1 {
+func ensureTransactOptsL1(auth *TransactOptsL1) *TransactOptsL1 {
 	if auth == nil {
 		return &TransactOptsL1{
+			Context: context.Background(),
+		}
+	}
+	if auth.Context == nil {
+		auth.Context = context.Background()
+	}
+	return auth
+}
+
+func ensureTransactOpts(auth *TransactOpts) *TransactOpts {
+	if auth == nil {
+		return &TransactOpts{
 			Context: context.Background(),
 		}
 	}
@@ -57,4 +69,12 @@ func newTransactorWithSigner(signer *ECDSASigner, chainID *big.Int) (*bind.Trans
 			return tx.WithSignature(latestSigner, signature)
 		},
 	}, nil
+}
+
+func insertGasPrice(opts *TransactOpts) {
+	if opts.GasPrice != nil {
+		opts.GasFeeCap = opts.GasPrice
+		opts.GasTipCap = nil
+		opts.GasPrice = nil
+	}
 }

--- a/accounts/wallet_l1.go
+++ b/accounts/wallet_l1.go
@@ -75,7 +75,7 @@ func NewWalletL1FromSigner(signer *ECDSASigner, clientL1 *ethclient.Client, clie
 
 	auth, err := newTransactorWithSigner(signer, l1ChainId)
 	if err != nil {
-		return nil, fmt.Errorf("failed to init TransactOpts: %w", err)
+		return nil, fmt.Errorf("failed to init TransactOptsL1: %w", err)
 	}
 
 	baseToken, err := clientL2.BaseTokenContractAddress(context.Background())
@@ -122,7 +122,7 @@ func NewWalletL1FromSignerAndCache(signer *ECDSASigner, clientL1 *ethclient.Clie
 
 	auth, err := newTransactorWithSigner(signer, l1ChainId)
 	if err != nil {
-		return nil, fmt.Errorf("failed to init TransactOpts: %w", err)
+		return nil, fmt.Errorf("failed to init TransactOptsL1: %w", err)
 	}
 
 	baseToken, err := clientL2.BaseTokenContractAddress(context.Background())
@@ -222,7 +222,7 @@ func (w *WalletL1) L2TokenAddress(ctx context.Context, token common.Address) (co
 }
 
 // ApproveERC20 approves the specified amount of tokens for the specified L1 bridge.
-func (w *WalletL1) ApproveERC20(auth *TransactOpts, token common.Address, amount *big.Int,
+func (w *WalletL1) ApproveERC20(auth *TransactOptsL1, token common.Address, amount *big.Int,
 	bridgeAddress common.Address) (*ethTypes.Transaction, error) {
 	if token == (common.Address{}) {
 		return nil, errors.New("token L1 address must be provided")
@@ -325,7 +325,7 @@ func (w *WalletL1) DepositAllowanceParams(opts *CallOpts, msg DepositCallMsg) ([
 // DepositTransaction.ApproveBaseERC20 can be enabled to perform token approval.
 // If there are already enough approved tokens for the L1 bridge, token approval will be skipped.
 // To check the amount of approved tokens for a specific bridge, use the AdapterL1.AllowanceL1 method.
-func (w *WalletL1) Deposit(auth *TransactOpts, tx DepositTransaction) (*ethTypes.Transaction, error) {
+func (w *WalletL1) Deposit(auth *TransactOptsL1, tx DepositTransaction) (*ethTypes.Transaction, error) {
 	opts := ensureTransactOpts(auth)
 	if tx.Token == utils.LegacyEthAddress {
 		tx.Token = utils.EthAddressInContracts
@@ -525,7 +525,7 @@ func (w *WalletL1) FullRequiredDepositFee(ctx context.Context, msg DepositCallMs
 }
 
 // FinalizeWithdraw proves the inclusion of the L2 -> L1 withdrawal message.
-func (w *WalletL1) FinalizeWithdraw(auth *TransactOpts, withdrawalHash common.Hash, index int) (*ethTypes.Transaction, error) {
+func (w *WalletL1) FinalizeWithdraw(auth *TransactOptsL1, withdrawalHash common.Hash, index int) (*ethTypes.Transaction, error) {
 	if w.clientL1 == nil {
 		return nil, errors.New("ethereum provider is not initialized")
 	}
@@ -687,7 +687,7 @@ func (w *WalletL1) IsWithdrawFinalized(opts *CallOpts, withdrawalHash common.Has
 // ClaimFailedDeposit withdraws funds from the initiated deposit, which failed when finalizing on L2.
 // If the deposit L2 transaction has failed, it sends an L1 transaction calling ClaimFailedDeposit method
 // of the L1 bridge, which results in returning L1 tokens back to the depositor, otherwise throws the error.
-func (w *WalletL1) ClaimFailedDeposit(auth *TransactOpts, depositHash common.Hash) (*ethTypes.Transaction, error) {
+func (w *WalletL1) ClaimFailedDeposit(auth *TransactOptsL1, depositHash common.Hash) (*ethTypes.Transaction, error) {
 	opts := ensureTransactOpts(auth)
 	receipt, err := w.clientL2.TransactionReceipt(opts.Context, depositHash)
 	if err != nil {
@@ -767,7 +767,7 @@ func (w *WalletL1) ClaimFailedDeposit(auth *TransactOpts, depositHash common.Has
 }
 
 // RequestExecute request execution of L2 transaction from L1.
-func (w *WalletL1) RequestExecute(auth *TransactOpts, tx RequestExecuteTransaction) (*ethTypes.Transaction, error) {
+func (w *WalletL1) RequestExecute(auth *TransactOptsL1, tx RequestExecuteTransaction) (*ethTypes.Transaction, error) {
 	opts := ensureTransactOpts(auth)
 	err := w.prepareRequestExecuteTx(opts, &tx)
 	if err != nil {
@@ -909,7 +909,7 @@ func (w *WalletL1) EstimateDepositL2GasFromDefaultBridge(ctx context.Context, to
 	}
 }
 
-func (w *WalletL1) depositEthToEthBasedChain(opts *TransactOpts, tx *DepositTransaction) (*ethTypes.Transaction, error) {
+func (w *WalletL1) depositEthToEthBasedChain(opts *TransactOptsL1, tx *DepositTransaction) (*ethTypes.Transaction, error) {
 	if err := w.populateDepositTxWithDefaults(opts, tx); err != nil {
 		return nil, err
 	}
@@ -926,7 +926,7 @@ func (w *WalletL1) depositEthToEthBasedChain(opts *TransactOpts, tx *DepositTran
 	return w.RequestExecute(opts, *preparedTx)
 }
 
-func (w *WalletL1) prepareDepositEthToEthBasedChain(opts *TransactOpts, tx *DepositTransaction, mintValue *big.Int) (*RequestExecuteTransaction, error) {
+func (w *WalletL1) prepareDepositEthToEthBasedChain(opts *TransactOptsL1, tx *DepositTransaction, mintValue *big.Int) (*RequestExecuteTransaction, error) {
 	if err := w.populateDepositTxWithDefaults(opts, tx); err != nil {
 		return nil, err
 	}
@@ -944,7 +944,7 @@ func (w *WalletL1) prepareDepositEthToEthBasedChain(opts *TransactOpts, tx *Depo
 	}, nil
 }
 
-func (w *WalletL1) depositTokenToEthBasedChain(opts *TransactOpts, tx *DepositTransaction) (*ethTypes.Transaction, error) {
+func (w *WalletL1) depositTokenToEthBasedChain(opts *TransactOptsL1, tx *DepositTransaction) (*ethTypes.Transaction, error) {
 	if err := w.populateDepositTxWithDefaults(opts, tx); err != nil {
 		return nil, err
 	}
@@ -986,7 +986,7 @@ func (w *WalletL1) depositTokenToEthBasedChain(opts *TransactOpts, tx *DepositTr
 	return preparedTx, nil
 }
 
-func (w *WalletL1) prepareDepositTokenToEthBasedChain(opts *TransactOpts, tx *DepositTransaction, mintValue *big.Int) (*ethTypes.Transaction, error) {
+func (w *WalletL1) prepareDepositTokenToEthBasedChain(opts *TransactOptsL1, tx *DepositTransaction, mintValue *big.Int) (*ethTypes.Transaction, error) {
 	if err := w.populateDepositTxWithDefaults(opts, tx); err != nil {
 		return nil, err
 	}
@@ -1031,7 +1031,7 @@ func (w *WalletL1) prepareDepositTokenToEthBasedChain(opts *TransactOpts, tx *De
 	return depositTx, nil
 }
 
-func (w *WalletL1) depositEthToNonEthBasedChain(opts *TransactOpts, tx *DepositTransaction) (*ethTypes.Transaction, error) {
+func (w *WalletL1) depositEthToNonEthBasedChain(opts *TransactOptsL1, tx *DepositTransaction) (*ethTypes.Transaction, error) {
 	if err := w.populateDepositTxWithDefaults(opts, tx); err != nil {
 		return nil, err
 	}
@@ -1070,7 +1070,7 @@ func (w *WalletL1) depositEthToNonEthBasedChain(opts *TransactOpts, tx *DepositT
 	return preparedTx, nil
 }
 
-func (w *WalletL1) prepareDepositEthToNonEthBasedChain(opts *TransactOpts, tx *DepositTransaction, mintValue *big.Int) (*ethTypes.Transaction, error) {
+func (w *WalletL1) prepareDepositEthToNonEthBasedChain(opts *TransactOptsL1, tx *DepositTransaction, mintValue *big.Int) (*ethTypes.Transaction, error) {
 	if err := w.populateDepositTxWithDefaults(opts, tx); err != nil {
 		return nil, err
 	}
@@ -1114,7 +1114,7 @@ func (w *WalletL1) prepareDepositEthToNonEthBasedChain(opts *TransactOpts, tx *D
 	return depositTx, nil
 }
 
-func (w *WalletL1) depositBaseTokenToNonEthBasedChain(opts *TransactOpts, tx *DepositTransaction) (*ethTypes.Transaction, error) {
+func (w *WalletL1) depositBaseTokenToNonEthBasedChain(opts *TransactOptsL1, tx *DepositTransaction) (*ethTypes.Transaction, error) {
 	if err := w.populateDepositTxWithDefaults(opts, tx); err != nil {
 		return nil, err
 	}
@@ -1146,7 +1146,7 @@ func (w *WalletL1) depositBaseTokenToNonEthBasedChain(opts *TransactOpts, tx *De
 	return w.RequestExecute(opts, *preparedTx)
 }
 
-func (w *WalletL1) prepareDepositBaseTokenToNonEthBasedChain(opts *TransactOpts, tx *DepositTransaction, mintValue *big.Int) (*RequestExecuteTransaction, error) {
+func (w *WalletL1) prepareDepositBaseTokenToNonEthBasedChain(opts *TransactOptsL1, tx *DepositTransaction, mintValue *big.Int) (*RequestExecuteTransaction, error) {
 	if err := w.populateDepositTxWithDefaults(opts, tx); err != nil {
 		return nil, err
 	}
@@ -1163,7 +1163,7 @@ func (w *WalletL1) prepareDepositBaseTokenToNonEthBasedChain(opts *TransactOpts,
 	}, nil
 }
 
-func (w *WalletL1) depositNonBaseTokenToNonEthBasedChain(opts *TransactOpts, tx *DepositTransaction) (*ethTypes.Transaction, error) {
+func (w *WalletL1) depositNonBaseTokenToNonEthBasedChain(opts *TransactOptsL1, tx *DepositTransaction) (*ethTypes.Transaction, error) {
 	if err := w.populateDepositTxWithDefaults(opts, tx); err != nil {
 		return nil, err
 	}
@@ -1217,7 +1217,7 @@ func (w *WalletL1) depositNonBaseTokenToNonEthBasedChain(opts *TransactOpts, tx 
 	return preparedTx, nil
 }
 
-func (w *WalletL1) prepareDepositNonBasedTokenToNonEthBasedChain(opts *TransactOpts, tx *DepositTransaction, mintValue *big.Int) (*ethTypes.Transaction, error) {
+func (w *WalletL1) prepareDepositNonBasedTokenToNonEthBasedChain(opts *TransactOptsL1, tx *DepositTransaction, mintValue *big.Int) (*ethTypes.Transaction, error) {
 	if err := w.populateDepositTxWithDefaults(opts, tx); err != nil {
 		return nil, err
 	}
@@ -1261,7 +1261,7 @@ func (w *WalletL1) prepareDepositNonBasedTokenToNonEthBasedChain(opts *TransactO
 	return depositTx, nil
 }
 
-func (w *WalletL1) populateDepositTxWithDefaults(opts *TransactOpts, tx *DepositTransaction) error {
+func (w *WalletL1) populateDepositTxWithDefaults(opts *TransactOptsL1, tx *DepositTransaction) error {
 	*opts = *ensureTransactOpts(opts)
 	if tx.Token == utils.LegacyEthAddress {
 		tx.Token = utils.EthAddressInContracts
@@ -1279,7 +1279,7 @@ func (w *WalletL1) populateDepositTxWithDefaults(opts *TransactOpts, tx *Deposit
 	return nil
 }
 
-func (w *WalletL1) estimateL2GasLimit(auth *TransactOpts, tx *DepositTransaction) error {
+func (w *WalletL1) estimateL2GasLimit(auth *TransactOptsL1, tx *DepositTransaction) error {
 	if tx.BridgeAddress != nil {
 		err := w.estimateL2GasLimitFromCustomBridge(auth, tx)
 		if err != nil {
@@ -1299,7 +1299,7 @@ func (w *WalletL1) estimateL2GasLimit(auth *TransactOpts, tx *DepositTransaction
 	return nil
 }
 
-func (w *WalletL1) estimateL2GasLimitFromCustomBridge(auth *TransactOpts, tx *DepositTransaction) error {
+func (w *WalletL1) estimateL2GasLimitFromCustomBridge(auth *TransactOptsL1, tx *DepositTransaction) error {
 	bridge, err := l1bridge.NewIL1Bridge(*tx.BridgeAddress, w.clientL1)
 	if err != nil {
 		return fmt.Errorf("failed to load custom bridge: %w", err)
@@ -1325,7 +1325,7 @@ func (w *WalletL1) estimateL2GasLimitFromCustomBridge(auth *TransactOpts, tx *De
 	return nil
 }
 
-func (w *WalletL1) calculateBaseCost(opts *TransactOpts, tx *DepositTransaction) (*big.Int, error) {
+func (w *WalletL1) calculateBaseCost(opts *TransactOptsL1, tx *DepositTransaction) (*big.Int, error) {
 	err := w.populateDepositTxWithDefaults(opts, tx)
 	if err != nil {
 		return nil, err
@@ -1340,7 +1340,7 @@ func (w *WalletL1) calculateBaseCost(opts *TransactOpts, tx *DepositTransaction)
 	}, tx.L2GasLimit, tx.GasPerPubdataByte, gasPriceForEstimation)
 }
 
-func (w *WalletL1) calculateMintValue(opts *TransactOpts, tx *DepositTransaction) (*big.Int, error) {
+func (w *WalletL1) calculateMintValue(opts *TransactOptsL1, tx *DepositTransaction) (*big.Int, error) {
 	baseCost, err := w.calculateBaseCost(opts, tx)
 	if err != nil {
 		return nil, err
@@ -1375,7 +1375,7 @@ func (w *WalletL1) secondBridgeCalldata(token, to common.Address, amount *big.In
 	}.Pack(token, amount, to)
 }
 
-func (w *WalletL1) approveERC20(auth *TransactOpts, token common.Address, amount *big.Int, bridgeAddress common.Address) error {
+func (w *WalletL1) approveERC20(auth *TransactOptsL1, token common.Address, amount *big.Int, bridgeAddress common.Address) error {
 	// We only request the allowance if the current one is not enough.
 	auth = ensureTransactOpts(auth)
 	allowance, err := w.AllowanceL1(&CallOpts{
@@ -1399,7 +1399,7 @@ func (w *WalletL1) approveERC20(auth *TransactOpts, token common.Address, amount
 	return nil
 }
 
-func (w *WalletL1) prepareRequestExecuteTx(auth *TransactOpts, tx *RequestExecuteTransaction) error {
+func (w *WalletL1) prepareRequestExecuteTx(auth *TransactOptsL1, tx *RequestExecuteTransaction) error {
 	opts := ensureTransactOpts(auth)
 	if tx.L2Value == nil {
 		tx.L2Value = big.NewInt(0)
@@ -1465,7 +1465,7 @@ func (w *WalletL1) prepareRequestExecuteTx(auth *TransactOpts, tx *RequestExecut
 // Checks if the options contain a GasPrice or GasFeeCap, if not it will try to insert
 // the GasFeeCap (maxFeePerGas) and GasTipCap (maxPriorityFee) if chain supports EIP1559,
 // otherwise it sets GasPrice
-func (w *WalletL1) insertGasPriceInTransactOpts(opts **TransactOpts) error {
+func (w *WalletL1) insertGasPriceInTransactOpts(opts **TransactOptsL1) error {
 	if *opts == nil {
 		*opts = ensureTransactOpts(*opts)
 	}

--- a/accounts/wallet_l2.go
+++ b/accounts/wallet_l2.go
@@ -51,7 +51,7 @@ func NewWalletL2FromSigner(signer *ECDSASigner, client *clients.Client) (*Wallet
 	chainId, err := client.ChainID(context.Background())
 	auth, err := newTransactorWithSigner(signer, chainId)
 	if err != nil {
-		return nil, fmt.Errorf("failed to init TransactOpts: %w", err)
+		return nil, fmt.Errorf("failed to init TransactOptsL1: %w", err)
 	}
 
 	return &WalletL2{
@@ -74,7 +74,7 @@ func NewWalletL2FromSignerAndCache(signer *ECDSASigner, client *clients.Client, 
 	chainId, err := client.ChainID(context.Background())
 	auth, err := newTransactorWithSigner(signer, chainId)
 	if err != nil {
-		return nil, fmt.Errorf("failed to init TransactOpts: %w", err)
+		return nil, fmt.Errorf("failed to init TransactOptsL1: %w", err)
 	}
 
 	c := cache
@@ -153,7 +153,7 @@ func (w *WalletL2) IsBaseToken(ctx context.Context, token common.Address) (bool,
 // Withdraw initiates the withdrawal process which withdraws ETH or any ERC20
 // token from the associated account on L2 network to the target account on L1
 // network.
-func (w *WalletL2) Withdraw(auth *TransactOpts, tx WithdrawalTransaction) (common.Hash, error) {
+func (w *WalletL2) Withdraw(auth *TransactOptsL1, tx WithdrawalTransaction) (common.Hash, error) {
 	opts := ensureTransactOpts(auth)
 	w.insertGasPrice(opts)
 
@@ -234,7 +234,7 @@ func (w *WalletL2) EstimateGasWithdraw(ctx context.Context, msg WithdrawalCallMs
 }
 
 // Transfer moves the base token or any ERC20 token from the associated account to the target account.
-func (w *WalletL2) Transfer(auth *TransactOpts, tx TransferTransaction) (common.Hash, error) {
+func (w *WalletL2) Transfer(auth *TransactOptsL1, tx TransferTransaction) (common.Hash, error) {
 	opts := ensureTransactOpts(auth)
 	w.insertGasPrice(opts)
 
@@ -399,7 +399,7 @@ func (w *WalletL2) SendTransaction(ctx context.Context, tx *Transaction) (common
 	return w.client.SendRawTransaction(ensureContext(ctx), rawTx)
 }
 
-func (w *WalletL2) transferBaseToken(auth *TransactOpts, tx TransferTransaction) (*ethTypes.Transaction, error) {
+func (w *WalletL2) transferBaseToken(auth *TransactOptsL1, tx TransferTransaction) (*ethTypes.Transaction, error) {
 	if auth.GasPrice != nil {
 		if auth.Nonce == nil {
 			nonce, err := w.client.NonceAt(auth.Context, w.Address(), nil)
@@ -448,7 +448,7 @@ func (w *WalletL2) transferBaseToken(auth *TransactOpts, tx TransferTransaction)
 	}
 }
 
-func (w *WalletL2) insertGasPrice(opts *TransactOpts) {
+func (w *WalletL2) insertGasPrice(opts *TransactOptsL1) {
 	if opts.GasPrice != nil {
 		opts.GasFeeCap = opts.GasPrice
 		opts.GasTipCap = nil

--- a/accounts/wallet_l2.go
+++ b/accounts/wallet_l2.go
@@ -153,9 +153,9 @@ func (w *WalletL2) IsBaseToken(ctx context.Context, token common.Address) (bool,
 // Withdraw initiates the withdrawal process which withdraws ETH or any ERC20
 // token from the associated account on L2 network to the target account on L1
 // network.
-func (w *WalletL2) Withdraw(auth *TransactOptsL1, tx WithdrawalTransaction) (common.Hash, error) {
+func (w *WalletL2) Withdraw(auth *TransactOpts, tx WithdrawalTransaction) (common.Hash, error) {
 	opts := ensureTransactOpts(auth)
-	w.insertGasPrice(opts)
+	insertGasPrice(opts)
 
 	if tx.Token == utils.LegacyEthAddress || tx.Token == utils.EthAddressInContracts {
 		var err error
@@ -192,7 +192,7 @@ func (w *WalletL2) Withdraw(auth *TransactOptsL1, tx WithdrawalTransaction) (com
 			Data:            data,
 			ChainID:         w.signer.ChainID(),
 			GasPerPubdata:   utils.DefaultGasPerPubdataLimit,
-			PaymasterParams: tx.PaymasterParams,
+			PaymasterParams: opts.PaymasterParams,
 		})
 	}
 
@@ -224,7 +224,7 @@ func (w *WalletL2) Withdraw(auth *TransactOptsL1, tx WithdrawalTransaction) (com
 		Data:            data,
 		ChainID:         w.signer.ChainID(),
 		GasPerPubdata:   utils.DefaultGasPerPubdataLimit,
-		PaymasterParams: tx.PaymasterParams,
+		PaymasterParams: opts.PaymasterParams,
 	})
 }
 
@@ -234,9 +234,9 @@ func (w *WalletL2) EstimateGasWithdraw(ctx context.Context, msg WithdrawalCallMs
 }
 
 // Transfer moves the base token or any ERC20 token from the associated account to the target account.
-func (w *WalletL2) Transfer(auth *TransactOptsL1, tx TransferTransaction) (common.Hash, error) {
+func (w *WalletL2) Transfer(auth *TransactOpts, tx TransferTransaction) (common.Hash, error) {
 	opts := ensureTransactOpts(auth)
-	w.insertGasPrice(opts)
+	insertGasPrice(opts)
 
 	if tx.Token == utils.LegacyEthAddress || tx.Token == utils.EthAddressInContracts {
 		var err error
@@ -256,7 +256,7 @@ func (w *WalletL2) Transfer(auth *TransactOptsL1, tx TransferTransaction) (commo
 			Value:           tx.Amount,
 			ChainID:         w.signer.ChainID(),
 			GasPerPubdata:   utils.DefaultGasPerPubdataLimit,
-			PaymasterParams: tx.PaymasterParams,
+			PaymasterParams: opts.PaymasterParams,
 		})
 	}
 
@@ -280,7 +280,7 @@ func (w *WalletL2) Transfer(auth *TransactOptsL1, tx TransferTransaction) (commo
 		Data:            data,
 		ChainID:         w.signer.ChainID(),
 		GasPerPubdata:   utils.DefaultGasPerPubdataLimit,
-		PaymasterParams: tx.PaymasterParams,
+		PaymasterParams: opts.PaymasterParams,
 	})
 }
 
@@ -445,13 +445,5 @@ func (w *WalletL2) transferBaseToken(auth *TransactOptsL1, tx TransferTransactio
 			return nil, err
 		}
 		return signedTx, nil
-	}
-}
-
-func (w *WalletL2) insertGasPrice(opts *TransactOptsL1) {
-	if opts.GasPrice != nil {
-		opts.GasFeeCap = opts.GasPrice
-		opts.GasTipCap = nil
-		opts.GasPrice = nil
 	}
 }

--- a/test/smart_account_test.go
+++ b/test/smart_account_test.go
@@ -252,12 +252,13 @@ func TestIntegration_EthBasedChain_SmartAccount_WithdrawEthUsingPaymaster(t *tes
 		})
 	assert.NoError(t, err, "GetPaymasterParams should not return an error")
 
-	withdrawHash, err := account.Withdraw(nil, accounts.WithdrawalTransaction{
-		To:              account.Address(),
-		Amount:          amount,
-		Token:           utils.LegacyEthAddress,
-		PaymasterParams: paymasterParams,
-	})
+	withdrawHash, err := account.Withdraw(
+		&accounts.TransactOpts{PaymasterParams: paymasterParams},
+		accounts.WithdrawalTransaction{
+			To:     account.Address(),
+			Amount: amount,
+			Token:  utils.LegacyEthAddress,
+		})
 	assert.NoError(t, err, "Withdraw should not return an error")
 
 	withdrawReceipt, err := client.WaitFinalized(context.Background(), withdrawHash)
@@ -334,12 +335,13 @@ func TestIntegration_NonEthBasedChain_SmartAccount_WithdrawEthUsingPaymaster(t *
 		})
 	assert.NoError(t, err, "GetPaymasterParams should not return an error")
 
-	withdrawHash, err := account.Withdraw(nil, accounts.WithdrawalTransaction{
-		To:              account.Address(),
-		Amount:          amount,
-		Token:           utils.LegacyEthAddress, // or l2EthAddress
-		PaymasterParams: paymasterParams,
-	})
+	withdrawHash, err := account.Withdraw(
+		&accounts.TransactOpts{PaymasterParams: paymasterParams},
+		accounts.WithdrawalTransaction{
+			To:     account.Address(),
+			Amount: amount,
+			Token:  utils.LegacyEthAddress, // or l2EthAddress
+		})
 	assert.NoError(t, err, "Withdraw should not return an error")
 
 	withdrawReceipt, err := client.WaitFinalized(context.Background(), withdrawHash)
@@ -456,12 +458,13 @@ func TestIntegration_NonEthBasedChain_SmartAccount_WithdrawBaseTokenUsingPaymast
 		})
 	assert.NoError(t, err, "GetPaymasterParams should not return an error")
 
-	withdrawHash, err := account.Withdraw(nil, accounts.WithdrawalTransaction{
-		To:              account.Address(),
-		Amount:          amount,
-		Token:           utils.L2BaseTokenAddress,
-		PaymasterParams: paymasterParams,
-	})
+	withdrawHash, err := account.Withdraw(
+		&accounts.TransactOpts{PaymasterParams: paymasterParams},
+		accounts.WithdrawalTransaction{
+			To:     account.Address(),
+			Amount: amount,
+			Token:  utils.L2BaseTokenAddress,
+		})
 	assert.NoError(t, err, "Withdraw should not return an error")
 
 	withdrawReceipt, err := client.WaitFinalized(context.Background(), withdrawHash)
@@ -578,12 +581,13 @@ func TestIntegrationSmartAccount_WithdrawTokenUsingPaymaster(t *testing.T) {
 		})
 	assert.NoError(t, err, "GetPaymasterParams should not return an error")
 
-	withdrawHash, err := account.Withdraw(nil, accounts.WithdrawalTransaction{
-		To:              account.Address(),
-		Amount:          amount,
-		Token:           L2Dai,
-		PaymasterParams: paymasterParams,
-	})
+	withdrawHash, err := account.Withdraw(
+		&accounts.TransactOpts{PaymasterParams: paymasterParams},
+		accounts.WithdrawalTransaction{
+			To:     account.Address(),
+			Amount: amount,
+			Token:  L2Dai,
+		})
 	assert.NoError(t, err, "Withdraw should not return an error")
 
 	withdrawReceipt, err := client.WaitFinalized(context.Background(), withdrawHash)
@@ -729,12 +733,13 @@ func TestIntegration_EthBasedChain_SmartAccount_TransferEthUsingPaymaster(t *tes
 		})
 	assert.NoError(t, err, "GetPaymasterParams should not return an error")
 
-	txHash, err := account.Transfer(nil, accounts.TransferTransaction{
-		To:              Address2,
-		Amount:          amount,
-		Token:           utils.LegacyEthAddress,
-		PaymasterParams: paymasterParams,
-	})
+	txHash, err := account.Transfer(
+		&accounts.TransactOpts{PaymasterParams: paymasterParams},
+		accounts.TransferTransaction{
+			To:     Address2,
+			Amount: amount,
+			Token:  utils.LegacyEthAddress,
+		})
 	assert.NoError(t, err, "Transfer should not return an error")
 
 	receipt, err := client.WaitMined(context.Background(), txHash)
@@ -806,12 +811,13 @@ func TestIntegration_NonEthBasedChain_SmartAccount_TransferEthUsingPaymaster(t *
 		})
 	assert.NoError(t, err, "GetPaymasterParams should not return an error")
 
-	txHash, err := sender.Transfer(nil, accounts.TransferTransaction{
-		To:              Address2,
-		Amount:          amount,
-		Token:           utils.LegacyEthAddress, // or l2EthAddress
-		PaymasterParams: paymasterParams,
-	})
+	txHash, err := sender.Transfer(
+		&accounts.TransactOpts{PaymasterParams: paymasterParams},
+		accounts.TransferTransaction{
+			To:     Address2,
+			Amount: amount,
+			Token:  utils.LegacyEthAddress, // or l2EthAddress
+		})
 	assert.NoError(t, err, "Transfer should not return an error")
 
 	receipt, err := client.WaitMined(context.Background(), txHash)
@@ -923,12 +929,13 @@ func TestIntegration_NonEthBasedChain_SmartAccount_TransferBaseTokenUsingPaymast
 		})
 	assert.NoError(t, err, "GetPaymasterParams should not return an error")
 
-	txHash, err := account.Transfer(nil, accounts.TransferTransaction{
-		To:              Address2,
-		Amount:          amount,
-		Token:           utils.L2BaseTokenAddress,
-		PaymasterParams: paymasterParams,
-	})
+	txHash, err := account.Transfer(
+		&accounts.TransactOpts{PaymasterParams: paymasterParams},
+		accounts.TransferTransaction{
+			To:     Address2,
+			Amount: amount,
+			Token:  utils.L2BaseTokenAddress,
+		})
 	assert.NoError(t, err, "Transfer should not return an error")
 
 	receipt, err := client.WaitMined(context.Background(), txHash)
@@ -1042,12 +1049,13 @@ func TestIntegrationSmartAccount_TransferTokenUsingPaymaster(t *testing.T) {
 		})
 	assert.NoError(t, err, "GetPaymasterParams should not return an error")
 
-	txHash, err := account.Transfer(nil, accounts.TransferTransaction{
-		To:              Address2,
-		Amount:          amount,
-		Token:           L2Dai,
-		PaymasterParams: paymasterParams,
-	})
+	txHash, err := account.Transfer(
+		&accounts.TransactOpts{PaymasterParams: paymasterParams},
+		accounts.TransferTransaction{
+			To:     Address2,
+			Amount: amount,
+			Token:  L2Dai,
+		})
 	assert.NoError(t, err, "Transfer should not return an error")
 
 	receipt, err := client.WaitMined(context.Background(), txHash)
@@ -1277,12 +1285,13 @@ func TestIntegrationMultisigSmartAccount_WithdrawUsingPaymaster(t *testing.T) {
 		})
 	assert.NoError(t, err, "GetPaymasterParams should not return an error")
 
-	withdrawHash, err := account.Withdraw(nil, accounts.WithdrawalTransaction{
-		To:              wallet.Address(),
-		Amount:          amount,
-		Token:           utils.LegacyEthAddress,
-		PaymasterParams: paymasterParams,
-	})
+	withdrawHash, err := account.Withdraw(
+		&accounts.TransactOpts{PaymasterParams: paymasterParams},
+		accounts.WithdrawalTransaction{
+			To:     wallet.Address(),
+			Amount: amount,
+			Token:  utils.LegacyEthAddress,
+		})
 	assert.NoError(t, err, "Withdraw should not return an error")
 
 	withdrawReceipt, err := client.WaitFinalized(context.Background(), withdrawHash)
@@ -1399,12 +1408,13 @@ func TestIntegrationMultisigSmartAccount_WithdrawTokenUsingPaymaster(t *testing.
 		})
 	assert.NoError(t, err, "GetPaymasterParams should not return an error")
 
-	withdrawHash, err := account.Withdraw(nil, accounts.WithdrawalTransaction{
-		To:              wallet.Address(),
-		Amount:          amount,
-		Token:           L2Dai,
-		PaymasterParams: paymasterParams,
-	})
+	withdrawHash, err := account.Withdraw(
+		&accounts.TransactOpts{PaymasterParams: paymasterParams},
+		accounts.WithdrawalTransaction{
+			To:     wallet.Address(),
+			Amount: amount,
+			Token:  L2Dai,
+		})
 	assert.NoError(t, err, "Withdraw should not return an error")
 
 	withdrawReceipt, err := client.WaitFinalized(context.Background(), withdrawHash)
@@ -1512,12 +1522,13 @@ func TestIntegrationMultisigSmartAccount_TransferEthUsingPaymaster(t *testing.T)
 		})
 	assert.NoError(t, err, "GetPaymasterParams should not return an error")
 
-	txHash, err := account.Transfer(nil, accounts.TransferTransaction{
-		To:              Address2,
-		Amount:          amount,
-		Token:           utils.LegacyEthAddress,
-		PaymasterParams: paymasterParams,
-	})
+	txHash, err := account.Transfer(
+		&accounts.TransactOpts{PaymasterParams: paymasterParams},
+		accounts.TransferTransaction{
+			To:     Address2,
+			Amount: amount,
+			Token:  utils.LegacyEthAddress,
+		})
 	assert.NoError(t, err, "Transfer should not return an error")
 
 	receipt, err := client.WaitMined(context.Background(), txHash)
@@ -1631,12 +1642,13 @@ func TestIntegrationMultisigSmartAccount_TransferTokenUsingPaymaster(t *testing.
 		})
 	assert.NoError(t, err, "GetPaymasterParams should not return an error")
 
-	txHash, err := account.Transfer(nil, accounts.TransferTransaction{
-		To:              Address2,
-		Amount:          amount,
-		Token:           L2Dai,
-		PaymasterParams: paymasterParams,
-	})
+	txHash, err := account.Transfer(
+		&accounts.TransactOpts{PaymasterParams: paymasterParams},
+		accounts.TransferTransaction{
+			To:     Address2,
+			Amount: amount,
+			Token:  L2Dai,
+		})
 	assert.NoError(t, err, "Transfer should not return an error")
 
 	receipt, err := client.WaitMined(context.Background(), txHash)

--- a/test/wallet_test.go
+++ b/test/wallet_test.go
@@ -478,12 +478,13 @@ func TestIntegration_EthBasedChain_Wallet_WithdrawEthUsingPaymaster(t *testing.T
 		})
 	assert.NoError(t, err, "GetPaymasterParams should not return an error")
 
-	withdrawTxHash, err := wallet.Withdraw(nil, accounts.WithdrawalTransaction{
-		To:              wallet.Address(),
-		Amount:          amount,
-		Token:           utils.LegacyEthAddress,
-		PaymasterParams: paymasterParams,
-	})
+	withdrawTxHash, err := wallet.Withdraw(
+		&accounts.TransactOpts{PaymasterParams: paymasterParams},
+		accounts.WithdrawalTransaction{
+			To:     wallet.Address(),
+			Amount: amount,
+			Token:  utils.LegacyEthAddress,
+		})
 	assert.NoError(t, err, "Withdraw should not return an error")
 
 	withdrawReceipt, err := client.WaitFinalized(context.Background(), withdrawTxHash)
@@ -585,12 +586,13 @@ func TestIntegration_NonEthBasedChain_Wallet_WithdrawEthUsingPaymaster(t *testin
 		})
 	assert.NoError(t, err, "GetPaymasterParams should not return an error")
 
-	withdrawTx, err := sender.Withdraw(nil, accounts.WithdrawalTransaction{
-		To:              sender.Address(),
-		Amount:          amount,
-		Token:           utils.LegacyEthAddress, // or l2EthAddress
-		PaymasterParams: paymasterParams,
-	})
+	withdrawTx, err := sender.Withdraw(
+		&accounts.TransactOpts{PaymasterParams: paymasterParams},
+		accounts.WithdrawalTransaction{
+			To:     sender.Address(),
+			Amount: amount,
+			Token:  utils.LegacyEthAddress, // or l2EthAddress
+		})
 	assert.NoError(t, err, "Withdraw should not return an error")
 
 	withdrawReceipt, err := client.WaitFinalized(context.Background(), withdrawTx)
@@ -731,12 +733,13 @@ func TestIntegrationWallet_WithdrawTokenUsingPaymaster(t *testing.T) {
 		})
 	assert.NoError(t, err, "GetPaymasterParams should not return an error")
 
-	withdrawTx, err := wallet.Withdraw(nil, accounts.WithdrawalTransaction{
-		To:              wallet.Address(),
-		Amount:          amount,
-		Token:           L2Dai,
-		PaymasterParams: paymasterParams,
-	})
+	withdrawTx, err := wallet.Withdraw(
+		&accounts.TransactOpts{PaymasterParams: paymasterParams},
+		accounts.WithdrawalTransaction{
+			To:     wallet.Address(),
+			Amount: amount,
+			Token:  L2Dai,
+		})
 	assert.NoError(t, err, "Withdraw should not return an error")
 
 	withdrawReceipt, err := client.WaitFinalized(context.Background(), withdrawTx)
@@ -823,12 +826,13 @@ func TestIntegration_EthBasedChain_Wallet_TransferEthUsingPaymaster(t *testing.T
 		})
 	assert.NoError(t, err, "GetPaymasterParams should not return an error")
 
-	txHash, err := wallet.Transfer(nil, accounts.TransferTransaction{
-		To:              Address2,
-		Amount:          amount,
-		Token:           utils.LegacyEthAddress,
-		PaymasterParams: paymasterParams,
-	})
+	txHash, err := wallet.Transfer(
+		&accounts.TransactOpts{PaymasterParams: paymasterParams},
+		accounts.TransferTransaction{
+			To:     Address2,
+			Amount: amount,
+			Token:  utils.LegacyEthAddress,
+		})
 	assert.NoError(t, err, "Transfer should not return an error")
 
 	receipt, err := client.WaitMined(context.Background(), txHash)
@@ -960,12 +964,13 @@ func TestIntegration_NonEthBasedChain_Wallet_TransferEthUsingPaymaster(t *testin
 		})
 	assert.NoError(t, err, "GetPaymasterParams should not return an error")
 
-	txHash, err := sender.Transfer(nil, accounts.TransferTransaction{
-		To:              Address2,
-		Amount:          amount,
-		Token:           utils.LegacyEthAddress, // or l2EthAddress
-		PaymasterParams: paymasterParams,
-	})
+	txHash, err := sender.Transfer(
+		&accounts.TransactOpts{PaymasterParams: paymasterParams},
+		accounts.TransferTransaction{
+			To:     Address2,
+			Amount: amount,
+			Token:  utils.LegacyEthAddress, // or l2EthAddress
+		})
 	assert.NoError(t, err, "Transfer should not return an error")
 
 	receipt, err := client.WaitMined(context.Background(), txHash)
@@ -1051,12 +1056,13 @@ func TestIntegration_Wallet_TransferTokenUsingPaymaster(t *testing.T) {
 		})
 	assert.NoError(t, err, "GetPaymasterParams should not return an error")
 
-	txHash, err := sender.Transfer(nil, accounts.TransferTransaction{
-		To:              Address2,
-		Amount:          amount,
-		Token:           L2Dai,
-		PaymasterParams: paymasterParams,
-	})
+	txHash, err := sender.Transfer(
+		&accounts.TransactOpts{PaymasterParams: paymasterParams},
+		accounts.TransferTransaction{
+			To:     Address2,
+			Amount: amount,
+			Token:  L2Dai,
+		})
 	assert.NoError(t, err, "Transfer should not return an error")
 
 	receipt, err := client.WaitMined(context.Background(), txHash)


### PR DESCRIPTION
# What :computer: 
* Rename the `TransactionOpts` to `TransactionOptsL1` since it's only meant to be used for L1 communication and does not provide ZKsync features. It's primary meant to be used for `WalletL1`.
* Add `TransacitionOpts` with `PaymasterParams` and `GasPerPubdata` properties which can be used with interaction with contracts. It's meant to be used for `WalletL2` and `Deployer`.
* Remove the `PaymasterParams` from `TransferTransaction` and `WithdrawalTransaction`, and utilize `PaymasterParams` from `TransactOpts`.