### PR TITLE
Refactor: rename `WalletL1.ApproveERC20` and `DepositTransaction` fields

### DIFF
--- a/accounts/types.go
+++ b/accounts/types.go
@@ -849,12 +849,12 @@ type DepositTransaction struct {
 	BridgeAddress *common.Address
 
 	// Whether should the token approval be performed under the hood. Set this flag to true if you
-	// bridge an ERC20 token and didn't call the approveERC20 function beforehand.
-	ApproveERC20 bool
+	// bridge an ERC20 token and didn't call the ApproveToken function beforehand.
+	ApproveToken bool
 
 	// Whether should the base token approval be performed under the hood. Set this flag to true if you
-	// bridge an ERC20 token and didn't call the approveERC20 function beforehand.
-	ApproveBaseERC20 bool
+	// bridge an ERC20 token and didn't call the ApproveToken function beforehand.
+	ApproveBaseToken bool
 
 	L2GasLimit *big.Int // Maximum amount of L2 gas that transaction can consume during execution on L2.
 
@@ -913,10 +913,10 @@ func (t *DepositTransaction) PopulateEmptyFields(from common.Address) {
 	if t.Token == (common.Address{}) {
 		t.Token = utils.LegacyEthAddress
 	}
-	if t.ApproveERC20 && t.ApproveAuth == nil {
+	if t.ApproveToken && t.ApproveAuth == nil {
 		t.ApproveAuth = ensureTransactOptsL1(t.ApproveAuth)
 	}
-	if t.ApproveBaseERC20 && t.ApproveBaseAuth == nil {
+	if t.ApproveBaseToken && t.ApproveBaseAuth == nil {
 		t.ApproveAuth = ensureTransactOptsL1(t.ApproveBaseAuth)
 	}
 }

--- a/accounts/wallet_l1.go
+++ b/accounts/wallet_l1.go
@@ -221,8 +221,8 @@ func (w *WalletL1) L2TokenAddress(ctx context.Context, token common.Address) (co
 	return w.clientL2.L2TokenAddress(ensureContext(ctx), token)
 }
 
-// ApproveERC20 approves the specified amount of tokens for the specified L1 bridge.
-func (w *WalletL1) ApproveERC20(auth *TransactOptsL1, token common.Address, amount *big.Int,
+// ApproveToken approves the specified amount of tokens for the specified L1 bridge.
+func (w *WalletL1) ApproveToken(auth *TransactOptsL1, token common.Address, amount *big.Int,
 	bridgeAddress common.Address) (*ethTypes.Transaction, error) {
 	if token == (common.Address{}) {
 		return nil, errors.New("token L1 address must be provided")
@@ -1385,7 +1385,7 @@ func (w *WalletL1) approveERC20(auth *TransactOptsL1, token common.Address, amou
 		return err
 	}
 	if allowance.Cmp(amount) < 0 {
-		approveTx, errApprove := w.ApproveERC20(
+		approveTx, errApprove := w.ApproveToken(
 			auth, token, amount, bridgeAddress,
 		)
 		if errApprove != nil {

--- a/accounts/wallet_l1.go
+++ b/accounts/wallet_l1.go
@@ -321,8 +321,8 @@ func (w *WalletL1) DepositAllowanceParams(opts *CallOpts, msg DepositCallMsg) ([
 // to the target account on the L2 network. The token can be either ETH or any ERC20 token.
 // For ERC20 tokens, enough approved tokens must be associated with the specified L1 bridge
 // (default one or the one defined in DepositTransaction.BridgeAddress).
-// In this case, depending on is the chain ETH-based or not DepositTransaction.ApproveERC20 or
-// DepositTransaction.ApproveBaseERC20 can be enabled to perform token approval.
+// In this case, depending on is the chain ETH-based or not DepositTransaction.ApproveToken or
+// DepositTransaction.ApproveBaseToken can be enabled to perform token approval.
 // If there are already enough approved tokens for the L1 bridge, token approval will be skipped.
 // To check the amount of approved tokens for a specific bridge, use the AdapterL1.AllowanceL1 method.
 func (w *WalletL1) Deposit(auth *TransactOptsL1, tx DepositTransaction) (*ethTypes.Transaction, error) {
@@ -961,7 +961,7 @@ func (w *WalletL1) depositTokenToEthBasedChain(opts *TransactOptsL1, tx *Deposit
 		return nil, checkErr
 	}
 
-	if tx.ApproveERC20 {
+	if tx.ApproveToken {
 		l1SharedBridgeAddress, addressError := w.cache.L1SharedBridgeAddress()
 		if addressError != nil {
 			return nil, addressError
@@ -1048,7 +1048,7 @@ func (w *WalletL1) depositEthToNonEthBasedChain(opts *TransactOptsL1, tx *Deposi
 		return nil, checkErr
 	}
 
-	if tx.ApproveBaseERC20 {
+	if tx.ApproveBaseToken {
 		l1SharedBridgeAddress, addressError := w.cache.L1SharedBridgeAddress()
 		if addressError != nil {
 			return nil, addressError
@@ -1123,9 +1123,9 @@ func (w *WalletL1) depositBaseTokenToNonEthBasedChain(opts *TransactOptsL1, tx *
 		return nil, err
 	}
 
-	if tx.ApproveBaseERC20 || tx.ApproveERC20 {
+	if tx.ApproveBaseToken || tx.ApproveToken {
 		approveOpts := tx.ApproveBaseAuth
-		if tx.ApproveBaseERC20 {
+		if tx.ApproveBaseToken {
 			approveOpts = tx.ApproveAuth
 		}
 		l1SharedBridgeAddress, addressError := w.cache.L1SharedBridgeAddress()
@@ -1180,7 +1180,7 @@ func (w *WalletL1) depositNonBaseTokenToNonEthBasedChain(opts *TransactOptsL1, t
 		return nil, checkErr
 	}
 
-	if tx.ApproveBaseERC20 {
+	if tx.ApproveBaseToken {
 		l1SharedBridgeAddress, addressError := w.cache.L1SharedBridgeAddress()
 		if addressError != nil {
 			return nil, addressError
@@ -1191,7 +1191,7 @@ func (w *WalletL1) depositNonBaseTokenToNonEthBasedChain(opts *TransactOptsL1, t
 		}
 	}
 
-	if tx.ApproveERC20 {
+	if tx.ApproveToken {
 		l1SharedBridgeAddress, addressError := w.cache.L1SharedBridgeAddress()
 		if addressError != nil {
 			return nil, addressError

--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -266,8 +266,8 @@ func sendTokenToL2(wallet *accounts.Wallet, client *clients.Client, ethClient *e
 		Token:            l1Token,
 		Amount:           amount,
 		To:               wallet.Address(),
-		ApproveERC20:     true,
-		ApproveBaseERC20: true,
+		ApproveToken:     true,
+		ApproveBaseToken: true,
 		RefundRecipient:  wallet.Address(),
 	})
 	if err != nil {

--- a/test/wallet_test.go
+++ b/test/wallet_test.go
@@ -266,8 +266,8 @@ func TestIntegrationWallet_ApproveERC20(t *testing.T) {
 	allowanceBefore, err := wallet.AllowanceL1(nil, l1TokenAddress, bridgeContracts.L1SharedBridge)
 	assert.NoError(t, err, "AllowanceL1 should not return an error")
 
-	tx, err := wallet.ApproveERC20(nil, L1Dai, approveAmount, bridgeContracts.L1SharedBridge)
-	assert.NoError(t, err, "ApproveERC20 should not return an error")
+	tx, err := wallet.ApproveToken(nil, L1Dai, approveAmount, bridgeContracts.L1SharedBridge)
+	assert.NoError(t, err, "ApproveToken should not return an error")
 
 	txReceipt, err := bind.WaitMined(context.Background(), ethClient, tx)
 	assert.NoError(t, err, "bind.WaitMined should not return an error")
@@ -1434,7 +1434,7 @@ func TestIntegrationWallet_DeployAccount(t *testing.T) {
 //		Token:            L1Dai,
 //		To:               wallet.Address1(),
 //		Amount:           big.NewInt(5),
-//		ApproveERC20:     true,
+//		ApproveToken:     true,
 //		ApproveBaseERC20: true,
 //		L2GasLimit:       big.NewInt(255_000), // make it fail because of low gas
 //	})
@@ -1517,8 +1517,8 @@ func TestIntegration_EthBasedChain_Wallet_EstimateGasDepositToken(t *testing.T) 
 	bridgeContracts, err := client.BridgeContracts(context.Background())
 	assert.NoError(t, err, "BridgeContracts should not return an error")
 
-	approveTx, err := wallet.ApproveERC20(nil, L1Dai, big.NewInt(5), bridgeContracts.L1SharedBridge)
-	assert.NoError(t, err, "ApproveERC20 should not return an error")
+	approveTx, err := wallet.ApproveToken(nil, L1Dai, big.NewInt(5), bridgeContracts.L1SharedBridge)
+	assert.NoError(t, err, "ApproveToken should not return an error")
 
 	_, err = bind.WaitMined(context.Background(), ethClient, approveTx)
 	assert.NoError(t, err, "bind.WaitMined should not return an error")
@@ -1715,8 +1715,8 @@ func TestIntegration_EthBasedChain_Wallet_FullRequiredDepositFeeToken(t *testing
 	bridgeContracts, err := client.BridgeContracts(context.Background())
 	assert.NoError(t, err, "BridgeContracts should not return an error")
 
-	approveTx, err := wallet.ApproveERC20(nil, L1Dai, big.NewInt(5), bridgeContracts.L1SharedBridge)
-	assert.NoError(t, err, "ApproveERC20 should not return an error")
+	approveTx, err := wallet.ApproveToken(nil, L1Dai, big.NewInt(5), bridgeContracts.L1SharedBridge)
+	assert.NoError(t, err, "ApproveToken should not return an error")
 
 	_, err = bind.WaitMined(context.Background(), ethClient, approveTx)
 	assert.NoError(t, err, "bind.WaitMined should not return an error")
@@ -1832,8 +1832,8 @@ func TestIntegration_NonEthBasedChain_Wallet_EstimateGasDepositEth(t *testing.T)
 	bridgeContracts, err := client.BridgeContracts(context.Background())
 	assert.NoError(t, err, "BridgeContracts should not return an error")
 
-	approveTx, err := wallet.ApproveERC20(nil, allowanceParams[0].Token, allowanceParams[0].Allowance, bridgeContracts.L1SharedBridge)
-	assert.NoError(t, err, "ApproveERC20 should not return an error")
+	approveTx, err := wallet.ApproveToken(nil, allowanceParams[0].Token, allowanceParams[0].Allowance, bridgeContracts.L1SharedBridge)
+	assert.NoError(t, err, "ApproveToken should not return an error")
 
 	_, err = bind.WaitMined(context.Background(), ethClient, approveTx)
 	assert.NoError(t, err, "bind.WaitMined should not return an error")
@@ -1870,8 +1870,8 @@ func TestIntegration_NonEthBasedChain_Wallet_EstimateGasDepositBaseToken(t *test
 	bridgeContracts, err := client.BridgeContracts(context.Background())
 	assert.NoError(t, err, "BridgeContracts should not return an error")
 
-	approveTx, err := wallet.ApproveERC20(nil, allowanceParams[0].Token, allowanceParams[0].Allowance, bridgeContracts.L1SharedBridge)
-	assert.NoError(t, err, "ApproveERC20 should not return an error")
+	approveTx, err := wallet.ApproveToken(nil, allowanceParams[0].Token, allowanceParams[0].Allowance, bridgeContracts.L1SharedBridge)
+	assert.NoError(t, err, "ApproveToken should not return an error")
 
 	_, err = bind.WaitMined(context.Background(), ethClient, approveTx)
 	assert.NoError(t, err, "bind.WaitMined should not return an error")
@@ -1905,14 +1905,14 @@ func TestIntegration_NonEthBasedChain_Wallet_EstimateGasDepositNonBasedToken(t *
 	bridgeContracts, err := client.BridgeContracts(context.Background())
 	assert.NoError(t, err, "BridgeContracts should not return an error")
 
-	approveTx, err := wallet.ApproveERC20(nil, allowanceParams[0].Token, allowanceParams[0].Allowance, bridgeContracts.L1SharedBridge)
-	assert.NoError(t, err, "ApproveERC20 should not return an error")
+	approveTx, err := wallet.ApproveToken(nil, allowanceParams[0].Token, allowanceParams[0].Allowance, bridgeContracts.L1SharedBridge)
+	assert.NoError(t, err, "ApproveToken should not return an error")
 
 	_, err = bind.WaitMined(context.Background(), ethClient, approveTx)
 	assert.NoError(t, err, "bind.WaitMined should not return an error")
 
-	approveTx, err = wallet.ApproveERC20(nil, allowanceParams[1].Token, allowanceParams[1].Allowance, bridgeContracts.L1SharedBridge)
-	assert.NoError(t, err, "ApproveERC20 should not return an error")
+	approveTx, err = wallet.ApproveToken(nil, allowanceParams[1].Token, allowanceParams[1].Allowance, bridgeContracts.L1SharedBridge)
+	assert.NoError(t, err, "ApproveToken should not return an error")
 
 	_, err = bind.WaitMined(context.Background(), ethClient, approveTx)
 	assert.NoError(t, err, "bind.WaitMined should not return an error")
@@ -2121,8 +2121,8 @@ func TestIntegration_NonEthBasedChain_Wallet_FullRequiredDepositFeeEth(t *testin
 	bridgeContracts, err := client.BridgeContracts(context.Background())
 	assert.NoError(t, err, "BridgeContracts should not return an error")
 
-	approveTx, err := wallet.ApproveERC20(nil, allowanceParams[0].Token, allowanceParams[0].Allowance, bridgeContracts.L1SharedBridge)
-	assert.NoError(t, err, "ApproveERC20 should not return an error")
+	approveTx, err := wallet.ApproveToken(nil, allowanceParams[0].Token, allowanceParams[0].Allowance, bridgeContracts.L1SharedBridge)
+	assert.NoError(t, err, "ApproveToken should not return an error")
 
 	_, err = bind.WaitMined(context.Background(), ethClient, approveTx)
 	assert.NoError(t, err, "bind.WaitMined should not return an error")
@@ -2164,8 +2164,8 @@ func TestIntegration_NonEthBasedChain_Wallet_FullRequiredDepositFeeBaseToken(t *
 	bridgeContracts, err := client.BridgeContracts(context.Background())
 	assert.NoError(t, err, "BridgeContracts should not return an error")
 
-	approveTx, err := wallet.ApproveERC20(nil, allowanceParams[0].Token, allowanceParams[0].Allowance, bridgeContracts.L1SharedBridge)
-	assert.NoError(t, err, "ApproveERC20 should not return an error")
+	approveTx, err := wallet.ApproveToken(nil, allowanceParams[0].Token, allowanceParams[0].Allowance, bridgeContracts.L1SharedBridge)
+	assert.NoError(t, err, "ApproveToken should not return an error")
 
 	_, err = bind.WaitMined(context.Background(), ethClient, approveTx)
 	assert.NoError(t, err, "bind.WaitMined should not return an error")
@@ -2203,14 +2203,14 @@ func TestIntegration_NonEthBasedChain_Wallet_FullRequiredDepositFeeNonBaseToken(
 	bridgeContracts, err := client.BridgeContracts(context.Background())
 	assert.NoError(t, err, "BridgeContracts should not return an error")
 
-	approveTx, err := wallet.ApproveERC20(nil, allowanceParams[0].Token, allowanceParams[0].Allowance, bridgeContracts.L1SharedBridge)
-	assert.NoError(t, err, "ApproveERC20 should not return an error")
+	approveTx, err := wallet.ApproveToken(nil, allowanceParams[0].Token, allowanceParams[0].Allowance, bridgeContracts.L1SharedBridge)
+	assert.NoError(t, err, "ApproveToken should not return an error")
 
 	_, err = bind.WaitMined(context.Background(), ethClient, approveTx)
 	assert.NoError(t, err, "bind.WaitMined should not return an error")
 
-	approveTx, err = wallet.ApproveERC20(nil, allowanceParams[1].Token, allowanceParams[1].Allowance, bridgeContracts.L1SharedBridge)
-	assert.NoError(t, err, "ApproveERC20 should not return an error")
+	approveTx, err = wallet.ApproveToken(nil, allowanceParams[1].Token, allowanceParams[1].Allowance, bridgeContracts.L1SharedBridge)
+	assert.NoError(t, err, "ApproveToken should not return an error")
 
 	_, err = bind.WaitMined(context.Background(), ethClient, approveTx)
 	assert.NoError(t, err, "bind.WaitMined should not return an error")
@@ -2292,8 +2292,8 @@ func TestIntegration_NonEthBasedChain_Wallet_FullRequiredDepositFeeTokenNotEnoug
 	bridgeContracts, err := client.BridgeContracts(context.Background())
 	assert.NoError(t, err, "BridgeContracts should not return an error")
 
-	approveTx, err := randomWallet.ApproveERC20(nil, allowanceParams[0].Token, allowanceParams[0].Allowance, bridgeContracts.L1SharedBridge)
-	assert.NoError(t, err, "ApproveERC20 should not return an error")
+	approveTx, err := randomWallet.ApproveToken(nil, allowanceParams[0].Token, allowanceParams[0].Allowance, bridgeContracts.L1SharedBridge)
+	assert.NoError(t, err, "ApproveToken should not return an error")
 
 	_, err = bind.WaitMined(context.Background(), ethClient, approveTx)
 	assert.NoError(t, err, "bind.WaitMined should not return an error")
@@ -2326,8 +2326,8 @@ func TestIntegration_NonEthBasedChain_Wallet_EstimateGasRequestExecute(t *testin
 	bridgeContracts, err := client.BridgeContracts(context.Background())
 	assert.NoError(t, err, "BridgeContracts should not return an error")
 
-	approveTx, err := wallet.ApproveERC20(nil, allowanceParams.Token, allowanceParams.Allowance, bridgeContracts.L1SharedBridge)
-	assert.NoError(t, err, "ApproveERC20 should not return an error")
+	approveTx, err := wallet.ApproveToken(nil, allowanceParams.Token, allowanceParams.Allowance, bridgeContracts.L1SharedBridge)
+	assert.NoError(t, err, "ApproveToken should not return an error")
 
 	_, err = bind.WaitMined(context.Background(), ethClient, approveTx)
 	assert.NoError(t, err, "bind.WaitMined should not return an error")
@@ -2372,8 +2372,8 @@ func TestIntegration_NonEthBasedChain_Wallet_RequestExecute(t *testing.T) {
 	bridgeContracts, err := client.BridgeContracts(context.Background())
 	assert.NoError(t, err, "BridgeContracts should not return an error")
 
-	approveTx, err := wallet.ApproveERC20(nil, allowanceParams.Token, allowanceParams.Allowance, bridgeContracts.L1SharedBridge)
-	assert.NoError(t, err, "ApproveERC20 should not return an error")
+	approveTx, err := wallet.ApproveToken(nil, allowanceParams.Token, allowanceParams.Allowance, bridgeContracts.L1SharedBridge)
+	assert.NoError(t, err, "ApproveToken should not return an error")
 
 	_, err = bind.WaitMined(context.Background(), ethClient, approveTx)
 	assert.NoError(t, err, "bind.WaitMined should not return an error")

--- a/test/wallet_test.go
+++ b/test/wallet_test.go
@@ -1435,7 +1435,7 @@ func TestIntegrationWallet_DeployAccount(t *testing.T) {
 //		To:               wallet.Address1(),
 //		Amount:           big.NewInt(5),
 //		ApproveToken:     true,
-//		ApproveBaseERC20: true,
+//		ApproveBaseToken: true,
 //		L2GasLimit:       big.NewInt(255_000), // make it fail because of low gas
 //	})
 //
@@ -1460,8 +1460,8 @@ func TestIntegration_Wallet_ClaimFailedDepositSuccessfulDeposit(t *testing.T) {
 		To:               wallet.Address(),
 		Token:            L1Dai,
 		Amount:           big.NewInt(5),
-		ApproveERC20:     true,
-		ApproveBaseERC20: true,
+		ApproveToken:     true,
+		ApproveBaseToken: true,
 		RefundRecipient:  wallet.Address(),
 	})
 	assert.NoError(t, err, "Deposit should not return an error")
@@ -1605,7 +1605,7 @@ func TestIntegration_EthBasedChain_Wallet_DepositToken(t *testing.T) {
 		To:              wallet.Address(),
 		Token:           L1Dai,
 		Amount:          amount,
-		ApproveERC20:    true,
+		ApproveToken:    true,
 		RefundRecipient: wallet.Address(),
 	})
 	assert.NoError(t, err, "Deposit should not return an error")
@@ -1947,7 +1947,7 @@ func TestIntegration_NonEthBasedChain_Wallet_DepositEth(t *testing.T) {
 		To:               wallet.Address(),
 		Token:            utils.LegacyEthAddress,
 		Amount:           amount,
-		ApproveBaseERC20: true,
+		ApproveBaseToken: true,
 		RefundRecipient:  wallet.Address(),
 	})
 	assert.NoError(t, err, "Deposit should not return an error")
@@ -1999,7 +1999,7 @@ func TestIntegration_NonEthBasedChain_Wallet_DepositBaseToken(t *testing.T) {
 		To:               wallet.Address(),
 		Token:            baseToken,
 		Amount:           amount,
-		ApproveBaseERC20: true,
+		ApproveBaseToken: true,
 		RefundRecipient:  wallet.Address(),
 	})
 	assert.NoError(t, err, "Deposit should not return an error")
@@ -2048,8 +2048,8 @@ func TestIntegration_NonEthBasedChain_Wallet_DepositNonBaseToken(t *testing.T) {
 		To:               wallet.Address(),
 		Token:            L1Dai,
 		Amount:           amount,
-		ApproveERC20:     true,
-		ApproveBaseERC20: true,
+		ApproveToken:     true,
+		ApproveBaseToken: true,
 		RefundRecipient:  wallet.Address(),
 	})
 	assert.NoError(t, err, "Deposit should not return an error")


### PR DESCRIPTION
# What :computer: 
* Rename `WalletL1.ApproveERC20` to `WalletL1.ApproveToken`.
* Rename fields in `DepositTransaction`:  `ApproveERC20` to `ApproveToken`, `ApproveBaseERC20` to `ApproveBaseToken`.