### PR TITLE
ZkSync SSO smart contracts wrapper generator and wrapper itself

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ fetch-contracts:
 generate-contracts:
 	cd scripts/generate-contracts && ./execute.sh && cd ../..
 
+generate-contracts-zksso:
+	cd scripts/zksync-sso && ./execute.sh && cd ../..
+
 run-tests-on-eth-based-chain:
 	go test -v -skip='^.*_NonEthBasedChain_.*$\' ./test  ./accounts ./utils ./types
 

--- a/contracts/zksyncsso/aafactory/aafactory.go
+++ b/contracts/zksyncsso/aafactory/aafactory.go
@@ -1,0 +1,554 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package aafactory
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// AAFactoryMetaData contains all meta data concerning the AAFactory contract.
+var AAFactoryMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"_beaconProxyBytecodeHash\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"_beacon\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_passKeyModule\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_sessionKeyModule\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"ACCOUNT_ALREADY_EXISTS\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"EMPTY_BEACON_ADDRESS\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"EMPTY_BEACON_BYTECODE_HASH\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"EMPTY_PASSKEY_ADDRESS\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"EMPTY_SESSIONKEY_ADDRESS\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"INVALID_ACCOUNT_KEYS\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"accountAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"uniqueAccountId\",\"type\":\"bytes32\"}],\"name\":\"AccountCreated\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"accountId\",\"type\":\"bytes32\"}],\"name\":\"accountMappings\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"deployedAccount\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"beacon\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"beaconProxyBytecodeHash\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"uniqueId\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"passKey\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"sessionKey\",\"type\":\"bytes\"},{\"internalType\":\"address[]\",\"name\":\"ownerKeys\",\"type\":\"address[]\"}],\"name\":\"deployModularAccount\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"accountAddress\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"uniqueId\",\"type\":\"bytes32\"},{\"internalType\":\"bytes[]\",\"name\":\"initialValidators\",\"type\":\"bytes[]\"},{\"internalType\":\"address[]\",\"name\":\"initialK1Owners\",\"type\":\"address[]\"}],\"name\":\"deployProxySsoAccount\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"accountAddress\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getEncodedBeacon\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"passKeyModule\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"sessionKeyModule\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+}
+
+// AAFactoryABI is the input ABI used to generate the binding from.
+// Deprecated: Use AAFactoryMetaData.ABI instead.
+var AAFactoryABI = AAFactoryMetaData.ABI
+
+// AAFactory is an auto generated Go binding around an Ethereum contract.
+type AAFactory struct {
+	AAFactoryCaller     // Read-only binding to the contract
+	AAFactoryTransactor // Write-only binding to the contract
+	AAFactoryFilterer   // Log filterer for contract events
+}
+
+// AAFactoryCaller is an auto generated read-only Go binding around an Ethereum contract.
+type AAFactoryCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// AAFactoryTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type AAFactoryTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// AAFactoryFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type AAFactoryFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// AAFactorySession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type AAFactorySession struct {
+	Contract     *AAFactory        // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// AAFactoryCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type AAFactoryCallerSession struct {
+	Contract *AAFactoryCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts    // Call options to use throughout this session
+}
+
+// AAFactoryTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type AAFactoryTransactorSession struct {
+	Contract     *AAFactoryTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts    // Transaction auth options to use throughout this session
+}
+
+// AAFactoryRaw is an auto generated low-level Go binding around an Ethereum contract.
+type AAFactoryRaw struct {
+	Contract *AAFactory // Generic contract binding to access the raw methods on
+}
+
+// AAFactoryCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type AAFactoryCallerRaw struct {
+	Contract *AAFactoryCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// AAFactoryTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type AAFactoryTransactorRaw struct {
+	Contract *AAFactoryTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewAAFactory creates a new instance of AAFactory, bound to a specific deployed contract.
+func NewAAFactory(address common.Address, backend bind.ContractBackend) (*AAFactory, error) {
+	contract, err := bindAAFactory(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &AAFactory{AAFactoryCaller: AAFactoryCaller{contract: contract}, AAFactoryTransactor: AAFactoryTransactor{contract: contract}, AAFactoryFilterer: AAFactoryFilterer{contract: contract}}, nil
+}
+
+// NewAAFactoryCaller creates a new read-only instance of AAFactory, bound to a specific deployed contract.
+func NewAAFactoryCaller(address common.Address, caller bind.ContractCaller) (*AAFactoryCaller, error) {
+	contract, err := bindAAFactory(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &AAFactoryCaller{contract: contract}, nil
+}
+
+// NewAAFactoryTransactor creates a new write-only instance of AAFactory, bound to a specific deployed contract.
+func NewAAFactoryTransactor(address common.Address, transactor bind.ContractTransactor) (*AAFactoryTransactor, error) {
+	contract, err := bindAAFactory(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &AAFactoryTransactor{contract: contract}, nil
+}
+
+// NewAAFactoryFilterer creates a new log filterer instance of AAFactory, bound to a specific deployed contract.
+func NewAAFactoryFilterer(address common.Address, filterer bind.ContractFilterer) (*AAFactoryFilterer, error) {
+	contract, err := bindAAFactory(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &AAFactoryFilterer{contract: contract}, nil
+}
+
+// bindAAFactory binds a generic wrapper to an already deployed contract.
+func bindAAFactory(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := AAFactoryMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_AAFactory *AAFactoryRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _AAFactory.Contract.AAFactoryCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_AAFactory *AAFactoryRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _AAFactory.Contract.AAFactoryTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_AAFactory *AAFactoryRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _AAFactory.Contract.AAFactoryTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_AAFactory *AAFactoryCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _AAFactory.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_AAFactory *AAFactoryTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _AAFactory.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_AAFactory *AAFactoryTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _AAFactory.Contract.contract.Transact(opts, method, params...)
+}
+
+// AccountMappings is a free data retrieval call binding the contract method 0x08614c35.
+//
+// Solidity: function accountMappings(bytes32 accountId) view returns(address deployedAccount)
+func (_AAFactory *AAFactoryCaller) AccountMappings(opts *bind.CallOpts, accountId [32]byte) (common.Address, error) {
+	var out []interface{}
+	err := _AAFactory.contract.Call(opts, &out, "accountMappings", accountId)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// AccountMappings is a free data retrieval call binding the contract method 0x08614c35.
+//
+// Solidity: function accountMappings(bytes32 accountId) view returns(address deployedAccount)
+func (_AAFactory *AAFactorySession) AccountMappings(accountId [32]byte) (common.Address, error) {
+	return _AAFactory.Contract.AccountMappings(&_AAFactory.CallOpts, accountId)
+}
+
+// AccountMappings is a free data retrieval call binding the contract method 0x08614c35.
+//
+// Solidity: function accountMappings(bytes32 accountId) view returns(address deployedAccount)
+func (_AAFactory *AAFactoryCallerSession) AccountMappings(accountId [32]byte) (common.Address, error) {
+	return _AAFactory.Contract.AccountMappings(&_AAFactory.CallOpts, accountId)
+}
+
+// Beacon is a free data retrieval call binding the contract method 0x59659e90.
+//
+// Solidity: function beacon() view returns(address)
+func (_AAFactory *AAFactoryCaller) Beacon(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _AAFactory.contract.Call(opts, &out, "beacon")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Beacon is a free data retrieval call binding the contract method 0x59659e90.
+//
+// Solidity: function beacon() view returns(address)
+func (_AAFactory *AAFactorySession) Beacon() (common.Address, error) {
+	return _AAFactory.Contract.Beacon(&_AAFactory.CallOpts)
+}
+
+// Beacon is a free data retrieval call binding the contract method 0x59659e90.
+//
+// Solidity: function beacon() view returns(address)
+func (_AAFactory *AAFactoryCallerSession) Beacon() (common.Address, error) {
+	return _AAFactory.Contract.Beacon(&_AAFactory.CallOpts)
+}
+
+// BeaconProxyBytecodeHash is a free data retrieval call binding the contract method 0xc23f8a8d.
+//
+// Solidity: function beaconProxyBytecodeHash() view returns(bytes32)
+func (_AAFactory *AAFactoryCaller) BeaconProxyBytecodeHash(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _AAFactory.contract.Call(opts, &out, "beaconProxyBytecodeHash")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// BeaconProxyBytecodeHash is a free data retrieval call binding the contract method 0xc23f8a8d.
+//
+// Solidity: function beaconProxyBytecodeHash() view returns(bytes32)
+func (_AAFactory *AAFactorySession) BeaconProxyBytecodeHash() ([32]byte, error) {
+	return _AAFactory.Contract.BeaconProxyBytecodeHash(&_AAFactory.CallOpts)
+}
+
+// BeaconProxyBytecodeHash is a free data retrieval call binding the contract method 0xc23f8a8d.
+//
+// Solidity: function beaconProxyBytecodeHash() view returns(bytes32)
+func (_AAFactory *AAFactoryCallerSession) BeaconProxyBytecodeHash() ([32]byte, error) {
+	return _AAFactory.Contract.BeaconProxyBytecodeHash(&_AAFactory.CallOpts)
+}
+
+// GetEncodedBeacon is a free data retrieval call binding the contract method 0xf9958a10.
+//
+// Solidity: function getEncodedBeacon() view returns(bytes)
+func (_AAFactory *AAFactoryCaller) GetEncodedBeacon(opts *bind.CallOpts) ([]byte, error) {
+	var out []interface{}
+	err := _AAFactory.contract.Call(opts, &out, "getEncodedBeacon")
+
+	if err != nil {
+		return *new([]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]byte)).(*[]byte)
+
+	return out0, err
+
+}
+
+// GetEncodedBeacon is a free data retrieval call binding the contract method 0xf9958a10.
+//
+// Solidity: function getEncodedBeacon() view returns(bytes)
+func (_AAFactory *AAFactorySession) GetEncodedBeacon() ([]byte, error) {
+	return _AAFactory.Contract.GetEncodedBeacon(&_AAFactory.CallOpts)
+}
+
+// GetEncodedBeacon is a free data retrieval call binding the contract method 0xf9958a10.
+//
+// Solidity: function getEncodedBeacon() view returns(bytes)
+func (_AAFactory *AAFactoryCallerSession) GetEncodedBeacon() ([]byte, error) {
+	return _AAFactory.Contract.GetEncodedBeacon(&_AAFactory.CallOpts)
+}
+
+// PassKeyModule is a free data retrieval call binding the contract method 0x8c9682d8.
+//
+// Solidity: function passKeyModule() view returns(address)
+func (_AAFactory *AAFactoryCaller) PassKeyModule(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _AAFactory.contract.Call(opts, &out, "passKeyModule")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PassKeyModule is a free data retrieval call binding the contract method 0x8c9682d8.
+//
+// Solidity: function passKeyModule() view returns(address)
+func (_AAFactory *AAFactorySession) PassKeyModule() (common.Address, error) {
+	return _AAFactory.Contract.PassKeyModule(&_AAFactory.CallOpts)
+}
+
+// PassKeyModule is a free data retrieval call binding the contract method 0x8c9682d8.
+//
+// Solidity: function passKeyModule() view returns(address)
+func (_AAFactory *AAFactoryCallerSession) PassKeyModule() (common.Address, error) {
+	return _AAFactory.Contract.PassKeyModule(&_AAFactory.CallOpts)
+}
+
+// SessionKeyModule is a free data retrieval call binding the contract method 0xf31b26fc.
+//
+// Solidity: function sessionKeyModule() view returns(address)
+func (_AAFactory *AAFactoryCaller) SessionKeyModule(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _AAFactory.contract.Call(opts, &out, "sessionKeyModule")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// SessionKeyModule is a free data retrieval call binding the contract method 0xf31b26fc.
+//
+// Solidity: function sessionKeyModule() view returns(address)
+func (_AAFactory *AAFactorySession) SessionKeyModule() (common.Address, error) {
+	return _AAFactory.Contract.SessionKeyModule(&_AAFactory.CallOpts)
+}
+
+// SessionKeyModule is a free data retrieval call binding the contract method 0xf31b26fc.
+//
+// Solidity: function sessionKeyModule() view returns(address)
+func (_AAFactory *AAFactoryCallerSession) SessionKeyModule() (common.Address, error) {
+	return _AAFactory.Contract.SessionKeyModule(&_AAFactory.CallOpts)
+}
+
+// DeployModularAccount is a paid mutator transaction binding the contract method 0x54385730.
+//
+// Solidity: function deployModularAccount(bytes32 uniqueId, bytes passKey, bytes sessionKey, address[] ownerKeys) returns(address accountAddress)
+func (_AAFactory *AAFactoryTransactor) DeployModularAccount(opts *bind.TransactOpts, uniqueId [32]byte, passKey []byte, sessionKey []byte, ownerKeys []common.Address) (*types.Transaction, error) {
+	return _AAFactory.contract.Transact(opts, "deployModularAccount", uniqueId, passKey, sessionKey, ownerKeys)
+}
+
+// DeployModularAccount is a paid mutator transaction binding the contract method 0x54385730.
+//
+// Solidity: function deployModularAccount(bytes32 uniqueId, bytes passKey, bytes sessionKey, address[] ownerKeys) returns(address accountAddress)
+func (_AAFactory *AAFactorySession) DeployModularAccount(uniqueId [32]byte, passKey []byte, sessionKey []byte, ownerKeys []common.Address) (*types.Transaction, error) {
+	return _AAFactory.Contract.DeployModularAccount(&_AAFactory.TransactOpts, uniqueId, passKey, sessionKey, ownerKeys)
+}
+
+// DeployModularAccount is a paid mutator transaction binding the contract method 0x54385730.
+//
+// Solidity: function deployModularAccount(bytes32 uniqueId, bytes passKey, bytes sessionKey, address[] ownerKeys) returns(address accountAddress)
+func (_AAFactory *AAFactoryTransactorSession) DeployModularAccount(uniqueId [32]byte, passKey []byte, sessionKey []byte, ownerKeys []common.Address) (*types.Transaction, error) {
+	return _AAFactory.Contract.DeployModularAccount(&_AAFactory.TransactOpts, uniqueId, passKey, sessionKey, ownerKeys)
+}
+
+// DeployProxySsoAccount is a paid mutator transaction binding the contract method 0x0b8a4ed4.
+//
+// Solidity: function deployProxySsoAccount(bytes32 uniqueId, bytes[] initialValidators, address[] initialK1Owners) returns(address accountAddress)
+func (_AAFactory *AAFactoryTransactor) DeployProxySsoAccount(opts *bind.TransactOpts, uniqueId [32]byte, initialValidators [][]byte, initialK1Owners []common.Address) (*types.Transaction, error) {
+	return _AAFactory.contract.Transact(opts, "deployProxySsoAccount", uniqueId, initialValidators, initialK1Owners)
+}
+
+// DeployProxySsoAccount is a paid mutator transaction binding the contract method 0x0b8a4ed4.
+//
+// Solidity: function deployProxySsoAccount(bytes32 uniqueId, bytes[] initialValidators, address[] initialK1Owners) returns(address accountAddress)
+func (_AAFactory *AAFactorySession) DeployProxySsoAccount(uniqueId [32]byte, initialValidators [][]byte, initialK1Owners []common.Address) (*types.Transaction, error) {
+	return _AAFactory.Contract.DeployProxySsoAccount(&_AAFactory.TransactOpts, uniqueId, initialValidators, initialK1Owners)
+}
+
+// DeployProxySsoAccount is a paid mutator transaction binding the contract method 0x0b8a4ed4.
+//
+// Solidity: function deployProxySsoAccount(bytes32 uniqueId, bytes[] initialValidators, address[] initialK1Owners) returns(address accountAddress)
+func (_AAFactory *AAFactoryTransactorSession) DeployProxySsoAccount(uniqueId [32]byte, initialValidators [][]byte, initialK1Owners []common.Address) (*types.Transaction, error) {
+	return _AAFactory.Contract.DeployProxySsoAccount(&_AAFactory.TransactOpts, uniqueId, initialValidators, initialK1Owners)
+}
+
+// AAFactoryAccountCreatedIterator is returned from FilterAccountCreated and is used to iterate over the raw logs and unpacked data for AccountCreated events raised by the AAFactory contract.
+type AAFactoryAccountCreatedIterator struct {
+	Event *AAFactoryAccountCreated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *AAFactoryAccountCreatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(AAFactoryAccountCreated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(AAFactoryAccountCreated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *AAFactoryAccountCreatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *AAFactoryAccountCreatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// AAFactoryAccountCreated represents a AccountCreated event raised by the AAFactory contract.
+type AAFactoryAccountCreated struct {
+	AccountAddress  common.Address
+	UniqueAccountId [32]byte
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterAccountCreated is a free log retrieval operation binding the contract event 0x8fe66a5d954d6d3e0306797e31e226812a9916895165c96c367ef52807631951.
+//
+// Solidity: event AccountCreated(address indexed accountAddress, bytes32 uniqueAccountId)
+func (_AAFactory *AAFactoryFilterer) FilterAccountCreated(opts *bind.FilterOpts, accountAddress []common.Address) (*AAFactoryAccountCreatedIterator, error) {
+
+	var accountAddressRule []interface{}
+	for _, accountAddressItem := range accountAddress {
+		accountAddressRule = append(accountAddressRule, accountAddressItem)
+	}
+
+	logs, sub, err := _AAFactory.contract.FilterLogs(opts, "AccountCreated", accountAddressRule)
+	if err != nil {
+		return nil, err
+	}
+	return &AAFactoryAccountCreatedIterator{contract: _AAFactory.contract, event: "AccountCreated", logs: logs, sub: sub}, nil
+}
+
+// WatchAccountCreated is a free log subscription operation binding the contract event 0x8fe66a5d954d6d3e0306797e31e226812a9916895165c96c367ef52807631951.
+//
+// Solidity: event AccountCreated(address indexed accountAddress, bytes32 uniqueAccountId)
+func (_AAFactory *AAFactoryFilterer) WatchAccountCreated(opts *bind.WatchOpts, sink chan<- *AAFactoryAccountCreated, accountAddress []common.Address) (event.Subscription, error) {
+
+	var accountAddressRule []interface{}
+	for _, accountAddressItem := range accountAddress {
+		accountAddressRule = append(accountAddressRule, accountAddressItem)
+	}
+
+	logs, sub, err := _AAFactory.contract.WatchLogs(opts, "AccountCreated", accountAddressRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(AAFactoryAccountCreated)
+				if err := _AAFactory.contract.UnpackLog(event, "AccountCreated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseAccountCreated is a log parse operation binding the contract event 0x8fe66a5d954d6d3e0306797e31e226812a9916895165c96c367ef52807631951.
+//
+// Solidity: event AccountCreated(address indexed accountAddress, bytes32 uniqueAccountId)
+func (_AAFactory *AAFactoryFilterer) ParseAccountCreated(log types.Log) (*AAFactoryAccountCreated, error) {
+	event := new(AAFactoryAccountCreated)
+	if err := _AAFactory.contract.UnpackLog(event, "AccountCreated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts/zksyncsso/accountproxy/accountproxy.go
+++ b/contracts/zksyncsso/accountproxy/accountproxy.go
@@ -1,0 +1,646 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package accountproxy
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// AccountProxyMetaData contains all meta data concerning the AccountProxy contract.
+var AccountProxyMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"beacon\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"previousAdmin\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"newAdmin\",\"type\":\"address\"}],\"name\":\"AdminChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"beacon\",\"type\":\"address\"}],\"name\":\"BeaconUpgraded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"implementation\",\"type\":\"address\"}],\"name\":\"Upgraded\",\"type\":\"event\"},{\"stateMutability\":\"payable\",\"type\":\"fallback\"},{\"stateMutability\":\"payable\",\"type\":\"receive\"}]",
+}
+
+// AccountProxyABI is the input ABI used to generate the binding from.
+// Deprecated: Use AccountProxyMetaData.ABI instead.
+var AccountProxyABI = AccountProxyMetaData.ABI
+
+// AccountProxy is an auto generated Go binding around an Ethereum contract.
+type AccountProxy struct {
+	AccountProxyCaller     // Read-only binding to the contract
+	AccountProxyTransactor // Write-only binding to the contract
+	AccountProxyFilterer   // Log filterer for contract events
+}
+
+// AccountProxyCaller is an auto generated read-only Go binding around an Ethereum contract.
+type AccountProxyCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// AccountProxyTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type AccountProxyTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// AccountProxyFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type AccountProxyFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// AccountProxySession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type AccountProxySession struct {
+	Contract     *AccountProxy     // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// AccountProxyCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type AccountProxyCallerSession struct {
+	Contract *AccountProxyCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts       // Call options to use throughout this session
+}
+
+// AccountProxyTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type AccountProxyTransactorSession struct {
+	Contract     *AccountProxyTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts       // Transaction auth options to use throughout this session
+}
+
+// AccountProxyRaw is an auto generated low-level Go binding around an Ethereum contract.
+type AccountProxyRaw struct {
+	Contract *AccountProxy // Generic contract binding to access the raw methods on
+}
+
+// AccountProxyCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type AccountProxyCallerRaw struct {
+	Contract *AccountProxyCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// AccountProxyTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type AccountProxyTransactorRaw struct {
+	Contract *AccountProxyTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewAccountProxy creates a new instance of AccountProxy, bound to a specific deployed contract.
+func NewAccountProxy(address common.Address, backend bind.ContractBackend) (*AccountProxy, error) {
+	contract, err := bindAccountProxy(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &AccountProxy{AccountProxyCaller: AccountProxyCaller{contract: contract}, AccountProxyTransactor: AccountProxyTransactor{contract: contract}, AccountProxyFilterer: AccountProxyFilterer{contract: contract}}, nil
+}
+
+// NewAccountProxyCaller creates a new read-only instance of AccountProxy, bound to a specific deployed contract.
+func NewAccountProxyCaller(address common.Address, caller bind.ContractCaller) (*AccountProxyCaller, error) {
+	contract, err := bindAccountProxy(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &AccountProxyCaller{contract: contract}, nil
+}
+
+// NewAccountProxyTransactor creates a new write-only instance of AccountProxy, bound to a specific deployed contract.
+func NewAccountProxyTransactor(address common.Address, transactor bind.ContractTransactor) (*AccountProxyTransactor, error) {
+	contract, err := bindAccountProxy(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &AccountProxyTransactor{contract: contract}, nil
+}
+
+// NewAccountProxyFilterer creates a new log filterer instance of AccountProxy, bound to a specific deployed contract.
+func NewAccountProxyFilterer(address common.Address, filterer bind.ContractFilterer) (*AccountProxyFilterer, error) {
+	contract, err := bindAccountProxy(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &AccountProxyFilterer{contract: contract}, nil
+}
+
+// bindAccountProxy binds a generic wrapper to an already deployed contract.
+func bindAccountProxy(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := AccountProxyMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_AccountProxy *AccountProxyRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _AccountProxy.Contract.AccountProxyCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_AccountProxy *AccountProxyRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _AccountProxy.Contract.AccountProxyTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_AccountProxy *AccountProxyRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _AccountProxy.Contract.AccountProxyTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_AccountProxy *AccountProxyCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _AccountProxy.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_AccountProxy *AccountProxyTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _AccountProxy.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_AccountProxy *AccountProxyTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _AccountProxy.Contract.contract.Transact(opts, method, params...)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() payable returns()
+func (_AccountProxy *AccountProxyTransactor) Fallback(opts *bind.TransactOpts, calldata []byte) (*types.Transaction, error) {
+	return _AccountProxy.contract.RawTransact(opts, calldata)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() payable returns()
+func (_AccountProxy *AccountProxySession) Fallback(calldata []byte) (*types.Transaction, error) {
+	return _AccountProxy.Contract.Fallback(&_AccountProxy.TransactOpts, calldata)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() payable returns()
+func (_AccountProxy *AccountProxyTransactorSession) Fallback(calldata []byte) (*types.Transaction, error) {
+	return _AccountProxy.Contract.Fallback(&_AccountProxy.TransactOpts, calldata)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_AccountProxy *AccountProxyTransactor) Receive(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _AccountProxy.contract.RawTransact(opts, nil) // calldata is disallowed for receive function
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_AccountProxy *AccountProxySession) Receive() (*types.Transaction, error) {
+	return _AccountProxy.Contract.Receive(&_AccountProxy.TransactOpts)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_AccountProxy *AccountProxyTransactorSession) Receive() (*types.Transaction, error) {
+	return _AccountProxy.Contract.Receive(&_AccountProxy.TransactOpts)
+}
+
+// AccountProxyAdminChangedIterator is returned from FilterAdminChanged and is used to iterate over the raw logs and unpacked data for AdminChanged events raised by the AccountProxy contract.
+type AccountProxyAdminChangedIterator struct {
+	Event *AccountProxyAdminChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *AccountProxyAdminChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(AccountProxyAdminChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(AccountProxyAdminChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *AccountProxyAdminChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *AccountProxyAdminChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// AccountProxyAdminChanged represents a AdminChanged event raised by the AccountProxy contract.
+type AccountProxyAdminChanged struct {
+	PreviousAdmin common.Address
+	NewAdmin      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterAdminChanged is a free log retrieval operation binding the contract event 0x7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f.
+//
+// Solidity: event AdminChanged(address previousAdmin, address newAdmin)
+func (_AccountProxy *AccountProxyFilterer) FilterAdminChanged(opts *bind.FilterOpts) (*AccountProxyAdminChangedIterator, error) {
+
+	logs, sub, err := _AccountProxy.contract.FilterLogs(opts, "AdminChanged")
+	if err != nil {
+		return nil, err
+	}
+	return &AccountProxyAdminChangedIterator{contract: _AccountProxy.contract, event: "AdminChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchAdminChanged is a free log subscription operation binding the contract event 0x7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f.
+//
+// Solidity: event AdminChanged(address previousAdmin, address newAdmin)
+func (_AccountProxy *AccountProxyFilterer) WatchAdminChanged(opts *bind.WatchOpts, sink chan<- *AccountProxyAdminChanged) (event.Subscription, error) {
+
+	logs, sub, err := _AccountProxy.contract.WatchLogs(opts, "AdminChanged")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(AccountProxyAdminChanged)
+				if err := _AccountProxy.contract.UnpackLog(event, "AdminChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseAdminChanged is a log parse operation binding the contract event 0x7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f.
+//
+// Solidity: event AdminChanged(address previousAdmin, address newAdmin)
+func (_AccountProxy *AccountProxyFilterer) ParseAdminChanged(log types.Log) (*AccountProxyAdminChanged, error) {
+	event := new(AccountProxyAdminChanged)
+	if err := _AccountProxy.contract.UnpackLog(event, "AdminChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// AccountProxyBeaconUpgradedIterator is returned from FilterBeaconUpgraded and is used to iterate over the raw logs and unpacked data for BeaconUpgraded events raised by the AccountProxy contract.
+type AccountProxyBeaconUpgradedIterator struct {
+	Event *AccountProxyBeaconUpgraded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *AccountProxyBeaconUpgradedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(AccountProxyBeaconUpgraded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(AccountProxyBeaconUpgraded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *AccountProxyBeaconUpgradedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *AccountProxyBeaconUpgradedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// AccountProxyBeaconUpgraded represents a BeaconUpgraded event raised by the AccountProxy contract.
+type AccountProxyBeaconUpgraded struct {
+	Beacon common.Address
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterBeaconUpgraded is a free log retrieval operation binding the contract event 0x1cf3b03a6cf19fa2baba4df148e9dcabedea7f8a5c07840e207e5c089be95d3e.
+//
+// Solidity: event BeaconUpgraded(address indexed beacon)
+func (_AccountProxy *AccountProxyFilterer) FilterBeaconUpgraded(opts *bind.FilterOpts, beacon []common.Address) (*AccountProxyBeaconUpgradedIterator, error) {
+
+	var beaconRule []interface{}
+	for _, beaconItem := range beacon {
+		beaconRule = append(beaconRule, beaconItem)
+	}
+
+	logs, sub, err := _AccountProxy.contract.FilterLogs(opts, "BeaconUpgraded", beaconRule)
+	if err != nil {
+		return nil, err
+	}
+	return &AccountProxyBeaconUpgradedIterator{contract: _AccountProxy.contract, event: "BeaconUpgraded", logs: logs, sub: sub}, nil
+}
+
+// WatchBeaconUpgraded is a free log subscription operation binding the contract event 0x1cf3b03a6cf19fa2baba4df148e9dcabedea7f8a5c07840e207e5c089be95d3e.
+//
+// Solidity: event BeaconUpgraded(address indexed beacon)
+func (_AccountProxy *AccountProxyFilterer) WatchBeaconUpgraded(opts *bind.WatchOpts, sink chan<- *AccountProxyBeaconUpgraded, beacon []common.Address) (event.Subscription, error) {
+
+	var beaconRule []interface{}
+	for _, beaconItem := range beacon {
+		beaconRule = append(beaconRule, beaconItem)
+	}
+
+	logs, sub, err := _AccountProxy.contract.WatchLogs(opts, "BeaconUpgraded", beaconRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(AccountProxyBeaconUpgraded)
+				if err := _AccountProxy.contract.UnpackLog(event, "BeaconUpgraded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBeaconUpgraded is a log parse operation binding the contract event 0x1cf3b03a6cf19fa2baba4df148e9dcabedea7f8a5c07840e207e5c089be95d3e.
+//
+// Solidity: event BeaconUpgraded(address indexed beacon)
+func (_AccountProxy *AccountProxyFilterer) ParseBeaconUpgraded(log types.Log) (*AccountProxyBeaconUpgraded, error) {
+	event := new(AccountProxyBeaconUpgraded)
+	if err := _AccountProxy.contract.UnpackLog(event, "BeaconUpgraded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// AccountProxyUpgradedIterator is returned from FilterUpgraded and is used to iterate over the raw logs and unpacked data for Upgraded events raised by the AccountProxy contract.
+type AccountProxyUpgradedIterator struct {
+	Event *AccountProxyUpgraded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *AccountProxyUpgradedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(AccountProxyUpgraded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(AccountProxyUpgraded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *AccountProxyUpgradedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *AccountProxyUpgradedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// AccountProxyUpgraded represents a Upgraded event raised by the AccountProxy contract.
+type AccountProxyUpgraded struct {
+	Implementation common.Address
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterUpgraded is a free log retrieval operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_AccountProxy *AccountProxyFilterer) FilterUpgraded(opts *bind.FilterOpts, implementation []common.Address) (*AccountProxyUpgradedIterator, error) {
+
+	var implementationRule []interface{}
+	for _, implementationItem := range implementation {
+		implementationRule = append(implementationRule, implementationItem)
+	}
+
+	logs, sub, err := _AccountProxy.contract.FilterLogs(opts, "Upgraded", implementationRule)
+	if err != nil {
+		return nil, err
+	}
+	return &AccountProxyUpgradedIterator{contract: _AccountProxy.contract, event: "Upgraded", logs: logs, sub: sub}, nil
+}
+
+// WatchUpgraded is a free log subscription operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_AccountProxy *AccountProxyFilterer) WatchUpgraded(opts *bind.WatchOpts, sink chan<- *AccountProxyUpgraded, implementation []common.Address) (event.Subscription, error) {
+
+	var implementationRule []interface{}
+	for _, implementationItem := range implementation {
+		implementationRule = append(implementationRule, implementationItem)
+	}
+
+	logs, sub, err := _AccountProxy.contract.WatchLogs(opts, "Upgraded", implementationRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(AccountProxyUpgraded)
+				if err := _AccountProxy.contract.UnpackLog(event, "Upgraded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUpgraded is a log parse operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_AccountProxy *AccountProxyFilterer) ParseUpgraded(log types.Log) (*AccountProxyUpgraded, error) {
+	event := new(AccountProxyUpgraded)
+	if err := _AccountProxy.contract.UnpackLog(event, "Upgraded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts/zksyncsso/auth/bootloaderauth/bootloaderauth.go
+++ b/contracts/zksyncsso/auth/bootloaderauth/bootloaderauth.go
@@ -1,0 +1,181 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package bootloaderauth
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// BootloaderAuthMetaData contains all meta data concerning the BootloaderAuth contract.
+var BootloaderAuthMetaData = &bind.MetaData{
+	ABI: "[]",
+}
+
+// BootloaderAuthABI is the input ABI used to generate the binding from.
+// Deprecated: Use BootloaderAuthMetaData.ABI instead.
+var BootloaderAuthABI = BootloaderAuthMetaData.ABI
+
+// BootloaderAuth is an auto generated Go binding around an Ethereum contract.
+type BootloaderAuth struct {
+	BootloaderAuthCaller     // Read-only binding to the contract
+	BootloaderAuthTransactor // Write-only binding to the contract
+	BootloaderAuthFilterer   // Log filterer for contract events
+}
+
+// BootloaderAuthCaller is an auto generated read-only Go binding around an Ethereum contract.
+type BootloaderAuthCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BootloaderAuthTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type BootloaderAuthTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BootloaderAuthFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type BootloaderAuthFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BootloaderAuthSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type BootloaderAuthSession struct {
+	Contract     *BootloaderAuth   // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// BootloaderAuthCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type BootloaderAuthCallerSession struct {
+	Contract *BootloaderAuthCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts         // Call options to use throughout this session
+}
+
+// BootloaderAuthTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type BootloaderAuthTransactorSession struct {
+	Contract     *BootloaderAuthTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts         // Transaction auth options to use throughout this session
+}
+
+// BootloaderAuthRaw is an auto generated low-level Go binding around an Ethereum contract.
+type BootloaderAuthRaw struct {
+	Contract *BootloaderAuth // Generic contract binding to access the raw methods on
+}
+
+// BootloaderAuthCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type BootloaderAuthCallerRaw struct {
+	Contract *BootloaderAuthCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// BootloaderAuthTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type BootloaderAuthTransactorRaw struct {
+	Contract *BootloaderAuthTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewBootloaderAuth creates a new instance of BootloaderAuth, bound to a specific deployed contract.
+func NewBootloaderAuth(address common.Address, backend bind.ContractBackend) (*BootloaderAuth, error) {
+	contract, err := bindBootloaderAuth(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &BootloaderAuth{BootloaderAuthCaller: BootloaderAuthCaller{contract: contract}, BootloaderAuthTransactor: BootloaderAuthTransactor{contract: contract}, BootloaderAuthFilterer: BootloaderAuthFilterer{contract: contract}}, nil
+}
+
+// NewBootloaderAuthCaller creates a new read-only instance of BootloaderAuth, bound to a specific deployed contract.
+func NewBootloaderAuthCaller(address common.Address, caller bind.ContractCaller) (*BootloaderAuthCaller, error) {
+	contract, err := bindBootloaderAuth(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BootloaderAuthCaller{contract: contract}, nil
+}
+
+// NewBootloaderAuthTransactor creates a new write-only instance of BootloaderAuth, bound to a specific deployed contract.
+func NewBootloaderAuthTransactor(address common.Address, transactor bind.ContractTransactor) (*BootloaderAuthTransactor, error) {
+	contract, err := bindBootloaderAuth(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BootloaderAuthTransactor{contract: contract}, nil
+}
+
+// NewBootloaderAuthFilterer creates a new log filterer instance of BootloaderAuth, bound to a specific deployed contract.
+func NewBootloaderAuthFilterer(address common.Address, filterer bind.ContractFilterer) (*BootloaderAuthFilterer, error) {
+	contract, err := bindBootloaderAuth(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &BootloaderAuthFilterer{contract: contract}, nil
+}
+
+// bindBootloaderAuth binds a generic wrapper to an already deployed contract.
+func bindBootloaderAuth(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := BootloaderAuthMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_BootloaderAuth *BootloaderAuthRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BootloaderAuth.Contract.BootloaderAuthCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_BootloaderAuth *BootloaderAuthRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BootloaderAuth.Contract.BootloaderAuthTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_BootloaderAuth *BootloaderAuthRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BootloaderAuth.Contract.BootloaderAuthTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_BootloaderAuth *BootloaderAuthCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BootloaderAuth.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_BootloaderAuth *BootloaderAuthTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BootloaderAuth.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_BootloaderAuth *BootloaderAuthTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BootloaderAuth.Contract.contract.Transact(opts, method, params...)
+}

--- a/contracts/zksyncsso/auth/selfauth/selfauth.go
+++ b/contracts/zksyncsso/auth/selfauth/selfauth.go
@@ -1,0 +1,181 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package selfauth
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// SelfAuthMetaData contains all meta data concerning the SelfAuth contract.
+var SelfAuthMetaData = &bind.MetaData{
+	ABI: "[]",
+}
+
+// SelfAuthABI is the input ABI used to generate the binding from.
+// Deprecated: Use SelfAuthMetaData.ABI instead.
+var SelfAuthABI = SelfAuthMetaData.ABI
+
+// SelfAuth is an auto generated Go binding around an Ethereum contract.
+type SelfAuth struct {
+	SelfAuthCaller     // Read-only binding to the contract
+	SelfAuthTransactor // Write-only binding to the contract
+	SelfAuthFilterer   // Log filterer for contract events
+}
+
+// SelfAuthCaller is an auto generated read-only Go binding around an Ethereum contract.
+type SelfAuthCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// SelfAuthTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type SelfAuthTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// SelfAuthFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type SelfAuthFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// SelfAuthSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type SelfAuthSession struct {
+	Contract     *SelfAuth         // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// SelfAuthCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type SelfAuthCallerSession struct {
+	Contract *SelfAuthCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts   // Call options to use throughout this session
+}
+
+// SelfAuthTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type SelfAuthTransactorSession struct {
+	Contract     *SelfAuthTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts   // Transaction auth options to use throughout this session
+}
+
+// SelfAuthRaw is an auto generated low-level Go binding around an Ethereum contract.
+type SelfAuthRaw struct {
+	Contract *SelfAuth // Generic contract binding to access the raw methods on
+}
+
+// SelfAuthCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type SelfAuthCallerRaw struct {
+	Contract *SelfAuthCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// SelfAuthTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type SelfAuthTransactorRaw struct {
+	Contract *SelfAuthTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewSelfAuth creates a new instance of SelfAuth, bound to a specific deployed contract.
+func NewSelfAuth(address common.Address, backend bind.ContractBackend) (*SelfAuth, error) {
+	contract, err := bindSelfAuth(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &SelfAuth{SelfAuthCaller: SelfAuthCaller{contract: contract}, SelfAuthTransactor: SelfAuthTransactor{contract: contract}, SelfAuthFilterer: SelfAuthFilterer{contract: contract}}, nil
+}
+
+// NewSelfAuthCaller creates a new read-only instance of SelfAuth, bound to a specific deployed contract.
+func NewSelfAuthCaller(address common.Address, caller bind.ContractCaller) (*SelfAuthCaller, error) {
+	contract, err := bindSelfAuth(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &SelfAuthCaller{contract: contract}, nil
+}
+
+// NewSelfAuthTransactor creates a new write-only instance of SelfAuth, bound to a specific deployed contract.
+func NewSelfAuthTransactor(address common.Address, transactor bind.ContractTransactor) (*SelfAuthTransactor, error) {
+	contract, err := bindSelfAuth(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &SelfAuthTransactor{contract: contract}, nil
+}
+
+// NewSelfAuthFilterer creates a new log filterer instance of SelfAuth, bound to a specific deployed contract.
+func NewSelfAuthFilterer(address common.Address, filterer bind.ContractFilterer) (*SelfAuthFilterer, error) {
+	contract, err := bindSelfAuth(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &SelfAuthFilterer{contract: contract}, nil
+}
+
+// bindSelfAuth binds a generic wrapper to an already deployed contract.
+func bindSelfAuth(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := SelfAuthMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_SelfAuth *SelfAuthRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _SelfAuth.Contract.SelfAuthCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_SelfAuth *SelfAuthRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _SelfAuth.Contract.SelfAuthTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_SelfAuth *SelfAuthRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _SelfAuth.Contract.SelfAuthTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_SelfAuth *SelfAuthCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _SelfAuth.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_SelfAuth *SelfAuthTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _SelfAuth.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_SelfAuth *SelfAuthTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _SelfAuth.Contract.contract.Transact(opts, method, params...)
+}

--- a/contracts/zksyncsso/batch/batchcaller/batchcaller.go
+++ b/contracts/zksyncsso/batch/batchcaller/batchcaller.go
@@ -1,0 +1,355 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package batchcaller
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// Call is an auto generated low-level Go binding around an user-defined struct.
+type Call struct {
+	Target       common.Address
+	AllowFailure bool
+	Value        *big.Int
+	CallData     []byte
+}
+
+// BatchCallerMetaData contains all meta data concerning the BatchCaller contract.
+var BatchCallerMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"actualValue\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expectedValue\",\"type\":\"uint256\"}],\"name\":\"BATCH_MSG_VALUE_MISMATCH\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"notSelf\",\"type\":\"address\"}],\"name\":\"NOT_FROM_SELF\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"index\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"revertData\",\"type\":\"bytes\"}],\"name\":\"BatchCallFailure\",\"type\":\"event\"},{\"inputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"allowFailure\",\"type\":\"bool\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"callData\",\"type\":\"bytes\"}],\"internalType\":\"structCall[]\",\"name\":\"_calls\",\"type\":\"tuple[]\"}],\"name\":\"batchCall\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"}]",
+}
+
+// BatchCallerABI is the input ABI used to generate the binding from.
+// Deprecated: Use BatchCallerMetaData.ABI instead.
+var BatchCallerABI = BatchCallerMetaData.ABI
+
+// BatchCaller is an auto generated Go binding around an Ethereum contract.
+type BatchCaller struct {
+	BatchCallerCaller     // Read-only binding to the contract
+	BatchCallerTransactor // Write-only binding to the contract
+	BatchCallerFilterer   // Log filterer for contract events
+}
+
+// BatchCallerCaller is an auto generated read-only Go binding around an Ethereum contract.
+type BatchCallerCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BatchCallerTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type BatchCallerTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BatchCallerFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type BatchCallerFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BatchCallerSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type BatchCallerSession struct {
+	Contract     *BatchCaller      // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// BatchCallerCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type BatchCallerCallerSession struct {
+	Contract *BatchCallerCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts      // Call options to use throughout this session
+}
+
+// BatchCallerTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type BatchCallerTransactorSession struct {
+	Contract     *BatchCallerTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts      // Transaction auth options to use throughout this session
+}
+
+// BatchCallerRaw is an auto generated low-level Go binding around an Ethereum contract.
+type BatchCallerRaw struct {
+	Contract *BatchCaller // Generic contract binding to access the raw methods on
+}
+
+// BatchCallerCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type BatchCallerCallerRaw struct {
+	Contract *BatchCallerCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// BatchCallerTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type BatchCallerTransactorRaw struct {
+	Contract *BatchCallerTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewBatchCaller creates a new instance of BatchCaller, bound to a specific deployed contract.
+func NewBatchCaller(address common.Address, backend bind.ContractBackend) (*BatchCaller, error) {
+	contract, err := bindBatchCaller(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &BatchCaller{BatchCallerCaller: BatchCallerCaller{contract: contract}, BatchCallerTransactor: BatchCallerTransactor{contract: contract}, BatchCallerFilterer: BatchCallerFilterer{contract: contract}}, nil
+}
+
+// NewBatchCallerCaller creates a new read-only instance of BatchCaller, bound to a specific deployed contract.
+func NewBatchCallerCaller(address common.Address, caller bind.ContractCaller) (*BatchCallerCaller, error) {
+	contract, err := bindBatchCaller(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BatchCallerCaller{contract: contract}, nil
+}
+
+// NewBatchCallerTransactor creates a new write-only instance of BatchCaller, bound to a specific deployed contract.
+func NewBatchCallerTransactor(address common.Address, transactor bind.ContractTransactor) (*BatchCallerTransactor, error) {
+	contract, err := bindBatchCaller(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BatchCallerTransactor{contract: contract}, nil
+}
+
+// NewBatchCallerFilterer creates a new log filterer instance of BatchCaller, bound to a specific deployed contract.
+func NewBatchCallerFilterer(address common.Address, filterer bind.ContractFilterer) (*BatchCallerFilterer, error) {
+	contract, err := bindBatchCaller(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &BatchCallerFilterer{contract: contract}, nil
+}
+
+// bindBatchCaller binds a generic wrapper to an already deployed contract.
+func bindBatchCaller(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := BatchCallerMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_BatchCaller *BatchCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BatchCaller.Contract.BatchCallerCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_BatchCaller *BatchCallerRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BatchCaller.Contract.BatchCallerTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_BatchCaller *BatchCallerRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BatchCaller.Contract.BatchCallerTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_BatchCaller *BatchCallerCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BatchCaller.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_BatchCaller *BatchCallerTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BatchCaller.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_BatchCaller *BatchCallerTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BatchCaller.Contract.contract.Transact(opts, method, params...)
+}
+
+// BatchCall is a paid mutator transaction binding the contract method 0x8f0273a9.
+//
+// Solidity: function batchCall((address,bool,uint256,bytes)[] _calls) payable returns()
+func (_BatchCaller *BatchCallerTransactor) BatchCall(opts *bind.TransactOpts, _calls []Call) (*types.Transaction, error) {
+	return _BatchCaller.contract.Transact(opts, "batchCall", _calls)
+}
+
+// BatchCall is a paid mutator transaction binding the contract method 0x8f0273a9.
+//
+// Solidity: function batchCall((address,bool,uint256,bytes)[] _calls) payable returns()
+func (_BatchCaller *BatchCallerSession) BatchCall(_calls []Call) (*types.Transaction, error) {
+	return _BatchCaller.Contract.BatchCall(&_BatchCaller.TransactOpts, _calls)
+}
+
+// BatchCall is a paid mutator transaction binding the contract method 0x8f0273a9.
+//
+// Solidity: function batchCall((address,bool,uint256,bytes)[] _calls) payable returns()
+func (_BatchCaller *BatchCallerTransactorSession) BatchCall(_calls []Call) (*types.Transaction, error) {
+	return _BatchCaller.Contract.BatchCall(&_BatchCaller.TransactOpts, _calls)
+}
+
+// BatchCallerBatchCallFailureIterator is returned from FilterBatchCallFailure and is used to iterate over the raw logs and unpacked data for BatchCallFailure events raised by the BatchCaller contract.
+type BatchCallerBatchCallFailureIterator struct {
+	Event *BatchCallerBatchCallFailure // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BatchCallerBatchCallFailureIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BatchCallerBatchCallFailure)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BatchCallerBatchCallFailure)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BatchCallerBatchCallFailureIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BatchCallerBatchCallFailureIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BatchCallerBatchCallFailure represents a BatchCallFailure event raised by the BatchCaller contract.
+type BatchCallerBatchCallFailure struct {
+	Index      *big.Int
+	RevertData []byte
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterBatchCallFailure is a free log retrieval operation binding the contract event 0x860d60a3c3ed451a144846eba67081eb134233fed0aff20997e5110b942b3d0e.
+//
+// Solidity: event BatchCallFailure(uint256 indexed index, bytes revertData)
+func (_BatchCaller *BatchCallerFilterer) FilterBatchCallFailure(opts *bind.FilterOpts, index []*big.Int) (*BatchCallerBatchCallFailureIterator, error) {
+
+	var indexRule []interface{}
+	for _, indexItem := range index {
+		indexRule = append(indexRule, indexItem)
+	}
+
+	logs, sub, err := _BatchCaller.contract.FilterLogs(opts, "BatchCallFailure", indexRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BatchCallerBatchCallFailureIterator{contract: _BatchCaller.contract, event: "BatchCallFailure", logs: logs, sub: sub}, nil
+}
+
+// WatchBatchCallFailure is a free log subscription operation binding the contract event 0x860d60a3c3ed451a144846eba67081eb134233fed0aff20997e5110b942b3d0e.
+//
+// Solidity: event BatchCallFailure(uint256 indexed index, bytes revertData)
+func (_BatchCaller *BatchCallerFilterer) WatchBatchCallFailure(opts *bind.WatchOpts, sink chan<- *BatchCallerBatchCallFailure, index []*big.Int) (event.Subscription, error) {
+
+	var indexRule []interface{}
+	for _, indexItem := range index {
+		indexRule = append(indexRule, indexItem)
+	}
+
+	logs, sub, err := _BatchCaller.contract.WatchLogs(opts, "BatchCallFailure", indexRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BatchCallerBatchCallFailure)
+				if err := _BatchCaller.contract.UnpackLog(event, "BatchCallFailure", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBatchCallFailure is a log parse operation binding the contract event 0x860d60a3c3ed451a144846eba67081eb134233fed0aff20997e5110b942b3d0e.
+//
+// Solidity: event BatchCallFailure(uint256 indexed index, bytes revertData)
+func (_BatchCaller *BatchCallerFilterer) ParseBatchCallFailure(log types.Log) (*BatchCallerBatchCallFailure, error) {
+	event := new(BatchCallerBatchCallFailure)
+	if err := _BatchCaller.contract.UnpackLog(event, "BatchCallFailure", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts/zksyncsso/efficientproxy/efficientproxy.go
+++ b/contracts/zksyncsso/efficientproxy/efficientproxy.go
@@ -1,0 +1,181 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package efficientproxy
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// EfficientProxyMetaData contains all meta data concerning the EfficientProxy contract.
+var EfficientProxyMetaData = &bind.MetaData{
+	ABI: "[]",
+}
+
+// EfficientProxyABI is the input ABI used to generate the binding from.
+// Deprecated: Use EfficientProxyMetaData.ABI instead.
+var EfficientProxyABI = EfficientProxyMetaData.ABI
+
+// EfficientProxy is an auto generated Go binding around an Ethereum contract.
+type EfficientProxy struct {
+	EfficientProxyCaller     // Read-only binding to the contract
+	EfficientProxyTransactor // Write-only binding to the contract
+	EfficientProxyFilterer   // Log filterer for contract events
+}
+
+// EfficientProxyCaller is an auto generated read-only Go binding around an Ethereum contract.
+type EfficientProxyCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// EfficientProxyTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type EfficientProxyTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// EfficientProxyFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type EfficientProxyFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// EfficientProxySession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type EfficientProxySession struct {
+	Contract     *EfficientProxy   // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// EfficientProxyCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type EfficientProxyCallerSession struct {
+	Contract *EfficientProxyCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts         // Call options to use throughout this session
+}
+
+// EfficientProxyTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type EfficientProxyTransactorSession struct {
+	Contract     *EfficientProxyTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts         // Transaction auth options to use throughout this session
+}
+
+// EfficientProxyRaw is an auto generated low-level Go binding around an Ethereum contract.
+type EfficientProxyRaw struct {
+	Contract *EfficientProxy // Generic contract binding to access the raw methods on
+}
+
+// EfficientProxyCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type EfficientProxyCallerRaw struct {
+	Contract *EfficientProxyCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// EfficientProxyTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type EfficientProxyTransactorRaw struct {
+	Contract *EfficientProxyTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewEfficientProxy creates a new instance of EfficientProxy, bound to a specific deployed contract.
+func NewEfficientProxy(address common.Address, backend bind.ContractBackend) (*EfficientProxy, error) {
+	contract, err := bindEfficientProxy(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &EfficientProxy{EfficientProxyCaller: EfficientProxyCaller{contract: contract}, EfficientProxyTransactor: EfficientProxyTransactor{contract: contract}, EfficientProxyFilterer: EfficientProxyFilterer{contract: contract}}, nil
+}
+
+// NewEfficientProxyCaller creates a new read-only instance of EfficientProxy, bound to a specific deployed contract.
+func NewEfficientProxyCaller(address common.Address, caller bind.ContractCaller) (*EfficientProxyCaller, error) {
+	contract, err := bindEfficientProxy(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &EfficientProxyCaller{contract: contract}, nil
+}
+
+// NewEfficientProxyTransactor creates a new write-only instance of EfficientProxy, bound to a specific deployed contract.
+func NewEfficientProxyTransactor(address common.Address, transactor bind.ContractTransactor) (*EfficientProxyTransactor, error) {
+	contract, err := bindEfficientProxy(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &EfficientProxyTransactor{contract: contract}, nil
+}
+
+// NewEfficientProxyFilterer creates a new log filterer instance of EfficientProxy, bound to a specific deployed contract.
+func NewEfficientProxyFilterer(address common.Address, filterer bind.ContractFilterer) (*EfficientProxyFilterer, error) {
+	contract, err := bindEfficientProxy(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &EfficientProxyFilterer{contract: contract}, nil
+}
+
+// bindEfficientProxy binds a generic wrapper to an already deployed contract.
+func bindEfficientProxy(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := EfficientProxyMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_EfficientProxy *EfficientProxyRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _EfficientProxy.Contract.EfficientProxyCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_EfficientProxy *EfficientProxyRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _EfficientProxy.Contract.EfficientProxyTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_EfficientProxy *EfficientProxyRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _EfficientProxy.Contract.EfficientProxyTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_EfficientProxy *EfficientProxyCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _EfficientProxy.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_EfficientProxy *EfficientProxyTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _EfficientProxy.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_EfficientProxy *EfficientProxyTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _EfficientProxy.Contract.contract.Transact(opts, method, params...)
+}

--- a/contracts/zksyncsso/handlers/erc1271handler/erc1271handler.go
+++ b/contracts/zksyncsso/handlers/erc1271handler/erc1271handler.go
@@ -1,0 +1,1017 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package erc1271handler
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// ERC1271HandlerMetaData contains all meta data concerning the ERC1271Handler contract.
+var ERC1271HandlerMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"}],\"name\":\"HOOK_ALREADY_EXISTS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"notSelf\",\"type\":\"address\"}],\"name\":\"NOT_FROM_SELF\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OWNER_ALREADY_EXISTS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OWNER_NOT_FOUND\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"VALIDATOR_ALREADY_EXISTS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"VALIDATOR_ERC165_FAIL\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"VALIDATOR_NOT_FOUND\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"K1OwnerAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"K1OwnerRemoved\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"ValidatorAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"ValidatorRemoved\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"addK1Owner\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"initData\",\"type\":\"bytes\"}],\"name\":\"addModuleValidator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"isK1Owner\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"isModuleValidator\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"hash\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"}],\"name\":\"isValidSignature\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"magicValue\",\"type\":\"bytes4\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"listK1Owners\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"k1OwnerList\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"listModuleValidators\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"validatorList\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"removeK1Owner\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"deinitData\",\"type\":\"bytes\"}],\"name\":\"removeModuleValidator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"deinitData\",\"type\":\"bytes\"}],\"name\":\"unlinkModuleValidator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+}
+
+// ERC1271HandlerABI is the input ABI used to generate the binding from.
+// Deprecated: Use ERC1271HandlerMetaData.ABI instead.
+var ERC1271HandlerABI = ERC1271HandlerMetaData.ABI
+
+// ERC1271Handler is an auto generated Go binding around an Ethereum contract.
+type ERC1271Handler struct {
+	ERC1271HandlerCaller     // Read-only binding to the contract
+	ERC1271HandlerTransactor // Write-only binding to the contract
+	ERC1271HandlerFilterer   // Log filterer for contract events
+}
+
+// ERC1271HandlerCaller is an auto generated read-only Go binding around an Ethereum contract.
+type ERC1271HandlerCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ERC1271HandlerTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type ERC1271HandlerTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ERC1271HandlerFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type ERC1271HandlerFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ERC1271HandlerSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type ERC1271HandlerSession struct {
+	Contract     *ERC1271Handler   // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// ERC1271HandlerCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type ERC1271HandlerCallerSession struct {
+	Contract *ERC1271HandlerCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts         // Call options to use throughout this session
+}
+
+// ERC1271HandlerTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type ERC1271HandlerTransactorSession struct {
+	Contract     *ERC1271HandlerTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts         // Transaction auth options to use throughout this session
+}
+
+// ERC1271HandlerRaw is an auto generated low-level Go binding around an Ethereum contract.
+type ERC1271HandlerRaw struct {
+	Contract *ERC1271Handler // Generic contract binding to access the raw methods on
+}
+
+// ERC1271HandlerCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type ERC1271HandlerCallerRaw struct {
+	Contract *ERC1271HandlerCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// ERC1271HandlerTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type ERC1271HandlerTransactorRaw struct {
+	Contract *ERC1271HandlerTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewERC1271Handler creates a new instance of ERC1271Handler, bound to a specific deployed contract.
+func NewERC1271Handler(address common.Address, backend bind.ContractBackend) (*ERC1271Handler, error) {
+	contract, err := bindERC1271Handler(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &ERC1271Handler{ERC1271HandlerCaller: ERC1271HandlerCaller{contract: contract}, ERC1271HandlerTransactor: ERC1271HandlerTransactor{contract: contract}, ERC1271HandlerFilterer: ERC1271HandlerFilterer{contract: contract}}, nil
+}
+
+// NewERC1271HandlerCaller creates a new read-only instance of ERC1271Handler, bound to a specific deployed contract.
+func NewERC1271HandlerCaller(address common.Address, caller bind.ContractCaller) (*ERC1271HandlerCaller, error) {
+	contract, err := bindERC1271Handler(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ERC1271HandlerCaller{contract: contract}, nil
+}
+
+// NewERC1271HandlerTransactor creates a new write-only instance of ERC1271Handler, bound to a specific deployed contract.
+func NewERC1271HandlerTransactor(address common.Address, transactor bind.ContractTransactor) (*ERC1271HandlerTransactor, error) {
+	contract, err := bindERC1271Handler(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ERC1271HandlerTransactor{contract: contract}, nil
+}
+
+// NewERC1271HandlerFilterer creates a new log filterer instance of ERC1271Handler, bound to a specific deployed contract.
+func NewERC1271HandlerFilterer(address common.Address, filterer bind.ContractFilterer) (*ERC1271HandlerFilterer, error) {
+	contract, err := bindERC1271Handler(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &ERC1271HandlerFilterer{contract: contract}, nil
+}
+
+// bindERC1271Handler binds a generic wrapper to an already deployed contract.
+func bindERC1271Handler(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := ERC1271HandlerMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_ERC1271Handler *ERC1271HandlerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _ERC1271Handler.Contract.ERC1271HandlerCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_ERC1271Handler *ERC1271HandlerRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ERC1271Handler.Contract.ERC1271HandlerTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_ERC1271Handler *ERC1271HandlerRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _ERC1271Handler.Contract.ERC1271HandlerTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_ERC1271Handler *ERC1271HandlerCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _ERC1271Handler.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_ERC1271Handler *ERC1271HandlerTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ERC1271Handler.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_ERC1271Handler *ERC1271HandlerTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _ERC1271Handler.Contract.contract.Transact(opts, method, params...)
+}
+
+// IsK1Owner is a free data retrieval call binding the contract method 0x6e354cb8.
+//
+// Solidity: function isK1Owner(address addr) view returns(bool)
+func (_ERC1271Handler *ERC1271HandlerCaller) IsK1Owner(opts *bind.CallOpts, addr common.Address) (bool, error) {
+	var out []interface{}
+	err := _ERC1271Handler.contract.Call(opts, &out, "isK1Owner", addr)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsK1Owner is a free data retrieval call binding the contract method 0x6e354cb8.
+//
+// Solidity: function isK1Owner(address addr) view returns(bool)
+func (_ERC1271Handler *ERC1271HandlerSession) IsK1Owner(addr common.Address) (bool, error) {
+	return _ERC1271Handler.Contract.IsK1Owner(&_ERC1271Handler.CallOpts, addr)
+}
+
+// IsK1Owner is a free data retrieval call binding the contract method 0x6e354cb8.
+//
+// Solidity: function isK1Owner(address addr) view returns(bool)
+func (_ERC1271Handler *ERC1271HandlerCallerSession) IsK1Owner(addr common.Address) (bool, error) {
+	return _ERC1271Handler.Contract.IsK1Owner(&_ERC1271Handler.CallOpts, addr)
+}
+
+// IsModuleValidator is a free data retrieval call binding the contract method 0x9b7be156.
+//
+// Solidity: function isModuleValidator(address validator) view returns(bool)
+func (_ERC1271Handler *ERC1271HandlerCaller) IsModuleValidator(opts *bind.CallOpts, validator common.Address) (bool, error) {
+	var out []interface{}
+	err := _ERC1271Handler.contract.Call(opts, &out, "isModuleValidator", validator)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsModuleValidator is a free data retrieval call binding the contract method 0x9b7be156.
+//
+// Solidity: function isModuleValidator(address validator) view returns(bool)
+func (_ERC1271Handler *ERC1271HandlerSession) IsModuleValidator(validator common.Address) (bool, error) {
+	return _ERC1271Handler.Contract.IsModuleValidator(&_ERC1271Handler.CallOpts, validator)
+}
+
+// IsModuleValidator is a free data retrieval call binding the contract method 0x9b7be156.
+//
+// Solidity: function isModuleValidator(address validator) view returns(bool)
+func (_ERC1271Handler *ERC1271HandlerCallerSession) IsModuleValidator(validator common.Address) (bool, error) {
+	return _ERC1271Handler.Contract.IsModuleValidator(&_ERC1271Handler.CallOpts, validator)
+}
+
+// IsValidSignature is a free data retrieval call binding the contract method 0x1626ba7e.
+//
+// Solidity: function isValidSignature(bytes32 hash, bytes signature) view returns(bytes4 magicValue)
+func (_ERC1271Handler *ERC1271HandlerCaller) IsValidSignature(opts *bind.CallOpts, hash [32]byte, signature []byte) ([4]byte, error) {
+	var out []interface{}
+	err := _ERC1271Handler.contract.Call(opts, &out, "isValidSignature", hash, signature)
+
+	if err != nil {
+		return *new([4]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([4]byte)).(*[4]byte)
+
+	return out0, err
+
+}
+
+// IsValidSignature is a free data retrieval call binding the contract method 0x1626ba7e.
+//
+// Solidity: function isValidSignature(bytes32 hash, bytes signature) view returns(bytes4 magicValue)
+func (_ERC1271Handler *ERC1271HandlerSession) IsValidSignature(hash [32]byte, signature []byte) ([4]byte, error) {
+	return _ERC1271Handler.Contract.IsValidSignature(&_ERC1271Handler.CallOpts, hash, signature)
+}
+
+// IsValidSignature is a free data retrieval call binding the contract method 0x1626ba7e.
+//
+// Solidity: function isValidSignature(bytes32 hash, bytes signature) view returns(bytes4 magicValue)
+func (_ERC1271Handler *ERC1271HandlerCallerSession) IsValidSignature(hash [32]byte, signature []byte) ([4]byte, error) {
+	return _ERC1271Handler.Contract.IsValidSignature(&_ERC1271Handler.CallOpts, hash, signature)
+}
+
+// ListK1Owners is a free data retrieval call binding the contract method 0x4f16eec8.
+//
+// Solidity: function listK1Owners() view returns(address[] k1OwnerList)
+func (_ERC1271Handler *ERC1271HandlerCaller) ListK1Owners(opts *bind.CallOpts) ([]common.Address, error) {
+	var out []interface{}
+	err := _ERC1271Handler.contract.Call(opts, &out, "listK1Owners")
+
+	if err != nil {
+		return *new([]common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
+
+	return out0, err
+
+}
+
+// ListK1Owners is a free data retrieval call binding the contract method 0x4f16eec8.
+//
+// Solidity: function listK1Owners() view returns(address[] k1OwnerList)
+func (_ERC1271Handler *ERC1271HandlerSession) ListK1Owners() ([]common.Address, error) {
+	return _ERC1271Handler.Contract.ListK1Owners(&_ERC1271Handler.CallOpts)
+}
+
+// ListK1Owners is a free data retrieval call binding the contract method 0x4f16eec8.
+//
+// Solidity: function listK1Owners() view returns(address[] k1OwnerList)
+func (_ERC1271Handler *ERC1271HandlerCallerSession) ListK1Owners() ([]common.Address, error) {
+	return _ERC1271Handler.Contract.ListK1Owners(&_ERC1271Handler.CallOpts)
+}
+
+// ListModuleValidators is a free data retrieval call binding the contract method 0x3d3a69bf.
+//
+// Solidity: function listModuleValidators() view returns(address[] validatorList)
+func (_ERC1271Handler *ERC1271HandlerCaller) ListModuleValidators(opts *bind.CallOpts) ([]common.Address, error) {
+	var out []interface{}
+	err := _ERC1271Handler.contract.Call(opts, &out, "listModuleValidators")
+
+	if err != nil {
+		return *new([]common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
+
+	return out0, err
+
+}
+
+// ListModuleValidators is a free data retrieval call binding the contract method 0x3d3a69bf.
+//
+// Solidity: function listModuleValidators() view returns(address[] validatorList)
+func (_ERC1271Handler *ERC1271HandlerSession) ListModuleValidators() ([]common.Address, error) {
+	return _ERC1271Handler.Contract.ListModuleValidators(&_ERC1271Handler.CallOpts)
+}
+
+// ListModuleValidators is a free data retrieval call binding the contract method 0x3d3a69bf.
+//
+// Solidity: function listModuleValidators() view returns(address[] validatorList)
+func (_ERC1271Handler *ERC1271HandlerCallerSession) ListModuleValidators() ([]common.Address, error) {
+	return _ERC1271Handler.Contract.ListModuleValidators(&_ERC1271Handler.CallOpts)
+}
+
+// AddK1Owner is a paid mutator transaction binding the contract method 0x23cef13e.
+//
+// Solidity: function addK1Owner(address addr) returns()
+func (_ERC1271Handler *ERC1271HandlerTransactor) AddK1Owner(opts *bind.TransactOpts, addr common.Address) (*types.Transaction, error) {
+	return _ERC1271Handler.contract.Transact(opts, "addK1Owner", addr)
+}
+
+// AddK1Owner is a paid mutator transaction binding the contract method 0x23cef13e.
+//
+// Solidity: function addK1Owner(address addr) returns()
+func (_ERC1271Handler *ERC1271HandlerSession) AddK1Owner(addr common.Address) (*types.Transaction, error) {
+	return _ERC1271Handler.Contract.AddK1Owner(&_ERC1271Handler.TransactOpts, addr)
+}
+
+// AddK1Owner is a paid mutator transaction binding the contract method 0x23cef13e.
+//
+// Solidity: function addK1Owner(address addr) returns()
+func (_ERC1271Handler *ERC1271HandlerTransactorSession) AddK1Owner(addr common.Address) (*types.Transaction, error) {
+	return _ERC1271Handler.Contract.AddK1Owner(&_ERC1271Handler.TransactOpts, addr)
+}
+
+// AddModuleValidator is a paid mutator transaction binding the contract method 0x2e0b437d.
+//
+// Solidity: function addModuleValidator(address validator, bytes initData) returns()
+func (_ERC1271Handler *ERC1271HandlerTransactor) AddModuleValidator(opts *bind.TransactOpts, validator common.Address, initData []byte) (*types.Transaction, error) {
+	return _ERC1271Handler.contract.Transact(opts, "addModuleValidator", validator, initData)
+}
+
+// AddModuleValidator is a paid mutator transaction binding the contract method 0x2e0b437d.
+//
+// Solidity: function addModuleValidator(address validator, bytes initData) returns()
+func (_ERC1271Handler *ERC1271HandlerSession) AddModuleValidator(validator common.Address, initData []byte) (*types.Transaction, error) {
+	return _ERC1271Handler.Contract.AddModuleValidator(&_ERC1271Handler.TransactOpts, validator, initData)
+}
+
+// AddModuleValidator is a paid mutator transaction binding the contract method 0x2e0b437d.
+//
+// Solidity: function addModuleValidator(address validator, bytes initData) returns()
+func (_ERC1271Handler *ERC1271HandlerTransactorSession) AddModuleValidator(validator common.Address, initData []byte) (*types.Transaction, error) {
+	return _ERC1271Handler.Contract.AddModuleValidator(&_ERC1271Handler.TransactOpts, validator, initData)
+}
+
+// RemoveK1Owner is a paid mutator transaction binding the contract method 0x714da018.
+//
+// Solidity: function removeK1Owner(address addr) returns()
+func (_ERC1271Handler *ERC1271HandlerTransactor) RemoveK1Owner(opts *bind.TransactOpts, addr common.Address) (*types.Transaction, error) {
+	return _ERC1271Handler.contract.Transact(opts, "removeK1Owner", addr)
+}
+
+// RemoveK1Owner is a paid mutator transaction binding the contract method 0x714da018.
+//
+// Solidity: function removeK1Owner(address addr) returns()
+func (_ERC1271Handler *ERC1271HandlerSession) RemoveK1Owner(addr common.Address) (*types.Transaction, error) {
+	return _ERC1271Handler.Contract.RemoveK1Owner(&_ERC1271Handler.TransactOpts, addr)
+}
+
+// RemoveK1Owner is a paid mutator transaction binding the contract method 0x714da018.
+//
+// Solidity: function removeK1Owner(address addr) returns()
+func (_ERC1271Handler *ERC1271HandlerTransactorSession) RemoveK1Owner(addr common.Address) (*types.Transaction, error) {
+	return _ERC1271Handler.Contract.RemoveK1Owner(&_ERC1271Handler.TransactOpts, addr)
+}
+
+// RemoveModuleValidator is a paid mutator transaction binding the contract method 0xb027e50a.
+//
+// Solidity: function removeModuleValidator(address validator, bytes deinitData) returns()
+func (_ERC1271Handler *ERC1271HandlerTransactor) RemoveModuleValidator(opts *bind.TransactOpts, validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _ERC1271Handler.contract.Transact(opts, "removeModuleValidator", validator, deinitData)
+}
+
+// RemoveModuleValidator is a paid mutator transaction binding the contract method 0xb027e50a.
+//
+// Solidity: function removeModuleValidator(address validator, bytes deinitData) returns()
+func (_ERC1271Handler *ERC1271HandlerSession) RemoveModuleValidator(validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _ERC1271Handler.Contract.RemoveModuleValidator(&_ERC1271Handler.TransactOpts, validator, deinitData)
+}
+
+// RemoveModuleValidator is a paid mutator transaction binding the contract method 0xb027e50a.
+//
+// Solidity: function removeModuleValidator(address validator, bytes deinitData) returns()
+func (_ERC1271Handler *ERC1271HandlerTransactorSession) RemoveModuleValidator(validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _ERC1271Handler.Contract.RemoveModuleValidator(&_ERC1271Handler.TransactOpts, validator, deinitData)
+}
+
+// UnlinkModuleValidator is a paid mutator transaction binding the contract method 0xa7d525e8.
+//
+// Solidity: function unlinkModuleValidator(address validator, bytes deinitData) returns()
+func (_ERC1271Handler *ERC1271HandlerTransactor) UnlinkModuleValidator(opts *bind.TransactOpts, validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _ERC1271Handler.contract.Transact(opts, "unlinkModuleValidator", validator, deinitData)
+}
+
+// UnlinkModuleValidator is a paid mutator transaction binding the contract method 0xa7d525e8.
+//
+// Solidity: function unlinkModuleValidator(address validator, bytes deinitData) returns()
+func (_ERC1271Handler *ERC1271HandlerSession) UnlinkModuleValidator(validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _ERC1271Handler.Contract.UnlinkModuleValidator(&_ERC1271Handler.TransactOpts, validator, deinitData)
+}
+
+// UnlinkModuleValidator is a paid mutator transaction binding the contract method 0xa7d525e8.
+//
+// Solidity: function unlinkModuleValidator(address validator, bytes deinitData) returns()
+func (_ERC1271Handler *ERC1271HandlerTransactorSession) UnlinkModuleValidator(validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _ERC1271Handler.Contract.UnlinkModuleValidator(&_ERC1271Handler.TransactOpts, validator, deinitData)
+}
+
+// ERC1271HandlerK1OwnerAddedIterator is returned from FilterK1OwnerAdded and is used to iterate over the raw logs and unpacked data for K1OwnerAdded events raised by the ERC1271Handler contract.
+type ERC1271HandlerK1OwnerAddedIterator struct {
+	Event *ERC1271HandlerK1OwnerAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ERC1271HandlerK1OwnerAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ERC1271HandlerK1OwnerAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ERC1271HandlerK1OwnerAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ERC1271HandlerK1OwnerAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ERC1271HandlerK1OwnerAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ERC1271HandlerK1OwnerAdded represents a K1OwnerAdded event raised by the ERC1271Handler contract.
+type ERC1271HandlerK1OwnerAdded struct {
+	Addr common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterK1OwnerAdded is a free log retrieval operation binding the contract event 0x40097f116787d282c09163d089084b2d950545433dad84146baf8da81064e84c.
+//
+// Solidity: event K1OwnerAdded(address indexed addr)
+func (_ERC1271Handler *ERC1271HandlerFilterer) FilterK1OwnerAdded(opts *bind.FilterOpts, addr []common.Address) (*ERC1271HandlerK1OwnerAddedIterator, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+
+	logs, sub, err := _ERC1271Handler.contract.FilterLogs(opts, "K1OwnerAdded", addrRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ERC1271HandlerK1OwnerAddedIterator{contract: _ERC1271Handler.contract, event: "K1OwnerAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchK1OwnerAdded is a free log subscription operation binding the contract event 0x40097f116787d282c09163d089084b2d950545433dad84146baf8da81064e84c.
+//
+// Solidity: event K1OwnerAdded(address indexed addr)
+func (_ERC1271Handler *ERC1271HandlerFilterer) WatchK1OwnerAdded(opts *bind.WatchOpts, sink chan<- *ERC1271HandlerK1OwnerAdded, addr []common.Address) (event.Subscription, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+
+	logs, sub, err := _ERC1271Handler.contract.WatchLogs(opts, "K1OwnerAdded", addrRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ERC1271HandlerK1OwnerAdded)
+				if err := _ERC1271Handler.contract.UnpackLog(event, "K1OwnerAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseK1OwnerAdded is a log parse operation binding the contract event 0x40097f116787d282c09163d089084b2d950545433dad84146baf8da81064e84c.
+//
+// Solidity: event K1OwnerAdded(address indexed addr)
+func (_ERC1271Handler *ERC1271HandlerFilterer) ParseK1OwnerAdded(log types.Log) (*ERC1271HandlerK1OwnerAdded, error) {
+	event := new(ERC1271HandlerK1OwnerAdded)
+	if err := _ERC1271Handler.contract.UnpackLog(event, "K1OwnerAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ERC1271HandlerK1OwnerRemovedIterator is returned from FilterK1OwnerRemoved and is used to iterate over the raw logs and unpacked data for K1OwnerRemoved events raised by the ERC1271Handler contract.
+type ERC1271HandlerK1OwnerRemovedIterator struct {
+	Event *ERC1271HandlerK1OwnerRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ERC1271HandlerK1OwnerRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ERC1271HandlerK1OwnerRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ERC1271HandlerK1OwnerRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ERC1271HandlerK1OwnerRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ERC1271HandlerK1OwnerRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ERC1271HandlerK1OwnerRemoved represents a K1OwnerRemoved event raised by the ERC1271Handler contract.
+type ERC1271HandlerK1OwnerRemoved struct {
+	Addr common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterK1OwnerRemoved is a free log retrieval operation binding the contract event 0xe09f0b842a072d50a0b373f3255e2a4216aeb61908e35a93a499f0ff2aa4c8fa.
+//
+// Solidity: event K1OwnerRemoved(address indexed addr)
+func (_ERC1271Handler *ERC1271HandlerFilterer) FilterK1OwnerRemoved(opts *bind.FilterOpts, addr []common.Address) (*ERC1271HandlerK1OwnerRemovedIterator, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+
+	logs, sub, err := _ERC1271Handler.contract.FilterLogs(opts, "K1OwnerRemoved", addrRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ERC1271HandlerK1OwnerRemovedIterator{contract: _ERC1271Handler.contract, event: "K1OwnerRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchK1OwnerRemoved is a free log subscription operation binding the contract event 0xe09f0b842a072d50a0b373f3255e2a4216aeb61908e35a93a499f0ff2aa4c8fa.
+//
+// Solidity: event K1OwnerRemoved(address indexed addr)
+func (_ERC1271Handler *ERC1271HandlerFilterer) WatchK1OwnerRemoved(opts *bind.WatchOpts, sink chan<- *ERC1271HandlerK1OwnerRemoved, addr []common.Address) (event.Subscription, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+
+	logs, sub, err := _ERC1271Handler.contract.WatchLogs(opts, "K1OwnerRemoved", addrRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ERC1271HandlerK1OwnerRemoved)
+				if err := _ERC1271Handler.contract.UnpackLog(event, "K1OwnerRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseK1OwnerRemoved is a log parse operation binding the contract event 0xe09f0b842a072d50a0b373f3255e2a4216aeb61908e35a93a499f0ff2aa4c8fa.
+//
+// Solidity: event K1OwnerRemoved(address indexed addr)
+func (_ERC1271Handler *ERC1271HandlerFilterer) ParseK1OwnerRemoved(log types.Log) (*ERC1271HandlerK1OwnerRemoved, error) {
+	event := new(ERC1271HandlerK1OwnerRemoved)
+	if err := _ERC1271Handler.contract.UnpackLog(event, "K1OwnerRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ERC1271HandlerValidatorAddedIterator is returned from FilterValidatorAdded and is used to iterate over the raw logs and unpacked data for ValidatorAdded events raised by the ERC1271Handler contract.
+type ERC1271HandlerValidatorAddedIterator struct {
+	Event *ERC1271HandlerValidatorAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ERC1271HandlerValidatorAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ERC1271HandlerValidatorAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ERC1271HandlerValidatorAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ERC1271HandlerValidatorAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ERC1271HandlerValidatorAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ERC1271HandlerValidatorAdded represents a ValidatorAdded event raised by the ERC1271Handler contract.
+type ERC1271HandlerValidatorAdded struct {
+	Validator common.Address
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterValidatorAdded is a free log retrieval operation binding the contract event 0xe366c1c0452ed8eec96861e9e54141ebff23c9ec89fe27b996b45f5ec3884987.
+//
+// Solidity: event ValidatorAdded(address indexed validator)
+func (_ERC1271Handler *ERC1271HandlerFilterer) FilterValidatorAdded(opts *bind.FilterOpts, validator []common.Address) (*ERC1271HandlerValidatorAddedIterator, error) {
+
+	var validatorRule []interface{}
+	for _, validatorItem := range validator {
+		validatorRule = append(validatorRule, validatorItem)
+	}
+
+	logs, sub, err := _ERC1271Handler.contract.FilterLogs(opts, "ValidatorAdded", validatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ERC1271HandlerValidatorAddedIterator{contract: _ERC1271Handler.contract, event: "ValidatorAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchValidatorAdded is a free log subscription operation binding the contract event 0xe366c1c0452ed8eec96861e9e54141ebff23c9ec89fe27b996b45f5ec3884987.
+//
+// Solidity: event ValidatorAdded(address indexed validator)
+func (_ERC1271Handler *ERC1271HandlerFilterer) WatchValidatorAdded(opts *bind.WatchOpts, sink chan<- *ERC1271HandlerValidatorAdded, validator []common.Address) (event.Subscription, error) {
+
+	var validatorRule []interface{}
+	for _, validatorItem := range validator {
+		validatorRule = append(validatorRule, validatorItem)
+	}
+
+	logs, sub, err := _ERC1271Handler.contract.WatchLogs(opts, "ValidatorAdded", validatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ERC1271HandlerValidatorAdded)
+				if err := _ERC1271Handler.contract.UnpackLog(event, "ValidatorAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseValidatorAdded is a log parse operation binding the contract event 0xe366c1c0452ed8eec96861e9e54141ebff23c9ec89fe27b996b45f5ec3884987.
+//
+// Solidity: event ValidatorAdded(address indexed validator)
+func (_ERC1271Handler *ERC1271HandlerFilterer) ParseValidatorAdded(log types.Log) (*ERC1271HandlerValidatorAdded, error) {
+	event := new(ERC1271HandlerValidatorAdded)
+	if err := _ERC1271Handler.contract.UnpackLog(event, "ValidatorAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ERC1271HandlerValidatorRemovedIterator is returned from FilterValidatorRemoved and is used to iterate over the raw logs and unpacked data for ValidatorRemoved events raised by the ERC1271Handler contract.
+type ERC1271HandlerValidatorRemovedIterator struct {
+	Event *ERC1271HandlerValidatorRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ERC1271HandlerValidatorRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ERC1271HandlerValidatorRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ERC1271HandlerValidatorRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ERC1271HandlerValidatorRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ERC1271HandlerValidatorRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ERC1271HandlerValidatorRemoved represents a ValidatorRemoved event raised by the ERC1271Handler contract.
+type ERC1271HandlerValidatorRemoved struct {
+	Validator common.Address
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterValidatorRemoved is a free log retrieval operation binding the contract event 0xe1434e25d6611e0db941968fdc97811c982ac1602e951637d206f5fdda9dd8f1.
+//
+// Solidity: event ValidatorRemoved(address indexed validator)
+func (_ERC1271Handler *ERC1271HandlerFilterer) FilterValidatorRemoved(opts *bind.FilterOpts, validator []common.Address) (*ERC1271HandlerValidatorRemovedIterator, error) {
+
+	var validatorRule []interface{}
+	for _, validatorItem := range validator {
+		validatorRule = append(validatorRule, validatorItem)
+	}
+
+	logs, sub, err := _ERC1271Handler.contract.FilterLogs(opts, "ValidatorRemoved", validatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ERC1271HandlerValidatorRemovedIterator{contract: _ERC1271Handler.contract, event: "ValidatorRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchValidatorRemoved is a free log subscription operation binding the contract event 0xe1434e25d6611e0db941968fdc97811c982ac1602e951637d206f5fdda9dd8f1.
+//
+// Solidity: event ValidatorRemoved(address indexed validator)
+func (_ERC1271Handler *ERC1271HandlerFilterer) WatchValidatorRemoved(opts *bind.WatchOpts, sink chan<- *ERC1271HandlerValidatorRemoved, validator []common.Address) (event.Subscription, error) {
+
+	var validatorRule []interface{}
+	for _, validatorItem := range validator {
+		validatorRule = append(validatorRule, validatorItem)
+	}
+
+	logs, sub, err := _ERC1271Handler.contract.WatchLogs(opts, "ValidatorRemoved", validatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ERC1271HandlerValidatorRemoved)
+				if err := _ERC1271Handler.contract.UnpackLog(event, "ValidatorRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseValidatorRemoved is a log parse operation binding the contract event 0xe1434e25d6611e0db941968fdc97811c982ac1602e951637d206f5fdda9dd8f1.
+//
+// Solidity: event ValidatorRemoved(address indexed validator)
+func (_ERC1271Handler *ERC1271HandlerFilterer) ParseValidatorRemoved(log types.Log) (*ERC1271HandlerValidatorRemoved, error) {
+	event := new(ERC1271HandlerValidatorRemoved)
+	if err := _ERC1271Handler.contract.UnpackLog(event, "ValidatorRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts/zksyncsso/helpers/logger/logger.go
+++ b/contracts/zksyncsso/helpers/logger/logger.go
@@ -1,0 +1,181 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package logger
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// LoggerMetaData contains all meta data concerning the Logger contract.
+var LoggerMetaData = &bind.MetaData{
+	ABI: "[]",
+}
+
+// LoggerABI is the input ABI used to generate the binding from.
+// Deprecated: Use LoggerMetaData.ABI instead.
+var LoggerABI = LoggerMetaData.ABI
+
+// Logger is an auto generated Go binding around an Ethereum contract.
+type Logger struct {
+	LoggerCaller     // Read-only binding to the contract
+	LoggerTransactor // Write-only binding to the contract
+	LoggerFilterer   // Log filterer for contract events
+}
+
+// LoggerCaller is an auto generated read-only Go binding around an Ethereum contract.
+type LoggerCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// LoggerTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type LoggerTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// LoggerFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type LoggerFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// LoggerSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type LoggerSession struct {
+	Contract     *Logger           // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// LoggerCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type LoggerCallerSession struct {
+	Contract *LoggerCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts // Call options to use throughout this session
+}
+
+// LoggerTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type LoggerTransactorSession struct {
+	Contract     *LoggerTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// LoggerRaw is an auto generated low-level Go binding around an Ethereum contract.
+type LoggerRaw struct {
+	Contract *Logger // Generic contract binding to access the raw methods on
+}
+
+// LoggerCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type LoggerCallerRaw struct {
+	Contract *LoggerCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// LoggerTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type LoggerTransactorRaw struct {
+	Contract *LoggerTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewLogger creates a new instance of Logger, bound to a specific deployed contract.
+func NewLogger(address common.Address, backend bind.ContractBackend) (*Logger, error) {
+	contract, err := bindLogger(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Logger{LoggerCaller: LoggerCaller{contract: contract}, LoggerTransactor: LoggerTransactor{contract: contract}, LoggerFilterer: LoggerFilterer{contract: contract}}, nil
+}
+
+// NewLoggerCaller creates a new read-only instance of Logger, bound to a specific deployed contract.
+func NewLoggerCaller(address common.Address, caller bind.ContractCaller) (*LoggerCaller, error) {
+	contract, err := bindLogger(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &LoggerCaller{contract: contract}, nil
+}
+
+// NewLoggerTransactor creates a new write-only instance of Logger, bound to a specific deployed contract.
+func NewLoggerTransactor(address common.Address, transactor bind.ContractTransactor) (*LoggerTransactor, error) {
+	contract, err := bindLogger(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &LoggerTransactor{contract: contract}, nil
+}
+
+// NewLoggerFilterer creates a new log filterer instance of Logger, bound to a specific deployed contract.
+func NewLoggerFilterer(address common.Address, filterer bind.ContractFilterer) (*LoggerFilterer, error) {
+	contract, err := bindLogger(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &LoggerFilterer{contract: contract}, nil
+}
+
+// bindLogger binds a generic wrapper to an already deployed contract.
+func bindLogger(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := LoggerMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Logger *LoggerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Logger.Contract.LoggerCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Logger *LoggerRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Logger.Contract.LoggerTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Logger *LoggerRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Logger.Contract.LoggerTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Logger *LoggerCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Logger.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Logger *LoggerTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Logger.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Logger *LoggerTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Logger.Contract.contract.Transact(opts, method, params...)
+}

--- a/contracts/zksyncsso/helpers/timestampasserterlocator/timestampasserterlocator.go
+++ b/contracts/zksyncsso/helpers/timestampasserterlocator/timestampasserterlocator.go
@@ -1,0 +1,181 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package timestampasserterlocator
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// TimestampAsserterLocatorMetaData contains all meta data concerning the TimestampAsserterLocator contract.
+var TimestampAsserterLocatorMetaData = &bind.MetaData{
+	ABI: "[]",
+}
+
+// TimestampAsserterLocatorABI is the input ABI used to generate the binding from.
+// Deprecated: Use TimestampAsserterLocatorMetaData.ABI instead.
+var TimestampAsserterLocatorABI = TimestampAsserterLocatorMetaData.ABI
+
+// TimestampAsserterLocator is an auto generated Go binding around an Ethereum contract.
+type TimestampAsserterLocator struct {
+	TimestampAsserterLocatorCaller     // Read-only binding to the contract
+	TimestampAsserterLocatorTransactor // Write-only binding to the contract
+	TimestampAsserterLocatorFilterer   // Log filterer for contract events
+}
+
+// TimestampAsserterLocatorCaller is an auto generated read-only Go binding around an Ethereum contract.
+type TimestampAsserterLocatorCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TimestampAsserterLocatorTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type TimestampAsserterLocatorTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TimestampAsserterLocatorFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type TimestampAsserterLocatorFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TimestampAsserterLocatorSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type TimestampAsserterLocatorSession struct {
+	Contract     *TimestampAsserterLocator // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts             // Call options to use throughout this session
+	TransactOpts bind.TransactOpts         // Transaction auth options to use throughout this session
+}
+
+// TimestampAsserterLocatorCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type TimestampAsserterLocatorCallerSession struct {
+	Contract *TimestampAsserterLocatorCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts                   // Call options to use throughout this session
+}
+
+// TimestampAsserterLocatorTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type TimestampAsserterLocatorTransactorSession struct {
+	Contract     *TimestampAsserterLocatorTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts                   // Transaction auth options to use throughout this session
+}
+
+// TimestampAsserterLocatorRaw is an auto generated low-level Go binding around an Ethereum contract.
+type TimestampAsserterLocatorRaw struct {
+	Contract *TimestampAsserterLocator // Generic contract binding to access the raw methods on
+}
+
+// TimestampAsserterLocatorCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type TimestampAsserterLocatorCallerRaw struct {
+	Contract *TimestampAsserterLocatorCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// TimestampAsserterLocatorTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type TimestampAsserterLocatorTransactorRaw struct {
+	Contract *TimestampAsserterLocatorTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewTimestampAsserterLocator creates a new instance of TimestampAsserterLocator, bound to a specific deployed contract.
+func NewTimestampAsserterLocator(address common.Address, backend bind.ContractBackend) (*TimestampAsserterLocator, error) {
+	contract, err := bindTimestampAsserterLocator(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &TimestampAsserterLocator{TimestampAsserterLocatorCaller: TimestampAsserterLocatorCaller{contract: contract}, TimestampAsserterLocatorTransactor: TimestampAsserterLocatorTransactor{contract: contract}, TimestampAsserterLocatorFilterer: TimestampAsserterLocatorFilterer{contract: contract}}, nil
+}
+
+// NewTimestampAsserterLocatorCaller creates a new read-only instance of TimestampAsserterLocator, bound to a specific deployed contract.
+func NewTimestampAsserterLocatorCaller(address common.Address, caller bind.ContractCaller) (*TimestampAsserterLocatorCaller, error) {
+	contract, err := bindTimestampAsserterLocator(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &TimestampAsserterLocatorCaller{contract: contract}, nil
+}
+
+// NewTimestampAsserterLocatorTransactor creates a new write-only instance of TimestampAsserterLocator, bound to a specific deployed contract.
+func NewTimestampAsserterLocatorTransactor(address common.Address, transactor bind.ContractTransactor) (*TimestampAsserterLocatorTransactor, error) {
+	contract, err := bindTimestampAsserterLocator(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &TimestampAsserterLocatorTransactor{contract: contract}, nil
+}
+
+// NewTimestampAsserterLocatorFilterer creates a new log filterer instance of TimestampAsserterLocator, bound to a specific deployed contract.
+func NewTimestampAsserterLocatorFilterer(address common.Address, filterer bind.ContractFilterer) (*TimestampAsserterLocatorFilterer, error) {
+	contract, err := bindTimestampAsserterLocator(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &TimestampAsserterLocatorFilterer{contract: contract}, nil
+}
+
+// bindTimestampAsserterLocator binds a generic wrapper to an already deployed contract.
+func bindTimestampAsserterLocator(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := TimestampAsserterLocatorMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_TimestampAsserterLocator *TimestampAsserterLocatorRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _TimestampAsserterLocator.Contract.TimestampAsserterLocatorCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_TimestampAsserterLocator *TimestampAsserterLocatorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _TimestampAsserterLocator.Contract.TimestampAsserterLocatorTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_TimestampAsserterLocator *TimestampAsserterLocatorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _TimestampAsserterLocator.Contract.TimestampAsserterLocatorTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_TimestampAsserterLocator *TimestampAsserterLocatorCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _TimestampAsserterLocator.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_TimestampAsserterLocator *TimestampAsserterLocatorTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _TimestampAsserterLocator.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_TimestampAsserterLocator *TimestampAsserterLocatorTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _TimestampAsserterLocator.Contract.contract.Transact(opts, method, params...)
+}

--- a/contracts/zksyncsso/helpers/tokencallbackhandler/tokencallbackhandler.go
+++ b/contracts/zksyncsso/helpers/tokencallbackhandler/tokencallbackhandler.go
@@ -1,0 +1,305 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package tokencallbackhandler
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// TokenCallbackHandlerMetaData contains all meta data concerning the TokenCallbackHandler contract.
+var TokenCallbackHandlerMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"uint256[]\",\"name\":\"\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256[]\",\"name\":\"\",\"type\":\"uint256[]\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"name\":\"onERC1155BatchReceived\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"\",\"type\":\"bytes4\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"name\":\"onERC1155Received\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"\",\"type\":\"bytes4\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"name\":\"onERC721Received\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"\",\"type\":\"bytes4\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"}],\"name\":\"supportsInterface\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+}
+
+// TokenCallbackHandlerABI is the input ABI used to generate the binding from.
+// Deprecated: Use TokenCallbackHandlerMetaData.ABI instead.
+var TokenCallbackHandlerABI = TokenCallbackHandlerMetaData.ABI
+
+// TokenCallbackHandler is an auto generated Go binding around an Ethereum contract.
+type TokenCallbackHandler struct {
+	TokenCallbackHandlerCaller     // Read-only binding to the contract
+	TokenCallbackHandlerTransactor // Write-only binding to the contract
+	TokenCallbackHandlerFilterer   // Log filterer for contract events
+}
+
+// TokenCallbackHandlerCaller is an auto generated read-only Go binding around an Ethereum contract.
+type TokenCallbackHandlerCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TokenCallbackHandlerTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type TokenCallbackHandlerTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TokenCallbackHandlerFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type TokenCallbackHandlerFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TokenCallbackHandlerSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type TokenCallbackHandlerSession struct {
+	Contract     *TokenCallbackHandler // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts         // Call options to use throughout this session
+	TransactOpts bind.TransactOpts     // Transaction auth options to use throughout this session
+}
+
+// TokenCallbackHandlerCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type TokenCallbackHandlerCallerSession struct {
+	Contract *TokenCallbackHandlerCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts               // Call options to use throughout this session
+}
+
+// TokenCallbackHandlerTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type TokenCallbackHandlerTransactorSession struct {
+	Contract     *TokenCallbackHandlerTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts               // Transaction auth options to use throughout this session
+}
+
+// TokenCallbackHandlerRaw is an auto generated low-level Go binding around an Ethereum contract.
+type TokenCallbackHandlerRaw struct {
+	Contract *TokenCallbackHandler // Generic contract binding to access the raw methods on
+}
+
+// TokenCallbackHandlerCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type TokenCallbackHandlerCallerRaw struct {
+	Contract *TokenCallbackHandlerCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// TokenCallbackHandlerTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type TokenCallbackHandlerTransactorRaw struct {
+	Contract *TokenCallbackHandlerTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewTokenCallbackHandler creates a new instance of TokenCallbackHandler, bound to a specific deployed contract.
+func NewTokenCallbackHandler(address common.Address, backend bind.ContractBackend) (*TokenCallbackHandler, error) {
+	contract, err := bindTokenCallbackHandler(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &TokenCallbackHandler{TokenCallbackHandlerCaller: TokenCallbackHandlerCaller{contract: contract}, TokenCallbackHandlerTransactor: TokenCallbackHandlerTransactor{contract: contract}, TokenCallbackHandlerFilterer: TokenCallbackHandlerFilterer{contract: contract}}, nil
+}
+
+// NewTokenCallbackHandlerCaller creates a new read-only instance of TokenCallbackHandler, bound to a specific deployed contract.
+func NewTokenCallbackHandlerCaller(address common.Address, caller bind.ContractCaller) (*TokenCallbackHandlerCaller, error) {
+	contract, err := bindTokenCallbackHandler(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &TokenCallbackHandlerCaller{contract: contract}, nil
+}
+
+// NewTokenCallbackHandlerTransactor creates a new write-only instance of TokenCallbackHandler, bound to a specific deployed contract.
+func NewTokenCallbackHandlerTransactor(address common.Address, transactor bind.ContractTransactor) (*TokenCallbackHandlerTransactor, error) {
+	contract, err := bindTokenCallbackHandler(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &TokenCallbackHandlerTransactor{contract: contract}, nil
+}
+
+// NewTokenCallbackHandlerFilterer creates a new log filterer instance of TokenCallbackHandler, bound to a specific deployed contract.
+func NewTokenCallbackHandlerFilterer(address common.Address, filterer bind.ContractFilterer) (*TokenCallbackHandlerFilterer, error) {
+	contract, err := bindTokenCallbackHandler(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &TokenCallbackHandlerFilterer{contract: contract}, nil
+}
+
+// bindTokenCallbackHandler binds a generic wrapper to an already deployed contract.
+func bindTokenCallbackHandler(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := TokenCallbackHandlerMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_TokenCallbackHandler *TokenCallbackHandlerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _TokenCallbackHandler.Contract.TokenCallbackHandlerCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_TokenCallbackHandler *TokenCallbackHandlerRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _TokenCallbackHandler.Contract.TokenCallbackHandlerTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_TokenCallbackHandler *TokenCallbackHandlerRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _TokenCallbackHandler.Contract.TokenCallbackHandlerTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_TokenCallbackHandler *TokenCallbackHandlerCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _TokenCallbackHandler.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_TokenCallbackHandler *TokenCallbackHandlerTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _TokenCallbackHandler.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_TokenCallbackHandler *TokenCallbackHandlerTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _TokenCallbackHandler.Contract.contract.Transact(opts, method, params...)
+}
+
+// OnERC1155BatchReceived is a free data retrieval call binding the contract method 0xbc197c81.
+//
+// Solidity: function onERC1155BatchReceived(address , address , uint256[] , uint256[] , bytes ) pure returns(bytes4)
+func (_TokenCallbackHandler *TokenCallbackHandlerCaller) OnERC1155BatchReceived(opts *bind.CallOpts, arg0 common.Address, arg1 common.Address, arg2 []*big.Int, arg3 []*big.Int, arg4 []byte) ([4]byte, error) {
+	var out []interface{}
+	err := _TokenCallbackHandler.contract.Call(opts, &out, "onERC1155BatchReceived", arg0, arg1, arg2, arg3, arg4)
+
+	if err != nil {
+		return *new([4]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([4]byte)).(*[4]byte)
+
+	return out0, err
+
+}
+
+// OnERC1155BatchReceived is a free data retrieval call binding the contract method 0xbc197c81.
+//
+// Solidity: function onERC1155BatchReceived(address , address , uint256[] , uint256[] , bytes ) pure returns(bytes4)
+func (_TokenCallbackHandler *TokenCallbackHandlerSession) OnERC1155BatchReceived(arg0 common.Address, arg1 common.Address, arg2 []*big.Int, arg3 []*big.Int, arg4 []byte) ([4]byte, error) {
+	return _TokenCallbackHandler.Contract.OnERC1155BatchReceived(&_TokenCallbackHandler.CallOpts, arg0, arg1, arg2, arg3, arg4)
+}
+
+// OnERC1155BatchReceived is a free data retrieval call binding the contract method 0xbc197c81.
+//
+// Solidity: function onERC1155BatchReceived(address , address , uint256[] , uint256[] , bytes ) pure returns(bytes4)
+func (_TokenCallbackHandler *TokenCallbackHandlerCallerSession) OnERC1155BatchReceived(arg0 common.Address, arg1 common.Address, arg2 []*big.Int, arg3 []*big.Int, arg4 []byte) ([4]byte, error) {
+	return _TokenCallbackHandler.Contract.OnERC1155BatchReceived(&_TokenCallbackHandler.CallOpts, arg0, arg1, arg2, arg3, arg4)
+}
+
+// OnERC1155Received is a free data retrieval call binding the contract method 0xf23a6e61.
+//
+// Solidity: function onERC1155Received(address , address , uint256 , uint256 , bytes ) pure returns(bytes4)
+func (_TokenCallbackHandler *TokenCallbackHandlerCaller) OnERC1155Received(opts *bind.CallOpts, arg0 common.Address, arg1 common.Address, arg2 *big.Int, arg3 *big.Int, arg4 []byte) ([4]byte, error) {
+	var out []interface{}
+	err := _TokenCallbackHandler.contract.Call(opts, &out, "onERC1155Received", arg0, arg1, arg2, arg3, arg4)
+
+	if err != nil {
+		return *new([4]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([4]byte)).(*[4]byte)
+
+	return out0, err
+
+}
+
+// OnERC1155Received is a free data retrieval call binding the contract method 0xf23a6e61.
+//
+// Solidity: function onERC1155Received(address , address , uint256 , uint256 , bytes ) pure returns(bytes4)
+func (_TokenCallbackHandler *TokenCallbackHandlerSession) OnERC1155Received(arg0 common.Address, arg1 common.Address, arg2 *big.Int, arg3 *big.Int, arg4 []byte) ([4]byte, error) {
+	return _TokenCallbackHandler.Contract.OnERC1155Received(&_TokenCallbackHandler.CallOpts, arg0, arg1, arg2, arg3, arg4)
+}
+
+// OnERC1155Received is a free data retrieval call binding the contract method 0xf23a6e61.
+//
+// Solidity: function onERC1155Received(address , address , uint256 , uint256 , bytes ) pure returns(bytes4)
+func (_TokenCallbackHandler *TokenCallbackHandlerCallerSession) OnERC1155Received(arg0 common.Address, arg1 common.Address, arg2 *big.Int, arg3 *big.Int, arg4 []byte) ([4]byte, error) {
+	return _TokenCallbackHandler.Contract.OnERC1155Received(&_TokenCallbackHandler.CallOpts, arg0, arg1, arg2, arg3, arg4)
+}
+
+// OnERC721Received is a free data retrieval call binding the contract method 0x150b7a02.
+//
+// Solidity: function onERC721Received(address , address , uint256 , bytes ) pure returns(bytes4)
+func (_TokenCallbackHandler *TokenCallbackHandlerCaller) OnERC721Received(opts *bind.CallOpts, arg0 common.Address, arg1 common.Address, arg2 *big.Int, arg3 []byte) ([4]byte, error) {
+	var out []interface{}
+	err := _TokenCallbackHandler.contract.Call(opts, &out, "onERC721Received", arg0, arg1, arg2, arg3)
+
+	if err != nil {
+		return *new([4]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([4]byte)).(*[4]byte)
+
+	return out0, err
+
+}
+
+// OnERC721Received is a free data retrieval call binding the contract method 0x150b7a02.
+//
+// Solidity: function onERC721Received(address , address , uint256 , bytes ) pure returns(bytes4)
+func (_TokenCallbackHandler *TokenCallbackHandlerSession) OnERC721Received(arg0 common.Address, arg1 common.Address, arg2 *big.Int, arg3 []byte) ([4]byte, error) {
+	return _TokenCallbackHandler.Contract.OnERC721Received(&_TokenCallbackHandler.CallOpts, arg0, arg1, arg2, arg3)
+}
+
+// OnERC721Received is a free data retrieval call binding the contract method 0x150b7a02.
+//
+// Solidity: function onERC721Received(address , address , uint256 , bytes ) pure returns(bytes4)
+func (_TokenCallbackHandler *TokenCallbackHandlerCallerSession) OnERC721Received(arg0 common.Address, arg1 common.Address, arg2 *big.Int, arg3 []byte) ([4]byte, error) {
+	return _TokenCallbackHandler.Contract.OnERC721Received(&_TokenCallbackHandler.CallOpts, arg0, arg1, arg2, arg3)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_TokenCallbackHandler *TokenCallbackHandlerCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _TokenCallbackHandler.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_TokenCallbackHandler *TokenCallbackHandlerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _TokenCallbackHandler.Contract.SupportsInterface(&_TokenCallbackHandler.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_TokenCallbackHandler *TokenCallbackHandlerCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _TokenCallbackHandler.Contract.SupportsInterface(&_TokenCallbackHandler.CallOpts, interfaceId)
+}

--- a/contracts/zksyncsso/helpers/utils/utils.go
+++ b/contracts/zksyncsso/helpers/utils/utils.go
@@ -1,0 +1,181 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package utils
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// UtilsMetaData contains all meta data concerning the Utils contract.
+var UtilsMetaData = &bind.MetaData{
+	ABI: "[]",
+}
+
+// UtilsABI is the input ABI used to generate the binding from.
+// Deprecated: Use UtilsMetaData.ABI instead.
+var UtilsABI = UtilsMetaData.ABI
+
+// Utils is an auto generated Go binding around an Ethereum contract.
+type Utils struct {
+	UtilsCaller     // Read-only binding to the contract
+	UtilsTransactor // Write-only binding to the contract
+	UtilsFilterer   // Log filterer for contract events
+}
+
+// UtilsCaller is an auto generated read-only Go binding around an Ethereum contract.
+type UtilsCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// UtilsTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type UtilsTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// UtilsFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type UtilsFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// UtilsSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type UtilsSession struct {
+	Contract     *Utils            // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// UtilsCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type UtilsCallerSession struct {
+	Contract *UtilsCaller  // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts // Call options to use throughout this session
+}
+
+// UtilsTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type UtilsTransactorSession struct {
+	Contract     *UtilsTransactor  // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// UtilsRaw is an auto generated low-level Go binding around an Ethereum contract.
+type UtilsRaw struct {
+	Contract *Utils // Generic contract binding to access the raw methods on
+}
+
+// UtilsCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type UtilsCallerRaw struct {
+	Contract *UtilsCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// UtilsTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type UtilsTransactorRaw struct {
+	Contract *UtilsTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewUtils creates a new instance of Utils, bound to a specific deployed contract.
+func NewUtils(address common.Address, backend bind.ContractBackend) (*Utils, error) {
+	contract, err := bindUtils(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Utils{UtilsCaller: UtilsCaller{contract: contract}, UtilsTransactor: UtilsTransactor{contract: contract}, UtilsFilterer: UtilsFilterer{contract: contract}}, nil
+}
+
+// NewUtilsCaller creates a new read-only instance of Utils, bound to a specific deployed contract.
+func NewUtilsCaller(address common.Address, caller bind.ContractCaller) (*UtilsCaller, error) {
+	contract, err := bindUtils(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &UtilsCaller{contract: contract}, nil
+}
+
+// NewUtilsTransactor creates a new write-only instance of Utils, bound to a specific deployed contract.
+func NewUtilsTransactor(address common.Address, transactor bind.ContractTransactor) (*UtilsTransactor, error) {
+	contract, err := bindUtils(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &UtilsTransactor{contract: contract}, nil
+}
+
+// NewUtilsFilterer creates a new log filterer instance of Utils, bound to a specific deployed contract.
+func NewUtilsFilterer(address common.Address, filterer bind.ContractFilterer) (*UtilsFilterer, error) {
+	contract, err := bindUtils(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &UtilsFilterer{contract: contract}, nil
+}
+
+// bindUtils binds a generic wrapper to an already deployed contract.
+func bindUtils(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := UtilsMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Utils *UtilsRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Utils.Contract.UtilsCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Utils *UtilsRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Utils.Contract.UtilsTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Utils *UtilsRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Utils.Contract.UtilsTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Utils *UtilsCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Utils.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Utils *UtilsTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Utils.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Utils *UtilsTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Utils.Contract.contract.Transact(opts, method, params...)
+}

--- a/contracts/zksyncsso/interfaces/iexecutionhook/iexecutionhook.go
+++ b/contracts/zksyncsso/interfaces/iexecutionhook/iexecutionhook.go
@@ -1,0 +1,316 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package iexecutionhook
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// Transaction is an auto generated low-level Go binding around an user-defined struct.
+type Transaction struct {
+	TxType                 *big.Int
+	From                   *big.Int
+	To                     *big.Int
+	GasLimit               *big.Int
+	GasPerPubdataByteLimit *big.Int
+	MaxFeePerGas           *big.Int
+	MaxPriorityFeePerGas   *big.Int
+	Paymaster              *big.Int
+	Nonce                  *big.Int
+	Value                  *big.Int
+	Reserved               [4]*big.Int
+	Data                   []byte
+	Signature              []byte
+	FactoryDeps            [][32]byte
+	PaymasterInput         []byte
+	ReservedDynamic        []byte
+}
+
+// IExecutionHookMetaData contains all meta data concerning the IExecutionHook contract.
+var IExecutionHookMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"onInstall\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"onUninstall\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"context\",\"type\":\"bytes\"}],\"name\":\"postExecutionHook\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[]\",\"name\":\"factoryDeps\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"reservedDynamic\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"transaction\",\"type\":\"tuple\"}],\"name\":\"preExecutionHook\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"context\",\"type\":\"bytes\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"}],\"name\":\"supportsInterface\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+}
+
+// IExecutionHookABI is the input ABI used to generate the binding from.
+// Deprecated: Use IExecutionHookMetaData.ABI instead.
+var IExecutionHookABI = IExecutionHookMetaData.ABI
+
+// IExecutionHook is an auto generated Go binding around an Ethereum contract.
+type IExecutionHook struct {
+	IExecutionHookCaller     // Read-only binding to the contract
+	IExecutionHookTransactor // Write-only binding to the contract
+	IExecutionHookFilterer   // Log filterer for contract events
+}
+
+// IExecutionHookCaller is an auto generated read-only Go binding around an Ethereum contract.
+type IExecutionHookCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IExecutionHookTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type IExecutionHookTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IExecutionHookFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type IExecutionHookFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IExecutionHookSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type IExecutionHookSession struct {
+	Contract     *IExecutionHook   // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// IExecutionHookCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type IExecutionHookCallerSession struct {
+	Contract *IExecutionHookCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts         // Call options to use throughout this session
+}
+
+// IExecutionHookTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type IExecutionHookTransactorSession struct {
+	Contract     *IExecutionHookTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts         // Transaction auth options to use throughout this session
+}
+
+// IExecutionHookRaw is an auto generated low-level Go binding around an Ethereum contract.
+type IExecutionHookRaw struct {
+	Contract *IExecutionHook // Generic contract binding to access the raw methods on
+}
+
+// IExecutionHookCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type IExecutionHookCallerRaw struct {
+	Contract *IExecutionHookCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// IExecutionHookTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type IExecutionHookTransactorRaw struct {
+	Contract *IExecutionHookTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewIExecutionHook creates a new instance of IExecutionHook, bound to a specific deployed contract.
+func NewIExecutionHook(address common.Address, backend bind.ContractBackend) (*IExecutionHook, error) {
+	contract, err := bindIExecutionHook(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &IExecutionHook{IExecutionHookCaller: IExecutionHookCaller{contract: contract}, IExecutionHookTransactor: IExecutionHookTransactor{contract: contract}, IExecutionHookFilterer: IExecutionHookFilterer{contract: contract}}, nil
+}
+
+// NewIExecutionHookCaller creates a new read-only instance of IExecutionHook, bound to a specific deployed contract.
+func NewIExecutionHookCaller(address common.Address, caller bind.ContractCaller) (*IExecutionHookCaller, error) {
+	contract, err := bindIExecutionHook(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IExecutionHookCaller{contract: contract}, nil
+}
+
+// NewIExecutionHookTransactor creates a new write-only instance of IExecutionHook, bound to a specific deployed contract.
+func NewIExecutionHookTransactor(address common.Address, transactor bind.ContractTransactor) (*IExecutionHookTransactor, error) {
+	contract, err := bindIExecutionHook(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IExecutionHookTransactor{contract: contract}, nil
+}
+
+// NewIExecutionHookFilterer creates a new log filterer instance of IExecutionHook, bound to a specific deployed contract.
+func NewIExecutionHookFilterer(address common.Address, filterer bind.ContractFilterer) (*IExecutionHookFilterer, error) {
+	contract, err := bindIExecutionHook(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &IExecutionHookFilterer{contract: contract}, nil
+}
+
+// bindIExecutionHook binds a generic wrapper to an already deployed contract.
+func bindIExecutionHook(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := IExecutionHookMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IExecutionHook *IExecutionHookRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _IExecutionHook.Contract.IExecutionHookCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IExecutionHook *IExecutionHookRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IExecutionHook.Contract.IExecutionHookTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IExecutionHook *IExecutionHookRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IExecutionHook.Contract.IExecutionHookTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IExecutionHook *IExecutionHookCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _IExecutionHook.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IExecutionHook *IExecutionHookTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IExecutionHook.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IExecutionHook *IExecutionHookTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IExecutionHook.Contract.contract.Transact(opts, method, params...)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_IExecutionHook *IExecutionHookCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _IExecutionHook.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_IExecutionHook *IExecutionHookSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _IExecutionHook.Contract.SupportsInterface(&_IExecutionHook.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_IExecutionHook *IExecutionHookCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _IExecutionHook.Contract.SupportsInterface(&_IExecutionHook.CallOpts, interfaceId)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_IExecutionHook *IExecutionHookTransactor) OnInstall(opts *bind.TransactOpts, data []byte) (*types.Transaction, error) {
+	return _IExecutionHook.contract.Transact(opts, "onInstall", data)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_IExecutionHook *IExecutionHookSession) OnInstall(data []byte) (*types.Transaction, error) {
+	return _IExecutionHook.Contract.OnInstall(&_IExecutionHook.TransactOpts, data)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_IExecutionHook *IExecutionHookTransactorSession) OnInstall(data []byte) (*types.Transaction, error) {
+	return _IExecutionHook.Contract.OnInstall(&_IExecutionHook.TransactOpts, data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_IExecutionHook *IExecutionHookTransactor) OnUninstall(opts *bind.TransactOpts, data []byte) (*types.Transaction, error) {
+	return _IExecutionHook.contract.Transact(opts, "onUninstall", data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_IExecutionHook *IExecutionHookSession) OnUninstall(data []byte) (*types.Transaction, error) {
+	return _IExecutionHook.Contract.OnUninstall(&_IExecutionHook.TransactOpts, data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_IExecutionHook *IExecutionHookTransactorSession) OnUninstall(data []byte) (*types.Transaction, error) {
+	return _IExecutionHook.Contract.OnUninstall(&_IExecutionHook.TransactOpts, data)
+}
+
+// PostExecutionHook is a paid mutator transaction binding the contract method 0x3920e539.
+//
+// Solidity: function postExecutionHook(bytes context) returns()
+func (_IExecutionHook *IExecutionHookTransactor) PostExecutionHook(opts *bind.TransactOpts, context []byte) (*types.Transaction, error) {
+	return _IExecutionHook.contract.Transact(opts, "postExecutionHook", context)
+}
+
+// PostExecutionHook is a paid mutator transaction binding the contract method 0x3920e539.
+//
+// Solidity: function postExecutionHook(bytes context) returns()
+func (_IExecutionHook *IExecutionHookSession) PostExecutionHook(context []byte) (*types.Transaction, error) {
+	return _IExecutionHook.Contract.PostExecutionHook(&_IExecutionHook.TransactOpts, context)
+}
+
+// PostExecutionHook is a paid mutator transaction binding the contract method 0x3920e539.
+//
+// Solidity: function postExecutionHook(bytes context) returns()
+func (_IExecutionHook *IExecutionHookTransactorSession) PostExecutionHook(context []byte) (*types.Transaction, error) {
+	return _IExecutionHook.Contract.PostExecutionHook(&_IExecutionHook.TransactOpts, context)
+}
+
+// PreExecutionHook is a paid mutator transaction binding the contract method 0x926a74a6.
+//
+// Solidity: function preExecutionHook((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) returns(bytes context)
+func (_IExecutionHook *IExecutionHookTransactor) PreExecutionHook(opts *bind.TransactOpts, transaction Transaction) (*types.Transaction, error) {
+	return _IExecutionHook.contract.Transact(opts, "preExecutionHook", transaction)
+}
+
+// PreExecutionHook is a paid mutator transaction binding the contract method 0x926a74a6.
+//
+// Solidity: function preExecutionHook((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) returns(bytes context)
+func (_IExecutionHook *IExecutionHookSession) PreExecutionHook(transaction Transaction) (*types.Transaction, error) {
+	return _IExecutionHook.Contract.PreExecutionHook(&_IExecutionHook.TransactOpts, transaction)
+}
+
+// PreExecutionHook is a paid mutator transaction binding the contract method 0x926a74a6.
+//
+// Solidity: function preExecutionHook((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) returns(bytes context)
+func (_IExecutionHook *IExecutionHookTransactorSession) PreExecutionHook(transaction Transaction) (*types.Transaction, error) {
+	return _IExecutionHook.Contract.PreExecutionHook(&_IExecutionHook.TransactOpts, transaction)
+}

--- a/contracts/zksyncsso/interfaces/iguardianrecoveryvalidator/iguardianrecoveryvalidator.go
+++ b/contracts/zksyncsso/interfaces/iguardianrecoveryvalidator/iguardianrecoveryvalidator.go
@@ -1,0 +1,1817 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package iguardianrecoveryvalidator
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// IGuardianRecoveryValidatorGuardian is an auto generated low-level Go binding around an user-defined struct.
+type IGuardianRecoveryValidatorGuardian struct {
+	Addr    common.Address
+	IsReady bool
+	AddedAt uint64
+}
+
+// IGuardianRecoveryValidatorRecoveryRequest is an auto generated low-level Go binding around an user-defined struct.
+type IGuardianRecoveryValidatorRecoveryRequest struct {
+	HashedCredentialId [32]byte
+	RawPublicKey       [2][32]byte
+	Timestamp          *big.Int
+}
+
+// Transaction is an auto generated low-level Go binding around an user-defined struct.
+type Transaction struct {
+	TxType                 *big.Int
+	From                   *big.Int
+	To                     *big.Int
+	GasLimit               *big.Int
+	GasPerPubdataByteLimit *big.Int
+	MaxFeePerGas           *big.Int
+	MaxPriorityFeePerGas   *big.Int
+	Paymaster              *big.Int
+	Nonce                  *big.Int
+	Value                  *big.Int
+	Reserved               [4]*big.Int
+	Data                   []byte
+	Signature              []byte
+	FactoryDeps            [][32]byte
+	PaymasterInput         []byte
+	ReservedDynamic        []byte
+}
+
+// IGuardianRecoveryValidatorMetaData contains all meta data concerning the IGuardianRecoveryValidator contract.
+var IGuardianRecoveryValidatorMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"guardian\",\"type\":\"address\"}],\"name\":\"AccountAlreadyGuardedByGuardian\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"guardian\",\"type\":\"address\"}],\"name\":\"AccountNotGuardedByAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"AccountRecoveryInProgress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"GuardianCannotBeSelf\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"guardian\",\"type\":\"address\"}],\"name\":\"GuardianNotFound\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"guardian\",\"type\":\"address\"}],\"name\":\"GuardianNotProposed\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidAccountToGuardAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidAccountToRecoverAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidGuardianAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidWebAuthValidatorAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NonFunctionCallTransaction\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"}],\"name\":\"UnknownHashedOriginDomain\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"WebAuthValidatorNotEnabled\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"guardian\",\"type\":\"address\"}],\"name\":\"GuardianAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"guardian\",\"type\":\"address\"}],\"name\":\"GuardianProposed\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"guardian\",\"type\":\"address\"}],\"name\":\"GuardianRemoved\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"}],\"name\":\"HashedOriginDomainDisabledForAccount\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"}],\"name\":\"HashedOriginDomainEnabledForAccount\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"hashedCredentialId\",\"type\":\"bytes32\"}],\"name\":\"RecoveryDiscarded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"hashedCredentialId\",\"type\":\"bytes32\"}],\"name\":\"RecoveryFinished\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"hashedCredentialId\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"guardian\",\"type\":\"address\"}],\"name\":\"RecoveryInitiated\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"accountToGuard\",\"type\":\"address\"}],\"name\":\"addGuardian\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"}],\"name\":\"discardRecovery\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"getPendingRecoveryData\",\"outputs\":[{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"hashedCredentialId\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32[2]\",\"name\":\"rawPublicKey\",\"type\":\"bytes32[2]\"},{\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"internalType\":\"structIGuardianRecoveryValidator.RecoveryRequest\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"guardian\",\"type\":\"address\"}],\"name\":\"guardianOf\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"guardiansFor\",\"outputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isReady\",\"type\":\"bool\"},{\"internalType\":\"uint64\",\"name\":\"addedAt\",\"type\":\"uint64\"}],\"internalType\":\"structIGuardianRecoveryValidator.Guardian[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"accountToRecover\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"hashedCredentialId\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32[2]\",\"name\":\"rawPublicKey\",\"type\":\"bytes32[2]\"},{\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"}],\"name\":\"initRecovery\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"onInstall\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"onUninstall\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"newGuardian\",\"type\":\"address\"}],\"name\":\"proposeGuardian\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"guardianToRemove\",\"type\":\"address\"}],\"name\":\"removeGuardian\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"}],\"name\":\"supportsInterface\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"signedHash\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"}],\"name\":\"validateSignature\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"signedHash\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[]\",\"name\":\"factoryDeps\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"reservedDynamic\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"transaction\",\"type\":\"tuple\"}],\"name\":\"validateTransaction\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+}
+
+// IGuardianRecoveryValidatorABI is the input ABI used to generate the binding from.
+// Deprecated: Use IGuardianRecoveryValidatorMetaData.ABI instead.
+var IGuardianRecoveryValidatorABI = IGuardianRecoveryValidatorMetaData.ABI
+
+// IGuardianRecoveryValidator is an auto generated Go binding around an Ethereum contract.
+type IGuardianRecoveryValidator struct {
+	IGuardianRecoveryValidatorCaller     // Read-only binding to the contract
+	IGuardianRecoveryValidatorTransactor // Write-only binding to the contract
+	IGuardianRecoveryValidatorFilterer   // Log filterer for contract events
+}
+
+// IGuardianRecoveryValidatorCaller is an auto generated read-only Go binding around an Ethereum contract.
+type IGuardianRecoveryValidatorCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IGuardianRecoveryValidatorTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type IGuardianRecoveryValidatorTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IGuardianRecoveryValidatorFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type IGuardianRecoveryValidatorFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IGuardianRecoveryValidatorSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type IGuardianRecoveryValidatorSession struct {
+	Contract     *IGuardianRecoveryValidator // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts               // Call options to use throughout this session
+	TransactOpts bind.TransactOpts           // Transaction auth options to use throughout this session
+}
+
+// IGuardianRecoveryValidatorCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type IGuardianRecoveryValidatorCallerSession struct {
+	Contract *IGuardianRecoveryValidatorCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts                     // Call options to use throughout this session
+}
+
+// IGuardianRecoveryValidatorTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type IGuardianRecoveryValidatorTransactorSession struct {
+	Contract     *IGuardianRecoveryValidatorTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts                     // Transaction auth options to use throughout this session
+}
+
+// IGuardianRecoveryValidatorRaw is an auto generated low-level Go binding around an Ethereum contract.
+type IGuardianRecoveryValidatorRaw struct {
+	Contract *IGuardianRecoveryValidator // Generic contract binding to access the raw methods on
+}
+
+// IGuardianRecoveryValidatorCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type IGuardianRecoveryValidatorCallerRaw struct {
+	Contract *IGuardianRecoveryValidatorCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// IGuardianRecoveryValidatorTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type IGuardianRecoveryValidatorTransactorRaw struct {
+	Contract *IGuardianRecoveryValidatorTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewIGuardianRecoveryValidator creates a new instance of IGuardianRecoveryValidator, bound to a specific deployed contract.
+func NewIGuardianRecoveryValidator(address common.Address, backend bind.ContractBackend) (*IGuardianRecoveryValidator, error) {
+	contract, err := bindIGuardianRecoveryValidator(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &IGuardianRecoveryValidator{IGuardianRecoveryValidatorCaller: IGuardianRecoveryValidatorCaller{contract: contract}, IGuardianRecoveryValidatorTransactor: IGuardianRecoveryValidatorTransactor{contract: contract}, IGuardianRecoveryValidatorFilterer: IGuardianRecoveryValidatorFilterer{contract: contract}}, nil
+}
+
+// NewIGuardianRecoveryValidatorCaller creates a new read-only instance of IGuardianRecoveryValidator, bound to a specific deployed contract.
+func NewIGuardianRecoveryValidatorCaller(address common.Address, caller bind.ContractCaller) (*IGuardianRecoveryValidatorCaller, error) {
+	contract, err := bindIGuardianRecoveryValidator(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IGuardianRecoveryValidatorCaller{contract: contract}, nil
+}
+
+// NewIGuardianRecoveryValidatorTransactor creates a new write-only instance of IGuardianRecoveryValidator, bound to a specific deployed contract.
+func NewIGuardianRecoveryValidatorTransactor(address common.Address, transactor bind.ContractTransactor) (*IGuardianRecoveryValidatorTransactor, error) {
+	contract, err := bindIGuardianRecoveryValidator(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IGuardianRecoveryValidatorTransactor{contract: contract}, nil
+}
+
+// NewIGuardianRecoveryValidatorFilterer creates a new log filterer instance of IGuardianRecoveryValidator, bound to a specific deployed contract.
+func NewIGuardianRecoveryValidatorFilterer(address common.Address, filterer bind.ContractFilterer) (*IGuardianRecoveryValidatorFilterer, error) {
+	contract, err := bindIGuardianRecoveryValidator(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &IGuardianRecoveryValidatorFilterer{contract: contract}, nil
+}
+
+// bindIGuardianRecoveryValidator binds a generic wrapper to an already deployed contract.
+func bindIGuardianRecoveryValidator(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := IGuardianRecoveryValidatorMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _IGuardianRecoveryValidator.Contract.IGuardianRecoveryValidatorCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.Contract.IGuardianRecoveryValidatorTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.Contract.IGuardianRecoveryValidatorTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _IGuardianRecoveryValidator.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.Contract.contract.Transact(opts, method, params...)
+}
+
+// GetPendingRecoveryData is a free data retrieval call binding the contract method 0xab9d5fff.
+//
+// Solidity: function getPendingRecoveryData(bytes32 hashedOriginDomain, address account) view returns((bytes32,bytes32[2],uint256))
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorCaller) GetPendingRecoveryData(opts *bind.CallOpts, hashedOriginDomain [32]byte, account common.Address) (IGuardianRecoveryValidatorRecoveryRequest, error) {
+	var out []interface{}
+	err := _IGuardianRecoveryValidator.contract.Call(opts, &out, "getPendingRecoveryData", hashedOriginDomain, account)
+
+	if err != nil {
+		return *new(IGuardianRecoveryValidatorRecoveryRequest), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(IGuardianRecoveryValidatorRecoveryRequest)).(*IGuardianRecoveryValidatorRecoveryRequest)
+
+	return out0, err
+
+}
+
+// GetPendingRecoveryData is a free data retrieval call binding the contract method 0xab9d5fff.
+//
+// Solidity: function getPendingRecoveryData(bytes32 hashedOriginDomain, address account) view returns((bytes32,bytes32[2],uint256))
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorSession) GetPendingRecoveryData(hashedOriginDomain [32]byte, account common.Address) (IGuardianRecoveryValidatorRecoveryRequest, error) {
+	return _IGuardianRecoveryValidator.Contract.GetPendingRecoveryData(&_IGuardianRecoveryValidator.CallOpts, hashedOriginDomain, account)
+}
+
+// GetPendingRecoveryData is a free data retrieval call binding the contract method 0xab9d5fff.
+//
+// Solidity: function getPendingRecoveryData(bytes32 hashedOriginDomain, address account) view returns((bytes32,bytes32[2],uint256))
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorCallerSession) GetPendingRecoveryData(hashedOriginDomain [32]byte, account common.Address) (IGuardianRecoveryValidatorRecoveryRequest, error) {
+	return _IGuardianRecoveryValidator.Contract.GetPendingRecoveryData(&_IGuardianRecoveryValidator.CallOpts, hashedOriginDomain, account)
+}
+
+// GuardianOf is a free data retrieval call binding the contract method 0xcb339850.
+//
+// Solidity: function guardianOf(bytes32 hashedOriginDomain, address guardian) view returns(address[])
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorCaller) GuardianOf(opts *bind.CallOpts, hashedOriginDomain [32]byte, guardian common.Address) ([]common.Address, error) {
+	var out []interface{}
+	err := _IGuardianRecoveryValidator.contract.Call(opts, &out, "guardianOf", hashedOriginDomain, guardian)
+
+	if err != nil {
+		return *new([]common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
+
+	return out0, err
+
+}
+
+// GuardianOf is a free data retrieval call binding the contract method 0xcb339850.
+//
+// Solidity: function guardianOf(bytes32 hashedOriginDomain, address guardian) view returns(address[])
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorSession) GuardianOf(hashedOriginDomain [32]byte, guardian common.Address) ([]common.Address, error) {
+	return _IGuardianRecoveryValidator.Contract.GuardianOf(&_IGuardianRecoveryValidator.CallOpts, hashedOriginDomain, guardian)
+}
+
+// GuardianOf is a free data retrieval call binding the contract method 0xcb339850.
+//
+// Solidity: function guardianOf(bytes32 hashedOriginDomain, address guardian) view returns(address[])
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorCallerSession) GuardianOf(hashedOriginDomain [32]byte, guardian common.Address) ([]common.Address, error) {
+	return _IGuardianRecoveryValidator.Contract.GuardianOf(&_IGuardianRecoveryValidator.CallOpts, hashedOriginDomain, guardian)
+}
+
+// GuardiansFor is a free data retrieval call binding the contract method 0x511f723d.
+//
+// Solidity: function guardiansFor(bytes32 hashedOriginDomain, address addr) view returns((address,bool,uint64)[])
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorCaller) GuardiansFor(opts *bind.CallOpts, hashedOriginDomain [32]byte, addr common.Address) ([]IGuardianRecoveryValidatorGuardian, error) {
+	var out []interface{}
+	err := _IGuardianRecoveryValidator.contract.Call(opts, &out, "guardiansFor", hashedOriginDomain, addr)
+
+	if err != nil {
+		return *new([]IGuardianRecoveryValidatorGuardian), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]IGuardianRecoveryValidatorGuardian)).(*[]IGuardianRecoveryValidatorGuardian)
+
+	return out0, err
+
+}
+
+// GuardiansFor is a free data retrieval call binding the contract method 0x511f723d.
+//
+// Solidity: function guardiansFor(bytes32 hashedOriginDomain, address addr) view returns((address,bool,uint64)[])
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorSession) GuardiansFor(hashedOriginDomain [32]byte, addr common.Address) ([]IGuardianRecoveryValidatorGuardian, error) {
+	return _IGuardianRecoveryValidator.Contract.GuardiansFor(&_IGuardianRecoveryValidator.CallOpts, hashedOriginDomain, addr)
+}
+
+// GuardiansFor is a free data retrieval call binding the contract method 0x511f723d.
+//
+// Solidity: function guardiansFor(bytes32 hashedOriginDomain, address addr) view returns((address,bool,uint64)[])
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorCallerSession) GuardiansFor(hashedOriginDomain [32]byte, addr common.Address) ([]IGuardianRecoveryValidatorGuardian, error) {
+	return _IGuardianRecoveryValidator.Contract.GuardiansFor(&_IGuardianRecoveryValidator.CallOpts, hashedOriginDomain, addr)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _IGuardianRecoveryValidator.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _IGuardianRecoveryValidator.Contract.SupportsInterface(&_IGuardianRecoveryValidator.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _IGuardianRecoveryValidator.Contract.SupportsInterface(&_IGuardianRecoveryValidator.CallOpts, interfaceId)
+}
+
+// ValidateSignature is a free data retrieval call binding the contract method 0x333daf92.
+//
+// Solidity: function validateSignature(bytes32 signedHash, bytes signature) view returns(bool)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorCaller) ValidateSignature(opts *bind.CallOpts, signedHash [32]byte, signature []byte) (bool, error) {
+	var out []interface{}
+	err := _IGuardianRecoveryValidator.contract.Call(opts, &out, "validateSignature", signedHash, signature)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// ValidateSignature is a free data retrieval call binding the contract method 0x333daf92.
+//
+// Solidity: function validateSignature(bytes32 signedHash, bytes signature) view returns(bool)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorSession) ValidateSignature(signedHash [32]byte, signature []byte) (bool, error) {
+	return _IGuardianRecoveryValidator.Contract.ValidateSignature(&_IGuardianRecoveryValidator.CallOpts, signedHash, signature)
+}
+
+// ValidateSignature is a free data retrieval call binding the contract method 0x333daf92.
+//
+// Solidity: function validateSignature(bytes32 signedHash, bytes signature) view returns(bool)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorCallerSession) ValidateSignature(signedHash [32]byte, signature []byte) (bool, error) {
+	return _IGuardianRecoveryValidator.Contract.ValidateSignature(&_IGuardianRecoveryValidator.CallOpts, signedHash, signature)
+}
+
+// AddGuardian is a paid mutator transaction binding the contract method 0x85431596.
+//
+// Solidity: function addGuardian(bytes32 hashedOriginDomain, address accountToGuard) returns(bool)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorTransactor) AddGuardian(opts *bind.TransactOpts, hashedOriginDomain [32]byte, accountToGuard common.Address) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.contract.Transact(opts, "addGuardian", hashedOriginDomain, accountToGuard)
+}
+
+// AddGuardian is a paid mutator transaction binding the contract method 0x85431596.
+//
+// Solidity: function addGuardian(bytes32 hashedOriginDomain, address accountToGuard) returns(bool)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorSession) AddGuardian(hashedOriginDomain [32]byte, accountToGuard common.Address) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.Contract.AddGuardian(&_IGuardianRecoveryValidator.TransactOpts, hashedOriginDomain, accountToGuard)
+}
+
+// AddGuardian is a paid mutator transaction binding the contract method 0x85431596.
+//
+// Solidity: function addGuardian(bytes32 hashedOriginDomain, address accountToGuard) returns(bool)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorTransactorSession) AddGuardian(hashedOriginDomain [32]byte, accountToGuard common.Address) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.Contract.AddGuardian(&_IGuardianRecoveryValidator.TransactOpts, hashedOriginDomain, accountToGuard)
+}
+
+// DiscardRecovery is a paid mutator transaction binding the contract method 0x51bd1f69.
+//
+// Solidity: function discardRecovery(bytes32 hashedOriginDomain) returns()
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorTransactor) DiscardRecovery(opts *bind.TransactOpts, hashedOriginDomain [32]byte) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.contract.Transact(opts, "discardRecovery", hashedOriginDomain)
+}
+
+// DiscardRecovery is a paid mutator transaction binding the contract method 0x51bd1f69.
+//
+// Solidity: function discardRecovery(bytes32 hashedOriginDomain) returns()
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorSession) DiscardRecovery(hashedOriginDomain [32]byte) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.Contract.DiscardRecovery(&_IGuardianRecoveryValidator.TransactOpts, hashedOriginDomain)
+}
+
+// DiscardRecovery is a paid mutator transaction binding the contract method 0x51bd1f69.
+//
+// Solidity: function discardRecovery(bytes32 hashedOriginDomain) returns()
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorTransactorSession) DiscardRecovery(hashedOriginDomain [32]byte) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.Contract.DiscardRecovery(&_IGuardianRecoveryValidator.TransactOpts, hashedOriginDomain)
+}
+
+// InitRecovery is a paid mutator transaction binding the contract method 0x236ad679.
+//
+// Solidity: function initRecovery(address accountToRecover, bytes32 hashedCredentialId, bytes32[2] rawPublicKey, bytes32 hashedOriginDomain) returns()
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorTransactor) InitRecovery(opts *bind.TransactOpts, accountToRecover common.Address, hashedCredentialId [32]byte, rawPublicKey [2][32]byte, hashedOriginDomain [32]byte) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.contract.Transact(opts, "initRecovery", accountToRecover, hashedCredentialId, rawPublicKey, hashedOriginDomain)
+}
+
+// InitRecovery is a paid mutator transaction binding the contract method 0x236ad679.
+//
+// Solidity: function initRecovery(address accountToRecover, bytes32 hashedCredentialId, bytes32[2] rawPublicKey, bytes32 hashedOriginDomain) returns()
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorSession) InitRecovery(accountToRecover common.Address, hashedCredentialId [32]byte, rawPublicKey [2][32]byte, hashedOriginDomain [32]byte) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.Contract.InitRecovery(&_IGuardianRecoveryValidator.TransactOpts, accountToRecover, hashedCredentialId, rawPublicKey, hashedOriginDomain)
+}
+
+// InitRecovery is a paid mutator transaction binding the contract method 0x236ad679.
+//
+// Solidity: function initRecovery(address accountToRecover, bytes32 hashedCredentialId, bytes32[2] rawPublicKey, bytes32 hashedOriginDomain) returns()
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorTransactorSession) InitRecovery(accountToRecover common.Address, hashedCredentialId [32]byte, rawPublicKey [2][32]byte, hashedOriginDomain [32]byte) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.Contract.InitRecovery(&_IGuardianRecoveryValidator.TransactOpts, accountToRecover, hashedCredentialId, rawPublicKey, hashedOriginDomain)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorTransactor) OnInstall(opts *bind.TransactOpts, data []byte) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.contract.Transact(opts, "onInstall", data)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorSession) OnInstall(data []byte) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.Contract.OnInstall(&_IGuardianRecoveryValidator.TransactOpts, data)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorTransactorSession) OnInstall(data []byte) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.Contract.OnInstall(&_IGuardianRecoveryValidator.TransactOpts, data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorTransactor) OnUninstall(opts *bind.TransactOpts, data []byte) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.contract.Transact(opts, "onUninstall", data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorSession) OnUninstall(data []byte) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.Contract.OnUninstall(&_IGuardianRecoveryValidator.TransactOpts, data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorTransactorSession) OnUninstall(data []byte) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.Contract.OnUninstall(&_IGuardianRecoveryValidator.TransactOpts, data)
+}
+
+// ProposeGuardian is a paid mutator transaction binding the contract method 0x9f5d29c9.
+//
+// Solidity: function proposeGuardian(bytes32 hashedOriginDomain, address newGuardian) returns()
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorTransactor) ProposeGuardian(opts *bind.TransactOpts, hashedOriginDomain [32]byte, newGuardian common.Address) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.contract.Transact(opts, "proposeGuardian", hashedOriginDomain, newGuardian)
+}
+
+// ProposeGuardian is a paid mutator transaction binding the contract method 0x9f5d29c9.
+//
+// Solidity: function proposeGuardian(bytes32 hashedOriginDomain, address newGuardian) returns()
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorSession) ProposeGuardian(hashedOriginDomain [32]byte, newGuardian common.Address) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.Contract.ProposeGuardian(&_IGuardianRecoveryValidator.TransactOpts, hashedOriginDomain, newGuardian)
+}
+
+// ProposeGuardian is a paid mutator transaction binding the contract method 0x9f5d29c9.
+//
+// Solidity: function proposeGuardian(bytes32 hashedOriginDomain, address newGuardian) returns()
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorTransactorSession) ProposeGuardian(hashedOriginDomain [32]byte, newGuardian common.Address) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.Contract.ProposeGuardian(&_IGuardianRecoveryValidator.TransactOpts, hashedOriginDomain, newGuardian)
+}
+
+// RemoveGuardian is a paid mutator transaction binding the contract method 0x3cab947d.
+//
+// Solidity: function removeGuardian(bytes32 hashedOriginDomain, address guardianToRemove) returns()
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorTransactor) RemoveGuardian(opts *bind.TransactOpts, hashedOriginDomain [32]byte, guardianToRemove common.Address) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.contract.Transact(opts, "removeGuardian", hashedOriginDomain, guardianToRemove)
+}
+
+// RemoveGuardian is a paid mutator transaction binding the contract method 0x3cab947d.
+//
+// Solidity: function removeGuardian(bytes32 hashedOriginDomain, address guardianToRemove) returns()
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorSession) RemoveGuardian(hashedOriginDomain [32]byte, guardianToRemove common.Address) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.Contract.RemoveGuardian(&_IGuardianRecoveryValidator.TransactOpts, hashedOriginDomain, guardianToRemove)
+}
+
+// RemoveGuardian is a paid mutator transaction binding the contract method 0x3cab947d.
+//
+// Solidity: function removeGuardian(bytes32 hashedOriginDomain, address guardianToRemove) returns()
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorTransactorSession) RemoveGuardian(hashedOriginDomain [32]byte, guardianToRemove common.Address) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.Contract.RemoveGuardian(&_IGuardianRecoveryValidator.TransactOpts, hashedOriginDomain, guardianToRemove)
+}
+
+// ValidateTransaction is a paid mutator transaction binding the contract method 0xbf1733f9.
+//
+// Solidity: function validateTransaction(bytes32 signedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) returns(bool)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorTransactor) ValidateTransaction(opts *bind.TransactOpts, signedHash [32]byte, transaction Transaction) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.contract.Transact(opts, "validateTransaction", signedHash, transaction)
+}
+
+// ValidateTransaction is a paid mutator transaction binding the contract method 0xbf1733f9.
+//
+// Solidity: function validateTransaction(bytes32 signedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) returns(bool)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorSession) ValidateTransaction(signedHash [32]byte, transaction Transaction) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.Contract.ValidateTransaction(&_IGuardianRecoveryValidator.TransactOpts, signedHash, transaction)
+}
+
+// ValidateTransaction is a paid mutator transaction binding the contract method 0xbf1733f9.
+//
+// Solidity: function validateTransaction(bytes32 signedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) returns(bool)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorTransactorSession) ValidateTransaction(signedHash [32]byte, transaction Transaction) (*types.Transaction, error) {
+	return _IGuardianRecoveryValidator.Contract.ValidateTransaction(&_IGuardianRecoveryValidator.TransactOpts, signedHash, transaction)
+}
+
+// IGuardianRecoveryValidatorGuardianAddedIterator is returned from FilterGuardianAdded and is used to iterate over the raw logs and unpacked data for GuardianAdded events raised by the IGuardianRecoveryValidator contract.
+type IGuardianRecoveryValidatorGuardianAddedIterator struct {
+	Event *IGuardianRecoveryValidatorGuardianAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *IGuardianRecoveryValidatorGuardianAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(IGuardianRecoveryValidatorGuardianAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(IGuardianRecoveryValidatorGuardianAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *IGuardianRecoveryValidatorGuardianAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *IGuardianRecoveryValidatorGuardianAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// IGuardianRecoveryValidatorGuardianAdded represents a GuardianAdded event raised by the IGuardianRecoveryValidator contract.
+type IGuardianRecoveryValidatorGuardianAdded struct {
+	Account            common.Address
+	HashedOriginDomain [32]byte
+	Guardian           common.Address
+	Raw                types.Log // Blockchain specific contextual infos
+}
+
+// FilterGuardianAdded is a free log retrieval operation binding the contract event 0x6aba2dccf4edc3319e24e776ffc5d7f8fa89456e0f15421abf316d28d427ed33.
+//
+// Solidity: event GuardianAdded(address indexed account, bytes32 indexed hashedOriginDomain, address indexed guardian)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorFilterer) FilterGuardianAdded(opts *bind.FilterOpts, account []common.Address, hashedOriginDomain [][32]byte, guardian []common.Address) (*IGuardianRecoveryValidatorGuardianAddedIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+	var guardianRule []interface{}
+	for _, guardianItem := range guardian {
+		guardianRule = append(guardianRule, guardianItem)
+	}
+
+	logs, sub, err := _IGuardianRecoveryValidator.contract.FilterLogs(opts, "GuardianAdded", accountRule, hashedOriginDomainRule, guardianRule)
+	if err != nil {
+		return nil, err
+	}
+	return &IGuardianRecoveryValidatorGuardianAddedIterator{contract: _IGuardianRecoveryValidator.contract, event: "GuardianAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchGuardianAdded is a free log subscription operation binding the contract event 0x6aba2dccf4edc3319e24e776ffc5d7f8fa89456e0f15421abf316d28d427ed33.
+//
+// Solidity: event GuardianAdded(address indexed account, bytes32 indexed hashedOriginDomain, address indexed guardian)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorFilterer) WatchGuardianAdded(opts *bind.WatchOpts, sink chan<- *IGuardianRecoveryValidatorGuardianAdded, account []common.Address, hashedOriginDomain [][32]byte, guardian []common.Address) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+	var guardianRule []interface{}
+	for _, guardianItem := range guardian {
+		guardianRule = append(guardianRule, guardianItem)
+	}
+
+	logs, sub, err := _IGuardianRecoveryValidator.contract.WatchLogs(opts, "GuardianAdded", accountRule, hashedOriginDomainRule, guardianRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(IGuardianRecoveryValidatorGuardianAdded)
+				if err := _IGuardianRecoveryValidator.contract.UnpackLog(event, "GuardianAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseGuardianAdded is a log parse operation binding the contract event 0x6aba2dccf4edc3319e24e776ffc5d7f8fa89456e0f15421abf316d28d427ed33.
+//
+// Solidity: event GuardianAdded(address indexed account, bytes32 indexed hashedOriginDomain, address indexed guardian)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorFilterer) ParseGuardianAdded(log types.Log) (*IGuardianRecoveryValidatorGuardianAdded, error) {
+	event := new(IGuardianRecoveryValidatorGuardianAdded)
+	if err := _IGuardianRecoveryValidator.contract.UnpackLog(event, "GuardianAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// IGuardianRecoveryValidatorGuardianProposedIterator is returned from FilterGuardianProposed and is used to iterate over the raw logs and unpacked data for GuardianProposed events raised by the IGuardianRecoveryValidator contract.
+type IGuardianRecoveryValidatorGuardianProposedIterator struct {
+	Event *IGuardianRecoveryValidatorGuardianProposed // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *IGuardianRecoveryValidatorGuardianProposedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(IGuardianRecoveryValidatorGuardianProposed)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(IGuardianRecoveryValidatorGuardianProposed)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *IGuardianRecoveryValidatorGuardianProposedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *IGuardianRecoveryValidatorGuardianProposedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// IGuardianRecoveryValidatorGuardianProposed represents a GuardianProposed event raised by the IGuardianRecoveryValidator contract.
+type IGuardianRecoveryValidatorGuardianProposed struct {
+	Account            common.Address
+	HashedOriginDomain [32]byte
+	Guardian           common.Address
+	Raw                types.Log // Blockchain specific contextual infos
+}
+
+// FilterGuardianProposed is a free log retrieval operation binding the contract event 0x3deaf0877005efc7ea2c571de4f96ff33bf60c0b32e188f1fa32bab3da8b870e.
+//
+// Solidity: event GuardianProposed(address indexed account, bytes32 indexed hashedOriginDomain, address indexed guardian)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorFilterer) FilterGuardianProposed(opts *bind.FilterOpts, account []common.Address, hashedOriginDomain [][32]byte, guardian []common.Address) (*IGuardianRecoveryValidatorGuardianProposedIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+	var guardianRule []interface{}
+	for _, guardianItem := range guardian {
+		guardianRule = append(guardianRule, guardianItem)
+	}
+
+	logs, sub, err := _IGuardianRecoveryValidator.contract.FilterLogs(opts, "GuardianProposed", accountRule, hashedOriginDomainRule, guardianRule)
+	if err != nil {
+		return nil, err
+	}
+	return &IGuardianRecoveryValidatorGuardianProposedIterator{contract: _IGuardianRecoveryValidator.contract, event: "GuardianProposed", logs: logs, sub: sub}, nil
+}
+
+// WatchGuardianProposed is a free log subscription operation binding the contract event 0x3deaf0877005efc7ea2c571de4f96ff33bf60c0b32e188f1fa32bab3da8b870e.
+//
+// Solidity: event GuardianProposed(address indexed account, bytes32 indexed hashedOriginDomain, address indexed guardian)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorFilterer) WatchGuardianProposed(opts *bind.WatchOpts, sink chan<- *IGuardianRecoveryValidatorGuardianProposed, account []common.Address, hashedOriginDomain [][32]byte, guardian []common.Address) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+	var guardianRule []interface{}
+	for _, guardianItem := range guardian {
+		guardianRule = append(guardianRule, guardianItem)
+	}
+
+	logs, sub, err := _IGuardianRecoveryValidator.contract.WatchLogs(opts, "GuardianProposed", accountRule, hashedOriginDomainRule, guardianRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(IGuardianRecoveryValidatorGuardianProposed)
+				if err := _IGuardianRecoveryValidator.contract.UnpackLog(event, "GuardianProposed", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseGuardianProposed is a log parse operation binding the contract event 0x3deaf0877005efc7ea2c571de4f96ff33bf60c0b32e188f1fa32bab3da8b870e.
+//
+// Solidity: event GuardianProposed(address indexed account, bytes32 indexed hashedOriginDomain, address indexed guardian)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorFilterer) ParseGuardianProposed(log types.Log) (*IGuardianRecoveryValidatorGuardianProposed, error) {
+	event := new(IGuardianRecoveryValidatorGuardianProposed)
+	if err := _IGuardianRecoveryValidator.contract.UnpackLog(event, "GuardianProposed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// IGuardianRecoveryValidatorGuardianRemovedIterator is returned from FilterGuardianRemoved and is used to iterate over the raw logs and unpacked data for GuardianRemoved events raised by the IGuardianRecoveryValidator contract.
+type IGuardianRecoveryValidatorGuardianRemovedIterator struct {
+	Event *IGuardianRecoveryValidatorGuardianRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *IGuardianRecoveryValidatorGuardianRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(IGuardianRecoveryValidatorGuardianRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(IGuardianRecoveryValidatorGuardianRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *IGuardianRecoveryValidatorGuardianRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *IGuardianRecoveryValidatorGuardianRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// IGuardianRecoveryValidatorGuardianRemoved represents a GuardianRemoved event raised by the IGuardianRecoveryValidator contract.
+type IGuardianRecoveryValidatorGuardianRemoved struct {
+	Account            common.Address
+	HashedOriginDomain [32]byte
+	Guardian           common.Address
+	Raw                types.Log // Blockchain specific contextual infos
+}
+
+// FilterGuardianRemoved is a free log retrieval operation binding the contract event 0xb9c57fa4d0e004062979bfe03380ddabcf23ec66f36e471ee5b5ab67349485b2.
+//
+// Solidity: event GuardianRemoved(address indexed account, bytes32 indexed hashedOriginDomain, address indexed guardian)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorFilterer) FilterGuardianRemoved(opts *bind.FilterOpts, account []common.Address, hashedOriginDomain [][32]byte, guardian []common.Address) (*IGuardianRecoveryValidatorGuardianRemovedIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+	var guardianRule []interface{}
+	for _, guardianItem := range guardian {
+		guardianRule = append(guardianRule, guardianItem)
+	}
+
+	logs, sub, err := _IGuardianRecoveryValidator.contract.FilterLogs(opts, "GuardianRemoved", accountRule, hashedOriginDomainRule, guardianRule)
+	if err != nil {
+		return nil, err
+	}
+	return &IGuardianRecoveryValidatorGuardianRemovedIterator{contract: _IGuardianRecoveryValidator.contract, event: "GuardianRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchGuardianRemoved is a free log subscription operation binding the contract event 0xb9c57fa4d0e004062979bfe03380ddabcf23ec66f36e471ee5b5ab67349485b2.
+//
+// Solidity: event GuardianRemoved(address indexed account, bytes32 indexed hashedOriginDomain, address indexed guardian)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorFilterer) WatchGuardianRemoved(opts *bind.WatchOpts, sink chan<- *IGuardianRecoveryValidatorGuardianRemoved, account []common.Address, hashedOriginDomain [][32]byte, guardian []common.Address) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+	var guardianRule []interface{}
+	for _, guardianItem := range guardian {
+		guardianRule = append(guardianRule, guardianItem)
+	}
+
+	logs, sub, err := _IGuardianRecoveryValidator.contract.WatchLogs(opts, "GuardianRemoved", accountRule, hashedOriginDomainRule, guardianRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(IGuardianRecoveryValidatorGuardianRemoved)
+				if err := _IGuardianRecoveryValidator.contract.UnpackLog(event, "GuardianRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseGuardianRemoved is a log parse operation binding the contract event 0xb9c57fa4d0e004062979bfe03380ddabcf23ec66f36e471ee5b5ab67349485b2.
+//
+// Solidity: event GuardianRemoved(address indexed account, bytes32 indexed hashedOriginDomain, address indexed guardian)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorFilterer) ParseGuardianRemoved(log types.Log) (*IGuardianRecoveryValidatorGuardianRemoved, error) {
+	event := new(IGuardianRecoveryValidatorGuardianRemoved)
+	if err := _IGuardianRecoveryValidator.contract.UnpackLog(event, "GuardianRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// IGuardianRecoveryValidatorHashedOriginDomainDisabledForAccountIterator is returned from FilterHashedOriginDomainDisabledForAccount and is used to iterate over the raw logs and unpacked data for HashedOriginDomainDisabledForAccount events raised by the IGuardianRecoveryValidator contract.
+type IGuardianRecoveryValidatorHashedOriginDomainDisabledForAccountIterator struct {
+	Event *IGuardianRecoveryValidatorHashedOriginDomainDisabledForAccount // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *IGuardianRecoveryValidatorHashedOriginDomainDisabledForAccountIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(IGuardianRecoveryValidatorHashedOriginDomainDisabledForAccount)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(IGuardianRecoveryValidatorHashedOriginDomainDisabledForAccount)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *IGuardianRecoveryValidatorHashedOriginDomainDisabledForAccountIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *IGuardianRecoveryValidatorHashedOriginDomainDisabledForAccountIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// IGuardianRecoveryValidatorHashedOriginDomainDisabledForAccount represents a HashedOriginDomainDisabledForAccount event raised by the IGuardianRecoveryValidator contract.
+type IGuardianRecoveryValidatorHashedOriginDomainDisabledForAccount struct {
+	Account            common.Address
+	HashedOriginDomain [32]byte
+	Raw                types.Log // Blockchain specific contextual infos
+}
+
+// FilterHashedOriginDomainDisabledForAccount is a free log retrieval operation binding the contract event 0x1373f4151802c1c04091d06c3f13c1948e40afad22bd00382d4702808d0320eb.
+//
+// Solidity: event HashedOriginDomainDisabledForAccount(address indexed account, bytes32 indexed hashedOriginDomain)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorFilterer) FilterHashedOriginDomainDisabledForAccount(opts *bind.FilterOpts, account []common.Address, hashedOriginDomain [][32]byte) (*IGuardianRecoveryValidatorHashedOriginDomainDisabledForAccountIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+
+	logs, sub, err := _IGuardianRecoveryValidator.contract.FilterLogs(opts, "HashedOriginDomainDisabledForAccount", accountRule, hashedOriginDomainRule)
+	if err != nil {
+		return nil, err
+	}
+	return &IGuardianRecoveryValidatorHashedOriginDomainDisabledForAccountIterator{contract: _IGuardianRecoveryValidator.contract, event: "HashedOriginDomainDisabledForAccount", logs: logs, sub: sub}, nil
+}
+
+// WatchHashedOriginDomainDisabledForAccount is a free log subscription operation binding the contract event 0x1373f4151802c1c04091d06c3f13c1948e40afad22bd00382d4702808d0320eb.
+//
+// Solidity: event HashedOriginDomainDisabledForAccount(address indexed account, bytes32 indexed hashedOriginDomain)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorFilterer) WatchHashedOriginDomainDisabledForAccount(opts *bind.WatchOpts, sink chan<- *IGuardianRecoveryValidatorHashedOriginDomainDisabledForAccount, account []common.Address, hashedOriginDomain [][32]byte) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+
+	logs, sub, err := _IGuardianRecoveryValidator.contract.WatchLogs(opts, "HashedOriginDomainDisabledForAccount", accountRule, hashedOriginDomainRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(IGuardianRecoveryValidatorHashedOriginDomainDisabledForAccount)
+				if err := _IGuardianRecoveryValidator.contract.UnpackLog(event, "HashedOriginDomainDisabledForAccount", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseHashedOriginDomainDisabledForAccount is a log parse operation binding the contract event 0x1373f4151802c1c04091d06c3f13c1948e40afad22bd00382d4702808d0320eb.
+//
+// Solidity: event HashedOriginDomainDisabledForAccount(address indexed account, bytes32 indexed hashedOriginDomain)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorFilterer) ParseHashedOriginDomainDisabledForAccount(log types.Log) (*IGuardianRecoveryValidatorHashedOriginDomainDisabledForAccount, error) {
+	event := new(IGuardianRecoveryValidatorHashedOriginDomainDisabledForAccount)
+	if err := _IGuardianRecoveryValidator.contract.UnpackLog(event, "HashedOriginDomainDisabledForAccount", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// IGuardianRecoveryValidatorHashedOriginDomainEnabledForAccountIterator is returned from FilterHashedOriginDomainEnabledForAccount and is used to iterate over the raw logs and unpacked data for HashedOriginDomainEnabledForAccount events raised by the IGuardianRecoveryValidator contract.
+type IGuardianRecoveryValidatorHashedOriginDomainEnabledForAccountIterator struct {
+	Event *IGuardianRecoveryValidatorHashedOriginDomainEnabledForAccount // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *IGuardianRecoveryValidatorHashedOriginDomainEnabledForAccountIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(IGuardianRecoveryValidatorHashedOriginDomainEnabledForAccount)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(IGuardianRecoveryValidatorHashedOriginDomainEnabledForAccount)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *IGuardianRecoveryValidatorHashedOriginDomainEnabledForAccountIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *IGuardianRecoveryValidatorHashedOriginDomainEnabledForAccountIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// IGuardianRecoveryValidatorHashedOriginDomainEnabledForAccount represents a HashedOriginDomainEnabledForAccount event raised by the IGuardianRecoveryValidator contract.
+type IGuardianRecoveryValidatorHashedOriginDomainEnabledForAccount struct {
+	Account            common.Address
+	HashedOriginDomain [32]byte
+	Raw                types.Log // Blockchain specific contextual infos
+}
+
+// FilterHashedOriginDomainEnabledForAccount is a free log retrieval operation binding the contract event 0x49e308297bf7e3373130f54d11e9944d094c586954301b5c7da3b918195c7580.
+//
+// Solidity: event HashedOriginDomainEnabledForAccount(address indexed account, bytes32 indexed hashedOriginDomain)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorFilterer) FilterHashedOriginDomainEnabledForAccount(opts *bind.FilterOpts, account []common.Address, hashedOriginDomain [][32]byte) (*IGuardianRecoveryValidatorHashedOriginDomainEnabledForAccountIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+
+	logs, sub, err := _IGuardianRecoveryValidator.contract.FilterLogs(opts, "HashedOriginDomainEnabledForAccount", accountRule, hashedOriginDomainRule)
+	if err != nil {
+		return nil, err
+	}
+	return &IGuardianRecoveryValidatorHashedOriginDomainEnabledForAccountIterator{contract: _IGuardianRecoveryValidator.contract, event: "HashedOriginDomainEnabledForAccount", logs: logs, sub: sub}, nil
+}
+
+// WatchHashedOriginDomainEnabledForAccount is a free log subscription operation binding the contract event 0x49e308297bf7e3373130f54d11e9944d094c586954301b5c7da3b918195c7580.
+//
+// Solidity: event HashedOriginDomainEnabledForAccount(address indexed account, bytes32 indexed hashedOriginDomain)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorFilterer) WatchHashedOriginDomainEnabledForAccount(opts *bind.WatchOpts, sink chan<- *IGuardianRecoveryValidatorHashedOriginDomainEnabledForAccount, account []common.Address, hashedOriginDomain [][32]byte) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+
+	logs, sub, err := _IGuardianRecoveryValidator.contract.WatchLogs(opts, "HashedOriginDomainEnabledForAccount", accountRule, hashedOriginDomainRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(IGuardianRecoveryValidatorHashedOriginDomainEnabledForAccount)
+				if err := _IGuardianRecoveryValidator.contract.UnpackLog(event, "HashedOriginDomainEnabledForAccount", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseHashedOriginDomainEnabledForAccount is a log parse operation binding the contract event 0x49e308297bf7e3373130f54d11e9944d094c586954301b5c7da3b918195c7580.
+//
+// Solidity: event HashedOriginDomainEnabledForAccount(address indexed account, bytes32 indexed hashedOriginDomain)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorFilterer) ParseHashedOriginDomainEnabledForAccount(log types.Log) (*IGuardianRecoveryValidatorHashedOriginDomainEnabledForAccount, error) {
+	event := new(IGuardianRecoveryValidatorHashedOriginDomainEnabledForAccount)
+	if err := _IGuardianRecoveryValidator.contract.UnpackLog(event, "HashedOriginDomainEnabledForAccount", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// IGuardianRecoveryValidatorRecoveryDiscardedIterator is returned from FilterRecoveryDiscarded and is used to iterate over the raw logs and unpacked data for RecoveryDiscarded events raised by the IGuardianRecoveryValidator contract.
+type IGuardianRecoveryValidatorRecoveryDiscardedIterator struct {
+	Event *IGuardianRecoveryValidatorRecoveryDiscarded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *IGuardianRecoveryValidatorRecoveryDiscardedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(IGuardianRecoveryValidatorRecoveryDiscarded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(IGuardianRecoveryValidatorRecoveryDiscarded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *IGuardianRecoveryValidatorRecoveryDiscardedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *IGuardianRecoveryValidatorRecoveryDiscardedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// IGuardianRecoveryValidatorRecoveryDiscarded represents a RecoveryDiscarded event raised by the IGuardianRecoveryValidator contract.
+type IGuardianRecoveryValidatorRecoveryDiscarded struct {
+	Account            common.Address
+	HashedOriginDomain [32]byte
+	HashedCredentialId [32]byte
+	Raw                types.Log // Blockchain specific contextual infos
+}
+
+// FilterRecoveryDiscarded is a free log retrieval operation binding the contract event 0xa4e8705d9ef0c51657f9c64b028c7199ff3cd3ee5d057d6e1088e64580853d13.
+//
+// Solidity: event RecoveryDiscarded(address indexed account, bytes32 indexed hashedOriginDomain, bytes32 indexed hashedCredentialId)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorFilterer) FilterRecoveryDiscarded(opts *bind.FilterOpts, account []common.Address, hashedOriginDomain [][32]byte, hashedCredentialId [][32]byte) (*IGuardianRecoveryValidatorRecoveryDiscardedIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+	var hashedCredentialIdRule []interface{}
+	for _, hashedCredentialIdItem := range hashedCredentialId {
+		hashedCredentialIdRule = append(hashedCredentialIdRule, hashedCredentialIdItem)
+	}
+
+	logs, sub, err := _IGuardianRecoveryValidator.contract.FilterLogs(opts, "RecoveryDiscarded", accountRule, hashedOriginDomainRule, hashedCredentialIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &IGuardianRecoveryValidatorRecoveryDiscardedIterator{contract: _IGuardianRecoveryValidator.contract, event: "RecoveryDiscarded", logs: logs, sub: sub}, nil
+}
+
+// WatchRecoveryDiscarded is a free log subscription operation binding the contract event 0xa4e8705d9ef0c51657f9c64b028c7199ff3cd3ee5d057d6e1088e64580853d13.
+//
+// Solidity: event RecoveryDiscarded(address indexed account, bytes32 indexed hashedOriginDomain, bytes32 indexed hashedCredentialId)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorFilterer) WatchRecoveryDiscarded(opts *bind.WatchOpts, sink chan<- *IGuardianRecoveryValidatorRecoveryDiscarded, account []common.Address, hashedOriginDomain [][32]byte, hashedCredentialId [][32]byte) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+	var hashedCredentialIdRule []interface{}
+	for _, hashedCredentialIdItem := range hashedCredentialId {
+		hashedCredentialIdRule = append(hashedCredentialIdRule, hashedCredentialIdItem)
+	}
+
+	logs, sub, err := _IGuardianRecoveryValidator.contract.WatchLogs(opts, "RecoveryDiscarded", accountRule, hashedOriginDomainRule, hashedCredentialIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(IGuardianRecoveryValidatorRecoveryDiscarded)
+				if err := _IGuardianRecoveryValidator.contract.UnpackLog(event, "RecoveryDiscarded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRecoveryDiscarded is a log parse operation binding the contract event 0xa4e8705d9ef0c51657f9c64b028c7199ff3cd3ee5d057d6e1088e64580853d13.
+//
+// Solidity: event RecoveryDiscarded(address indexed account, bytes32 indexed hashedOriginDomain, bytes32 indexed hashedCredentialId)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorFilterer) ParseRecoveryDiscarded(log types.Log) (*IGuardianRecoveryValidatorRecoveryDiscarded, error) {
+	event := new(IGuardianRecoveryValidatorRecoveryDiscarded)
+	if err := _IGuardianRecoveryValidator.contract.UnpackLog(event, "RecoveryDiscarded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// IGuardianRecoveryValidatorRecoveryFinishedIterator is returned from FilterRecoveryFinished and is used to iterate over the raw logs and unpacked data for RecoveryFinished events raised by the IGuardianRecoveryValidator contract.
+type IGuardianRecoveryValidatorRecoveryFinishedIterator struct {
+	Event *IGuardianRecoveryValidatorRecoveryFinished // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *IGuardianRecoveryValidatorRecoveryFinishedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(IGuardianRecoveryValidatorRecoveryFinished)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(IGuardianRecoveryValidatorRecoveryFinished)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *IGuardianRecoveryValidatorRecoveryFinishedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *IGuardianRecoveryValidatorRecoveryFinishedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// IGuardianRecoveryValidatorRecoveryFinished represents a RecoveryFinished event raised by the IGuardianRecoveryValidator contract.
+type IGuardianRecoveryValidatorRecoveryFinished struct {
+	Account            common.Address
+	HashedOriginDomain [32]byte
+	HashedCredentialId [32]byte
+	Raw                types.Log // Blockchain specific contextual infos
+}
+
+// FilterRecoveryFinished is a free log retrieval operation binding the contract event 0x122f699d3998d7d483d87a65abbdba44780a412ca03b283c5c6fc45b6d7d94d2.
+//
+// Solidity: event RecoveryFinished(address indexed account, bytes32 indexed hashedOriginDomain, bytes32 indexed hashedCredentialId)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorFilterer) FilterRecoveryFinished(opts *bind.FilterOpts, account []common.Address, hashedOriginDomain [][32]byte, hashedCredentialId [][32]byte) (*IGuardianRecoveryValidatorRecoveryFinishedIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+	var hashedCredentialIdRule []interface{}
+	for _, hashedCredentialIdItem := range hashedCredentialId {
+		hashedCredentialIdRule = append(hashedCredentialIdRule, hashedCredentialIdItem)
+	}
+
+	logs, sub, err := _IGuardianRecoveryValidator.contract.FilterLogs(opts, "RecoveryFinished", accountRule, hashedOriginDomainRule, hashedCredentialIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &IGuardianRecoveryValidatorRecoveryFinishedIterator{contract: _IGuardianRecoveryValidator.contract, event: "RecoveryFinished", logs: logs, sub: sub}, nil
+}
+
+// WatchRecoveryFinished is a free log subscription operation binding the contract event 0x122f699d3998d7d483d87a65abbdba44780a412ca03b283c5c6fc45b6d7d94d2.
+//
+// Solidity: event RecoveryFinished(address indexed account, bytes32 indexed hashedOriginDomain, bytes32 indexed hashedCredentialId)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorFilterer) WatchRecoveryFinished(opts *bind.WatchOpts, sink chan<- *IGuardianRecoveryValidatorRecoveryFinished, account []common.Address, hashedOriginDomain [][32]byte, hashedCredentialId [][32]byte) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+	var hashedCredentialIdRule []interface{}
+	for _, hashedCredentialIdItem := range hashedCredentialId {
+		hashedCredentialIdRule = append(hashedCredentialIdRule, hashedCredentialIdItem)
+	}
+
+	logs, sub, err := _IGuardianRecoveryValidator.contract.WatchLogs(opts, "RecoveryFinished", accountRule, hashedOriginDomainRule, hashedCredentialIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(IGuardianRecoveryValidatorRecoveryFinished)
+				if err := _IGuardianRecoveryValidator.contract.UnpackLog(event, "RecoveryFinished", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRecoveryFinished is a log parse operation binding the contract event 0x122f699d3998d7d483d87a65abbdba44780a412ca03b283c5c6fc45b6d7d94d2.
+//
+// Solidity: event RecoveryFinished(address indexed account, bytes32 indexed hashedOriginDomain, bytes32 indexed hashedCredentialId)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorFilterer) ParseRecoveryFinished(log types.Log) (*IGuardianRecoveryValidatorRecoveryFinished, error) {
+	event := new(IGuardianRecoveryValidatorRecoveryFinished)
+	if err := _IGuardianRecoveryValidator.contract.UnpackLog(event, "RecoveryFinished", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// IGuardianRecoveryValidatorRecoveryInitiatedIterator is returned from FilterRecoveryInitiated and is used to iterate over the raw logs and unpacked data for RecoveryInitiated events raised by the IGuardianRecoveryValidator contract.
+type IGuardianRecoveryValidatorRecoveryInitiatedIterator struct {
+	Event *IGuardianRecoveryValidatorRecoveryInitiated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *IGuardianRecoveryValidatorRecoveryInitiatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(IGuardianRecoveryValidatorRecoveryInitiated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(IGuardianRecoveryValidatorRecoveryInitiated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *IGuardianRecoveryValidatorRecoveryInitiatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *IGuardianRecoveryValidatorRecoveryInitiatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// IGuardianRecoveryValidatorRecoveryInitiated represents a RecoveryInitiated event raised by the IGuardianRecoveryValidator contract.
+type IGuardianRecoveryValidatorRecoveryInitiated struct {
+	Account            common.Address
+	HashedOriginDomain [32]byte
+	HashedCredentialId [32]byte
+	Guardian           common.Address
+	Raw                types.Log // Blockchain specific contextual infos
+}
+
+// FilterRecoveryInitiated is a free log retrieval operation binding the contract event 0x750203e1c6151c9136eca3be6c61d060ea236395244e97c72ee3735c131c3802.
+//
+// Solidity: event RecoveryInitiated(address indexed account, bytes32 indexed hashedOriginDomain, bytes32 indexed hashedCredentialId, address guardian)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorFilterer) FilterRecoveryInitiated(opts *bind.FilterOpts, account []common.Address, hashedOriginDomain [][32]byte, hashedCredentialId [][32]byte) (*IGuardianRecoveryValidatorRecoveryInitiatedIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+	var hashedCredentialIdRule []interface{}
+	for _, hashedCredentialIdItem := range hashedCredentialId {
+		hashedCredentialIdRule = append(hashedCredentialIdRule, hashedCredentialIdItem)
+	}
+
+	logs, sub, err := _IGuardianRecoveryValidator.contract.FilterLogs(opts, "RecoveryInitiated", accountRule, hashedOriginDomainRule, hashedCredentialIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &IGuardianRecoveryValidatorRecoveryInitiatedIterator{contract: _IGuardianRecoveryValidator.contract, event: "RecoveryInitiated", logs: logs, sub: sub}, nil
+}
+
+// WatchRecoveryInitiated is a free log subscription operation binding the contract event 0x750203e1c6151c9136eca3be6c61d060ea236395244e97c72ee3735c131c3802.
+//
+// Solidity: event RecoveryInitiated(address indexed account, bytes32 indexed hashedOriginDomain, bytes32 indexed hashedCredentialId, address guardian)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorFilterer) WatchRecoveryInitiated(opts *bind.WatchOpts, sink chan<- *IGuardianRecoveryValidatorRecoveryInitiated, account []common.Address, hashedOriginDomain [][32]byte, hashedCredentialId [][32]byte) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+	var hashedCredentialIdRule []interface{}
+	for _, hashedCredentialIdItem := range hashedCredentialId {
+		hashedCredentialIdRule = append(hashedCredentialIdRule, hashedCredentialIdItem)
+	}
+
+	logs, sub, err := _IGuardianRecoveryValidator.contract.WatchLogs(opts, "RecoveryInitiated", accountRule, hashedOriginDomainRule, hashedCredentialIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(IGuardianRecoveryValidatorRecoveryInitiated)
+				if err := _IGuardianRecoveryValidator.contract.UnpackLog(event, "RecoveryInitiated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRecoveryInitiated is a log parse operation binding the contract event 0x750203e1c6151c9136eca3be6c61d060ea236395244e97c72ee3735c131c3802.
+//
+// Solidity: event RecoveryInitiated(address indexed account, bytes32 indexed hashedOriginDomain, bytes32 indexed hashedCredentialId, address guardian)
+func (_IGuardianRecoveryValidator *IGuardianRecoveryValidatorFilterer) ParseRecoveryInitiated(log types.Log) (*IGuardianRecoveryValidatorRecoveryInitiated, error) {
+	event := new(IGuardianRecoveryValidatorRecoveryInitiated)
+	if err := _IGuardianRecoveryValidator.contract.UnpackLog(event, "RecoveryInitiated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts/zksyncsso/interfaces/ihookmanager/ihookmanager.go
+++ b/contracts/zksyncsso/interfaces/ihookmanager/ihookmanager.go
@@ -1,0 +1,594 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package ihookmanager
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// IHookManagerMetaData contains all meta data concerning the IHookManager contract.
+var IHookManagerMetaData = &bind.MetaData{
+	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"}],\"name\":\"HookAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"}],\"name\":\"HookRemoved\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"},{\"internalType\":\"bytes\",\"name\":\"initData\",\"type\":\"bytes\"}],\"name\":\"addHook\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"isHook\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"}],\"name\":\"listHooks\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"hookList\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"},{\"internalType\":\"bytes\",\"name\":\"deinitData\",\"type\":\"bytes\"}],\"name\":\"removeHook\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"},{\"internalType\":\"bytes\",\"name\":\"deinitData\",\"type\":\"bytes\"}],\"name\":\"unlinkHook\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+}
+
+// IHookManagerABI is the input ABI used to generate the binding from.
+// Deprecated: Use IHookManagerMetaData.ABI instead.
+var IHookManagerABI = IHookManagerMetaData.ABI
+
+// IHookManager is an auto generated Go binding around an Ethereum contract.
+type IHookManager struct {
+	IHookManagerCaller     // Read-only binding to the contract
+	IHookManagerTransactor // Write-only binding to the contract
+	IHookManagerFilterer   // Log filterer for contract events
+}
+
+// IHookManagerCaller is an auto generated read-only Go binding around an Ethereum contract.
+type IHookManagerCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IHookManagerTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type IHookManagerTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IHookManagerFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type IHookManagerFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IHookManagerSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type IHookManagerSession struct {
+	Contract     *IHookManager     // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// IHookManagerCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type IHookManagerCallerSession struct {
+	Contract *IHookManagerCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts       // Call options to use throughout this session
+}
+
+// IHookManagerTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type IHookManagerTransactorSession struct {
+	Contract     *IHookManagerTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts       // Transaction auth options to use throughout this session
+}
+
+// IHookManagerRaw is an auto generated low-level Go binding around an Ethereum contract.
+type IHookManagerRaw struct {
+	Contract *IHookManager // Generic contract binding to access the raw methods on
+}
+
+// IHookManagerCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type IHookManagerCallerRaw struct {
+	Contract *IHookManagerCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// IHookManagerTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type IHookManagerTransactorRaw struct {
+	Contract *IHookManagerTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewIHookManager creates a new instance of IHookManager, bound to a specific deployed contract.
+func NewIHookManager(address common.Address, backend bind.ContractBackend) (*IHookManager, error) {
+	contract, err := bindIHookManager(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &IHookManager{IHookManagerCaller: IHookManagerCaller{contract: contract}, IHookManagerTransactor: IHookManagerTransactor{contract: contract}, IHookManagerFilterer: IHookManagerFilterer{contract: contract}}, nil
+}
+
+// NewIHookManagerCaller creates a new read-only instance of IHookManager, bound to a specific deployed contract.
+func NewIHookManagerCaller(address common.Address, caller bind.ContractCaller) (*IHookManagerCaller, error) {
+	contract, err := bindIHookManager(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IHookManagerCaller{contract: contract}, nil
+}
+
+// NewIHookManagerTransactor creates a new write-only instance of IHookManager, bound to a specific deployed contract.
+func NewIHookManagerTransactor(address common.Address, transactor bind.ContractTransactor) (*IHookManagerTransactor, error) {
+	contract, err := bindIHookManager(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IHookManagerTransactor{contract: contract}, nil
+}
+
+// NewIHookManagerFilterer creates a new log filterer instance of IHookManager, bound to a specific deployed contract.
+func NewIHookManagerFilterer(address common.Address, filterer bind.ContractFilterer) (*IHookManagerFilterer, error) {
+	contract, err := bindIHookManager(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &IHookManagerFilterer{contract: contract}, nil
+}
+
+// bindIHookManager binds a generic wrapper to an already deployed contract.
+func bindIHookManager(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := IHookManagerMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IHookManager *IHookManagerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _IHookManager.Contract.IHookManagerCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IHookManager *IHookManagerRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IHookManager.Contract.IHookManagerTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IHookManager *IHookManagerRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IHookManager.Contract.IHookManagerTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IHookManager *IHookManagerCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _IHookManager.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IHookManager *IHookManagerTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IHookManager.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IHookManager *IHookManagerTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IHookManager.Contract.contract.Transact(opts, method, params...)
+}
+
+// IsHook is a free data retrieval call binding the contract method 0xd2676529.
+//
+// Solidity: function isHook(address addr) view returns(bool)
+func (_IHookManager *IHookManagerCaller) IsHook(opts *bind.CallOpts, addr common.Address) (bool, error) {
+	var out []interface{}
+	err := _IHookManager.contract.Call(opts, &out, "isHook", addr)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsHook is a free data retrieval call binding the contract method 0xd2676529.
+//
+// Solidity: function isHook(address addr) view returns(bool)
+func (_IHookManager *IHookManagerSession) IsHook(addr common.Address) (bool, error) {
+	return _IHookManager.Contract.IsHook(&_IHookManager.CallOpts, addr)
+}
+
+// IsHook is a free data retrieval call binding the contract method 0xd2676529.
+//
+// Solidity: function isHook(address addr) view returns(bool)
+func (_IHookManager *IHookManagerCallerSession) IsHook(addr common.Address) (bool, error) {
+	return _IHookManager.Contract.IsHook(&_IHookManager.CallOpts, addr)
+}
+
+// ListHooks is a free data retrieval call binding the contract method 0xdb8a323f.
+//
+// Solidity: function listHooks(bool isValidation) view returns(address[] hookList)
+func (_IHookManager *IHookManagerCaller) ListHooks(opts *bind.CallOpts, isValidation bool) ([]common.Address, error) {
+	var out []interface{}
+	err := _IHookManager.contract.Call(opts, &out, "listHooks", isValidation)
+
+	if err != nil {
+		return *new([]common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
+
+	return out0, err
+
+}
+
+// ListHooks is a free data retrieval call binding the contract method 0xdb8a323f.
+//
+// Solidity: function listHooks(bool isValidation) view returns(address[] hookList)
+func (_IHookManager *IHookManagerSession) ListHooks(isValidation bool) ([]common.Address, error) {
+	return _IHookManager.Contract.ListHooks(&_IHookManager.CallOpts, isValidation)
+}
+
+// ListHooks is a free data retrieval call binding the contract method 0xdb8a323f.
+//
+// Solidity: function listHooks(bool isValidation) view returns(address[] hookList)
+func (_IHookManager *IHookManagerCallerSession) ListHooks(isValidation bool) ([]common.Address, error) {
+	return _IHookManager.Contract.ListHooks(&_IHookManager.CallOpts, isValidation)
+}
+
+// AddHook is a paid mutator transaction binding the contract method 0x0775a94e.
+//
+// Solidity: function addHook(address hook, bool isValidation, bytes initData) returns()
+func (_IHookManager *IHookManagerTransactor) AddHook(opts *bind.TransactOpts, hook common.Address, isValidation bool, initData []byte) (*types.Transaction, error) {
+	return _IHookManager.contract.Transact(opts, "addHook", hook, isValidation, initData)
+}
+
+// AddHook is a paid mutator transaction binding the contract method 0x0775a94e.
+//
+// Solidity: function addHook(address hook, bool isValidation, bytes initData) returns()
+func (_IHookManager *IHookManagerSession) AddHook(hook common.Address, isValidation bool, initData []byte) (*types.Transaction, error) {
+	return _IHookManager.Contract.AddHook(&_IHookManager.TransactOpts, hook, isValidation, initData)
+}
+
+// AddHook is a paid mutator transaction binding the contract method 0x0775a94e.
+//
+// Solidity: function addHook(address hook, bool isValidation, bytes initData) returns()
+func (_IHookManager *IHookManagerTransactorSession) AddHook(hook common.Address, isValidation bool, initData []byte) (*types.Transaction, error) {
+	return _IHookManager.Contract.AddHook(&_IHookManager.TransactOpts, hook, isValidation, initData)
+}
+
+// RemoveHook is a paid mutator transaction binding the contract method 0xe1551286.
+//
+// Solidity: function removeHook(address hook, bool isValidation, bytes deinitData) returns()
+func (_IHookManager *IHookManagerTransactor) RemoveHook(opts *bind.TransactOpts, hook common.Address, isValidation bool, deinitData []byte) (*types.Transaction, error) {
+	return _IHookManager.contract.Transact(opts, "removeHook", hook, isValidation, deinitData)
+}
+
+// RemoveHook is a paid mutator transaction binding the contract method 0xe1551286.
+//
+// Solidity: function removeHook(address hook, bool isValidation, bytes deinitData) returns()
+func (_IHookManager *IHookManagerSession) RemoveHook(hook common.Address, isValidation bool, deinitData []byte) (*types.Transaction, error) {
+	return _IHookManager.Contract.RemoveHook(&_IHookManager.TransactOpts, hook, isValidation, deinitData)
+}
+
+// RemoveHook is a paid mutator transaction binding the contract method 0xe1551286.
+//
+// Solidity: function removeHook(address hook, bool isValidation, bytes deinitData) returns()
+func (_IHookManager *IHookManagerTransactorSession) RemoveHook(hook common.Address, isValidation bool, deinitData []byte) (*types.Transaction, error) {
+	return _IHookManager.Contract.RemoveHook(&_IHookManager.TransactOpts, hook, isValidation, deinitData)
+}
+
+// UnlinkHook is a paid mutator transaction binding the contract method 0x126c46c1.
+//
+// Solidity: function unlinkHook(address hook, bool isValidation, bytes deinitData) returns()
+func (_IHookManager *IHookManagerTransactor) UnlinkHook(opts *bind.TransactOpts, hook common.Address, isValidation bool, deinitData []byte) (*types.Transaction, error) {
+	return _IHookManager.contract.Transact(opts, "unlinkHook", hook, isValidation, deinitData)
+}
+
+// UnlinkHook is a paid mutator transaction binding the contract method 0x126c46c1.
+//
+// Solidity: function unlinkHook(address hook, bool isValidation, bytes deinitData) returns()
+func (_IHookManager *IHookManagerSession) UnlinkHook(hook common.Address, isValidation bool, deinitData []byte) (*types.Transaction, error) {
+	return _IHookManager.Contract.UnlinkHook(&_IHookManager.TransactOpts, hook, isValidation, deinitData)
+}
+
+// UnlinkHook is a paid mutator transaction binding the contract method 0x126c46c1.
+//
+// Solidity: function unlinkHook(address hook, bool isValidation, bytes deinitData) returns()
+func (_IHookManager *IHookManagerTransactorSession) UnlinkHook(hook common.Address, isValidation bool, deinitData []byte) (*types.Transaction, error) {
+	return _IHookManager.Contract.UnlinkHook(&_IHookManager.TransactOpts, hook, isValidation, deinitData)
+}
+
+// IHookManagerHookAddedIterator is returned from FilterHookAdded and is used to iterate over the raw logs and unpacked data for HookAdded events raised by the IHookManager contract.
+type IHookManagerHookAddedIterator struct {
+	Event *IHookManagerHookAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *IHookManagerHookAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(IHookManagerHookAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(IHookManagerHookAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *IHookManagerHookAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *IHookManagerHookAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// IHookManagerHookAdded represents a HookAdded event raised by the IHookManager contract.
+type IHookManagerHookAdded struct {
+	Hook common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterHookAdded is a free log retrieval operation binding the contract event 0x28e00134722f84e69c391c81e4fe022ee3e61048222a8ea2f98c9f235f797508.
+//
+// Solidity: event HookAdded(address indexed hook)
+func (_IHookManager *IHookManagerFilterer) FilterHookAdded(opts *bind.FilterOpts, hook []common.Address) (*IHookManagerHookAddedIterator, error) {
+
+	var hookRule []interface{}
+	for _, hookItem := range hook {
+		hookRule = append(hookRule, hookItem)
+	}
+
+	logs, sub, err := _IHookManager.contract.FilterLogs(opts, "HookAdded", hookRule)
+	if err != nil {
+		return nil, err
+	}
+	return &IHookManagerHookAddedIterator{contract: _IHookManager.contract, event: "HookAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchHookAdded is a free log subscription operation binding the contract event 0x28e00134722f84e69c391c81e4fe022ee3e61048222a8ea2f98c9f235f797508.
+//
+// Solidity: event HookAdded(address indexed hook)
+func (_IHookManager *IHookManagerFilterer) WatchHookAdded(opts *bind.WatchOpts, sink chan<- *IHookManagerHookAdded, hook []common.Address) (event.Subscription, error) {
+
+	var hookRule []interface{}
+	for _, hookItem := range hook {
+		hookRule = append(hookRule, hookItem)
+	}
+
+	logs, sub, err := _IHookManager.contract.WatchLogs(opts, "HookAdded", hookRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(IHookManagerHookAdded)
+				if err := _IHookManager.contract.UnpackLog(event, "HookAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseHookAdded is a log parse operation binding the contract event 0x28e00134722f84e69c391c81e4fe022ee3e61048222a8ea2f98c9f235f797508.
+//
+// Solidity: event HookAdded(address indexed hook)
+func (_IHookManager *IHookManagerFilterer) ParseHookAdded(log types.Log) (*IHookManagerHookAdded, error) {
+	event := new(IHookManagerHookAdded)
+	if err := _IHookManager.contract.UnpackLog(event, "HookAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// IHookManagerHookRemovedIterator is returned from FilterHookRemoved and is used to iterate over the raw logs and unpacked data for HookRemoved events raised by the IHookManager contract.
+type IHookManagerHookRemovedIterator struct {
+	Event *IHookManagerHookRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *IHookManagerHookRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(IHookManagerHookRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(IHookManagerHookRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *IHookManagerHookRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *IHookManagerHookRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// IHookManagerHookRemoved represents a HookRemoved event raised by the IHookManager contract.
+type IHookManagerHookRemoved struct {
+	Hook common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterHookRemoved is a free log retrieval operation binding the contract event 0x47d0871e905ac6550f54ba266e0d90d2dc8ed67a957c064ca3438eddf4e3fd89.
+//
+// Solidity: event HookRemoved(address indexed hook)
+func (_IHookManager *IHookManagerFilterer) FilterHookRemoved(opts *bind.FilterOpts, hook []common.Address) (*IHookManagerHookRemovedIterator, error) {
+
+	var hookRule []interface{}
+	for _, hookItem := range hook {
+		hookRule = append(hookRule, hookItem)
+	}
+
+	logs, sub, err := _IHookManager.contract.FilterLogs(opts, "HookRemoved", hookRule)
+	if err != nil {
+		return nil, err
+	}
+	return &IHookManagerHookRemovedIterator{contract: _IHookManager.contract, event: "HookRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchHookRemoved is a free log subscription operation binding the contract event 0x47d0871e905ac6550f54ba266e0d90d2dc8ed67a957c064ca3438eddf4e3fd89.
+//
+// Solidity: event HookRemoved(address indexed hook)
+func (_IHookManager *IHookManagerFilterer) WatchHookRemoved(opts *bind.WatchOpts, sink chan<- *IHookManagerHookRemoved, hook []common.Address) (event.Subscription, error) {
+
+	var hookRule []interface{}
+	for _, hookItem := range hook {
+		hookRule = append(hookRule, hookItem)
+	}
+
+	logs, sub, err := _IHookManager.contract.WatchLogs(opts, "HookRemoved", hookRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(IHookManagerHookRemoved)
+				if err := _IHookManager.contract.UnpackLog(event, "HookRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseHookRemoved is a log parse operation binding the contract event 0x47d0871e905ac6550f54ba266e0d90d2dc8ed67a957c064ca3438eddf4e3fd89.
+//
+// Solidity: event HookRemoved(address indexed hook)
+func (_IHookManager *IHookManagerFilterer) ParseHookRemoved(log types.Log) (*IHookManagerHookRemoved, error) {
+	event := new(IHookManagerHookRemoved)
+	if err := _IHookManager.contract.UnpackLog(event, "HookRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts/zksyncsso/interfaces/imodule/imodule.go
+++ b/contracts/zksyncsso/interfaces/imodule/imodule.go
@@ -1,0 +1,223 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package imodule
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// IModuleMetaData contains all meta data concerning the IModule contract.
+var IModuleMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"onInstall\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"onUninstall\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+}
+
+// IModuleABI is the input ABI used to generate the binding from.
+// Deprecated: Use IModuleMetaData.ABI instead.
+var IModuleABI = IModuleMetaData.ABI
+
+// IModule is an auto generated Go binding around an Ethereum contract.
+type IModule struct {
+	IModuleCaller     // Read-only binding to the contract
+	IModuleTransactor // Write-only binding to the contract
+	IModuleFilterer   // Log filterer for contract events
+}
+
+// IModuleCaller is an auto generated read-only Go binding around an Ethereum contract.
+type IModuleCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IModuleTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type IModuleTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IModuleFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type IModuleFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IModuleSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type IModuleSession struct {
+	Contract     *IModule          // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// IModuleCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type IModuleCallerSession struct {
+	Contract *IModuleCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts  // Call options to use throughout this session
+}
+
+// IModuleTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type IModuleTransactorSession struct {
+	Contract     *IModuleTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts  // Transaction auth options to use throughout this session
+}
+
+// IModuleRaw is an auto generated low-level Go binding around an Ethereum contract.
+type IModuleRaw struct {
+	Contract *IModule // Generic contract binding to access the raw methods on
+}
+
+// IModuleCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type IModuleCallerRaw struct {
+	Contract *IModuleCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// IModuleTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type IModuleTransactorRaw struct {
+	Contract *IModuleTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewIModule creates a new instance of IModule, bound to a specific deployed contract.
+func NewIModule(address common.Address, backend bind.ContractBackend) (*IModule, error) {
+	contract, err := bindIModule(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &IModule{IModuleCaller: IModuleCaller{contract: contract}, IModuleTransactor: IModuleTransactor{contract: contract}, IModuleFilterer: IModuleFilterer{contract: contract}}, nil
+}
+
+// NewIModuleCaller creates a new read-only instance of IModule, bound to a specific deployed contract.
+func NewIModuleCaller(address common.Address, caller bind.ContractCaller) (*IModuleCaller, error) {
+	contract, err := bindIModule(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IModuleCaller{contract: contract}, nil
+}
+
+// NewIModuleTransactor creates a new write-only instance of IModule, bound to a specific deployed contract.
+func NewIModuleTransactor(address common.Address, transactor bind.ContractTransactor) (*IModuleTransactor, error) {
+	contract, err := bindIModule(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IModuleTransactor{contract: contract}, nil
+}
+
+// NewIModuleFilterer creates a new log filterer instance of IModule, bound to a specific deployed contract.
+func NewIModuleFilterer(address common.Address, filterer bind.ContractFilterer) (*IModuleFilterer, error) {
+	contract, err := bindIModule(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &IModuleFilterer{contract: contract}, nil
+}
+
+// bindIModule binds a generic wrapper to an already deployed contract.
+func bindIModule(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := IModuleMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IModule *IModuleRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _IModule.Contract.IModuleCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IModule *IModuleRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IModule.Contract.IModuleTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IModule *IModuleRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IModule.Contract.IModuleTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IModule *IModuleCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _IModule.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IModule *IModuleTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IModule.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IModule *IModuleTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IModule.Contract.contract.Transact(opts, method, params...)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_IModule *IModuleTransactor) OnInstall(opts *bind.TransactOpts, data []byte) (*types.Transaction, error) {
+	return _IModule.contract.Transact(opts, "onInstall", data)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_IModule *IModuleSession) OnInstall(data []byte) (*types.Transaction, error) {
+	return _IModule.Contract.OnInstall(&_IModule.TransactOpts, data)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_IModule *IModuleTransactorSession) OnInstall(data []byte) (*types.Transaction, error) {
+	return _IModule.Contract.OnInstall(&_IModule.TransactOpts, data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_IModule *IModuleTransactor) OnUninstall(opts *bind.TransactOpts, data []byte) (*types.Transaction, error) {
+	return _IModule.contract.Transact(opts, "onUninstall", data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_IModule *IModuleSession) OnUninstall(data []byte) (*types.Transaction, error) {
+	return _IModule.Contract.OnUninstall(&_IModule.TransactOpts, data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_IModule *IModuleTransactorSession) OnUninstall(data []byte) (*types.Transaction, error) {
+	return _IModule.Contract.OnUninstall(&_IModule.TransactOpts, data)
+}

--- a/contracts/zksyncsso/interfaces/imodulevalidator/imodulevalidator.go
+++ b/contracts/zksyncsso/interfaces/imodulevalidator/imodulevalidator.go
@@ -1,0 +1,326 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package imodulevalidator
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// Transaction is an auto generated low-level Go binding around an user-defined struct.
+type Transaction struct {
+	TxType                 *big.Int
+	From                   *big.Int
+	To                     *big.Int
+	GasLimit               *big.Int
+	GasPerPubdataByteLimit *big.Int
+	MaxFeePerGas           *big.Int
+	MaxPriorityFeePerGas   *big.Int
+	Paymaster              *big.Int
+	Nonce                  *big.Int
+	Value                  *big.Int
+	Reserved               [4]*big.Int
+	Data                   []byte
+	Signature              []byte
+	FactoryDeps            [][32]byte
+	PaymasterInput         []byte
+	ReservedDynamic        []byte
+}
+
+// IModuleValidatorMetaData contains all meta data concerning the IModuleValidator contract.
+var IModuleValidatorMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"onInstall\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"onUninstall\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"}],\"name\":\"supportsInterface\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"signedHash\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"}],\"name\":\"validateSignature\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"signedHash\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[]\",\"name\":\"factoryDeps\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"reservedDynamic\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"transaction\",\"type\":\"tuple\"}],\"name\":\"validateTransaction\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+}
+
+// IModuleValidatorABI is the input ABI used to generate the binding from.
+// Deprecated: Use IModuleValidatorMetaData.ABI instead.
+var IModuleValidatorABI = IModuleValidatorMetaData.ABI
+
+// IModuleValidator is an auto generated Go binding around an Ethereum contract.
+type IModuleValidator struct {
+	IModuleValidatorCaller     // Read-only binding to the contract
+	IModuleValidatorTransactor // Write-only binding to the contract
+	IModuleValidatorFilterer   // Log filterer for contract events
+}
+
+// IModuleValidatorCaller is an auto generated read-only Go binding around an Ethereum contract.
+type IModuleValidatorCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IModuleValidatorTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type IModuleValidatorTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IModuleValidatorFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type IModuleValidatorFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IModuleValidatorSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type IModuleValidatorSession struct {
+	Contract     *IModuleValidator // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// IModuleValidatorCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type IModuleValidatorCallerSession struct {
+	Contract *IModuleValidatorCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts           // Call options to use throughout this session
+}
+
+// IModuleValidatorTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type IModuleValidatorTransactorSession struct {
+	Contract     *IModuleValidatorTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts           // Transaction auth options to use throughout this session
+}
+
+// IModuleValidatorRaw is an auto generated low-level Go binding around an Ethereum contract.
+type IModuleValidatorRaw struct {
+	Contract *IModuleValidator // Generic contract binding to access the raw methods on
+}
+
+// IModuleValidatorCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type IModuleValidatorCallerRaw struct {
+	Contract *IModuleValidatorCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// IModuleValidatorTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type IModuleValidatorTransactorRaw struct {
+	Contract *IModuleValidatorTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewIModuleValidator creates a new instance of IModuleValidator, bound to a specific deployed contract.
+func NewIModuleValidator(address common.Address, backend bind.ContractBackend) (*IModuleValidator, error) {
+	contract, err := bindIModuleValidator(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &IModuleValidator{IModuleValidatorCaller: IModuleValidatorCaller{contract: contract}, IModuleValidatorTransactor: IModuleValidatorTransactor{contract: contract}, IModuleValidatorFilterer: IModuleValidatorFilterer{contract: contract}}, nil
+}
+
+// NewIModuleValidatorCaller creates a new read-only instance of IModuleValidator, bound to a specific deployed contract.
+func NewIModuleValidatorCaller(address common.Address, caller bind.ContractCaller) (*IModuleValidatorCaller, error) {
+	contract, err := bindIModuleValidator(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IModuleValidatorCaller{contract: contract}, nil
+}
+
+// NewIModuleValidatorTransactor creates a new write-only instance of IModuleValidator, bound to a specific deployed contract.
+func NewIModuleValidatorTransactor(address common.Address, transactor bind.ContractTransactor) (*IModuleValidatorTransactor, error) {
+	contract, err := bindIModuleValidator(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IModuleValidatorTransactor{contract: contract}, nil
+}
+
+// NewIModuleValidatorFilterer creates a new log filterer instance of IModuleValidator, bound to a specific deployed contract.
+func NewIModuleValidatorFilterer(address common.Address, filterer bind.ContractFilterer) (*IModuleValidatorFilterer, error) {
+	contract, err := bindIModuleValidator(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &IModuleValidatorFilterer{contract: contract}, nil
+}
+
+// bindIModuleValidator binds a generic wrapper to an already deployed contract.
+func bindIModuleValidator(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := IModuleValidatorMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IModuleValidator *IModuleValidatorRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _IModuleValidator.Contract.IModuleValidatorCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IModuleValidator *IModuleValidatorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IModuleValidator.Contract.IModuleValidatorTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IModuleValidator *IModuleValidatorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IModuleValidator.Contract.IModuleValidatorTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IModuleValidator *IModuleValidatorCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _IModuleValidator.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IModuleValidator *IModuleValidatorTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IModuleValidator.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IModuleValidator *IModuleValidatorTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IModuleValidator.Contract.contract.Transact(opts, method, params...)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_IModuleValidator *IModuleValidatorCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _IModuleValidator.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_IModuleValidator *IModuleValidatorSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _IModuleValidator.Contract.SupportsInterface(&_IModuleValidator.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_IModuleValidator *IModuleValidatorCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _IModuleValidator.Contract.SupportsInterface(&_IModuleValidator.CallOpts, interfaceId)
+}
+
+// ValidateSignature is a free data retrieval call binding the contract method 0x333daf92.
+//
+// Solidity: function validateSignature(bytes32 signedHash, bytes signature) view returns(bool)
+func (_IModuleValidator *IModuleValidatorCaller) ValidateSignature(opts *bind.CallOpts, signedHash [32]byte, signature []byte) (bool, error) {
+	var out []interface{}
+	err := _IModuleValidator.contract.Call(opts, &out, "validateSignature", signedHash, signature)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// ValidateSignature is a free data retrieval call binding the contract method 0x333daf92.
+//
+// Solidity: function validateSignature(bytes32 signedHash, bytes signature) view returns(bool)
+func (_IModuleValidator *IModuleValidatorSession) ValidateSignature(signedHash [32]byte, signature []byte) (bool, error) {
+	return _IModuleValidator.Contract.ValidateSignature(&_IModuleValidator.CallOpts, signedHash, signature)
+}
+
+// ValidateSignature is a free data retrieval call binding the contract method 0x333daf92.
+//
+// Solidity: function validateSignature(bytes32 signedHash, bytes signature) view returns(bool)
+func (_IModuleValidator *IModuleValidatorCallerSession) ValidateSignature(signedHash [32]byte, signature []byte) (bool, error) {
+	return _IModuleValidator.Contract.ValidateSignature(&_IModuleValidator.CallOpts, signedHash, signature)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_IModuleValidator *IModuleValidatorTransactor) OnInstall(opts *bind.TransactOpts, data []byte) (*types.Transaction, error) {
+	return _IModuleValidator.contract.Transact(opts, "onInstall", data)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_IModuleValidator *IModuleValidatorSession) OnInstall(data []byte) (*types.Transaction, error) {
+	return _IModuleValidator.Contract.OnInstall(&_IModuleValidator.TransactOpts, data)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_IModuleValidator *IModuleValidatorTransactorSession) OnInstall(data []byte) (*types.Transaction, error) {
+	return _IModuleValidator.Contract.OnInstall(&_IModuleValidator.TransactOpts, data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_IModuleValidator *IModuleValidatorTransactor) OnUninstall(opts *bind.TransactOpts, data []byte) (*types.Transaction, error) {
+	return _IModuleValidator.contract.Transact(opts, "onUninstall", data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_IModuleValidator *IModuleValidatorSession) OnUninstall(data []byte) (*types.Transaction, error) {
+	return _IModuleValidator.Contract.OnUninstall(&_IModuleValidator.TransactOpts, data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_IModuleValidator *IModuleValidatorTransactorSession) OnUninstall(data []byte) (*types.Transaction, error) {
+	return _IModuleValidator.Contract.OnUninstall(&_IModuleValidator.TransactOpts, data)
+}
+
+// ValidateTransaction is a paid mutator transaction binding the contract method 0xbf1733f9.
+//
+// Solidity: function validateTransaction(bytes32 signedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) returns(bool)
+func (_IModuleValidator *IModuleValidatorTransactor) ValidateTransaction(opts *bind.TransactOpts, signedHash [32]byte, transaction Transaction) (*types.Transaction, error) {
+	return _IModuleValidator.contract.Transact(opts, "validateTransaction", signedHash, transaction)
+}
+
+// ValidateTransaction is a paid mutator transaction binding the contract method 0xbf1733f9.
+//
+// Solidity: function validateTransaction(bytes32 signedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) returns(bool)
+func (_IModuleValidator *IModuleValidatorSession) ValidateTransaction(signedHash [32]byte, transaction Transaction) (*types.Transaction, error) {
+	return _IModuleValidator.Contract.ValidateTransaction(&_IModuleValidator.TransactOpts, signedHash, transaction)
+}
+
+// ValidateTransaction is a paid mutator transaction binding the contract method 0xbf1733f9.
+//
+// Solidity: function validateTransaction(bytes32 signedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) returns(bool)
+func (_IModuleValidator *IModuleValidatorTransactorSession) ValidateTransaction(signedHash [32]byte, transaction Transaction) (*types.Transaction, error) {
+	return _IModuleValidator.Contract.ValidateTransaction(&_IModuleValidator.TransactOpts, signedHash, transaction)
+}

--- a/contracts/zksyncsso/interfaces/iownermanager/iownermanager.go
+++ b/contracts/zksyncsso/interfaces/iownermanager/iownermanager.go
@@ -1,0 +1,573 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package iownermanager
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// IOwnerManagerMetaData contains all meta data concerning the IOwnerManager contract.
+var IOwnerManagerMetaData = &bind.MetaData{
+	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"K1OwnerAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"K1OwnerRemoved\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"addK1Owner\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"isK1Owner\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"listK1Owners\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"k1OwnerList\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"removeK1Owner\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+}
+
+// IOwnerManagerABI is the input ABI used to generate the binding from.
+// Deprecated: Use IOwnerManagerMetaData.ABI instead.
+var IOwnerManagerABI = IOwnerManagerMetaData.ABI
+
+// IOwnerManager is an auto generated Go binding around an Ethereum contract.
+type IOwnerManager struct {
+	IOwnerManagerCaller     // Read-only binding to the contract
+	IOwnerManagerTransactor // Write-only binding to the contract
+	IOwnerManagerFilterer   // Log filterer for contract events
+}
+
+// IOwnerManagerCaller is an auto generated read-only Go binding around an Ethereum contract.
+type IOwnerManagerCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IOwnerManagerTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type IOwnerManagerTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IOwnerManagerFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type IOwnerManagerFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IOwnerManagerSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type IOwnerManagerSession struct {
+	Contract     *IOwnerManager    // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// IOwnerManagerCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type IOwnerManagerCallerSession struct {
+	Contract *IOwnerManagerCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts        // Call options to use throughout this session
+}
+
+// IOwnerManagerTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type IOwnerManagerTransactorSession struct {
+	Contract     *IOwnerManagerTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts        // Transaction auth options to use throughout this session
+}
+
+// IOwnerManagerRaw is an auto generated low-level Go binding around an Ethereum contract.
+type IOwnerManagerRaw struct {
+	Contract *IOwnerManager // Generic contract binding to access the raw methods on
+}
+
+// IOwnerManagerCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type IOwnerManagerCallerRaw struct {
+	Contract *IOwnerManagerCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// IOwnerManagerTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type IOwnerManagerTransactorRaw struct {
+	Contract *IOwnerManagerTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewIOwnerManager creates a new instance of IOwnerManager, bound to a specific deployed contract.
+func NewIOwnerManager(address common.Address, backend bind.ContractBackend) (*IOwnerManager, error) {
+	contract, err := bindIOwnerManager(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &IOwnerManager{IOwnerManagerCaller: IOwnerManagerCaller{contract: contract}, IOwnerManagerTransactor: IOwnerManagerTransactor{contract: contract}, IOwnerManagerFilterer: IOwnerManagerFilterer{contract: contract}}, nil
+}
+
+// NewIOwnerManagerCaller creates a new read-only instance of IOwnerManager, bound to a specific deployed contract.
+func NewIOwnerManagerCaller(address common.Address, caller bind.ContractCaller) (*IOwnerManagerCaller, error) {
+	contract, err := bindIOwnerManager(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IOwnerManagerCaller{contract: contract}, nil
+}
+
+// NewIOwnerManagerTransactor creates a new write-only instance of IOwnerManager, bound to a specific deployed contract.
+func NewIOwnerManagerTransactor(address common.Address, transactor bind.ContractTransactor) (*IOwnerManagerTransactor, error) {
+	contract, err := bindIOwnerManager(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IOwnerManagerTransactor{contract: contract}, nil
+}
+
+// NewIOwnerManagerFilterer creates a new log filterer instance of IOwnerManager, bound to a specific deployed contract.
+func NewIOwnerManagerFilterer(address common.Address, filterer bind.ContractFilterer) (*IOwnerManagerFilterer, error) {
+	contract, err := bindIOwnerManager(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &IOwnerManagerFilterer{contract: contract}, nil
+}
+
+// bindIOwnerManager binds a generic wrapper to an already deployed contract.
+func bindIOwnerManager(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := IOwnerManagerMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IOwnerManager *IOwnerManagerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _IOwnerManager.Contract.IOwnerManagerCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IOwnerManager *IOwnerManagerRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IOwnerManager.Contract.IOwnerManagerTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IOwnerManager *IOwnerManagerRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IOwnerManager.Contract.IOwnerManagerTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IOwnerManager *IOwnerManagerCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _IOwnerManager.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IOwnerManager *IOwnerManagerTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IOwnerManager.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IOwnerManager *IOwnerManagerTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IOwnerManager.Contract.contract.Transact(opts, method, params...)
+}
+
+// IsK1Owner is a free data retrieval call binding the contract method 0x6e354cb8.
+//
+// Solidity: function isK1Owner(address addr) view returns(bool)
+func (_IOwnerManager *IOwnerManagerCaller) IsK1Owner(opts *bind.CallOpts, addr common.Address) (bool, error) {
+	var out []interface{}
+	err := _IOwnerManager.contract.Call(opts, &out, "isK1Owner", addr)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsK1Owner is a free data retrieval call binding the contract method 0x6e354cb8.
+//
+// Solidity: function isK1Owner(address addr) view returns(bool)
+func (_IOwnerManager *IOwnerManagerSession) IsK1Owner(addr common.Address) (bool, error) {
+	return _IOwnerManager.Contract.IsK1Owner(&_IOwnerManager.CallOpts, addr)
+}
+
+// IsK1Owner is a free data retrieval call binding the contract method 0x6e354cb8.
+//
+// Solidity: function isK1Owner(address addr) view returns(bool)
+func (_IOwnerManager *IOwnerManagerCallerSession) IsK1Owner(addr common.Address) (bool, error) {
+	return _IOwnerManager.Contract.IsK1Owner(&_IOwnerManager.CallOpts, addr)
+}
+
+// ListK1Owners is a free data retrieval call binding the contract method 0x4f16eec8.
+//
+// Solidity: function listK1Owners() view returns(address[] k1OwnerList)
+func (_IOwnerManager *IOwnerManagerCaller) ListK1Owners(opts *bind.CallOpts) ([]common.Address, error) {
+	var out []interface{}
+	err := _IOwnerManager.contract.Call(opts, &out, "listK1Owners")
+
+	if err != nil {
+		return *new([]common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
+
+	return out0, err
+
+}
+
+// ListK1Owners is a free data retrieval call binding the contract method 0x4f16eec8.
+//
+// Solidity: function listK1Owners() view returns(address[] k1OwnerList)
+func (_IOwnerManager *IOwnerManagerSession) ListK1Owners() ([]common.Address, error) {
+	return _IOwnerManager.Contract.ListK1Owners(&_IOwnerManager.CallOpts)
+}
+
+// ListK1Owners is a free data retrieval call binding the contract method 0x4f16eec8.
+//
+// Solidity: function listK1Owners() view returns(address[] k1OwnerList)
+func (_IOwnerManager *IOwnerManagerCallerSession) ListK1Owners() ([]common.Address, error) {
+	return _IOwnerManager.Contract.ListK1Owners(&_IOwnerManager.CallOpts)
+}
+
+// AddK1Owner is a paid mutator transaction binding the contract method 0x23cef13e.
+//
+// Solidity: function addK1Owner(address addr) returns()
+func (_IOwnerManager *IOwnerManagerTransactor) AddK1Owner(opts *bind.TransactOpts, addr common.Address) (*types.Transaction, error) {
+	return _IOwnerManager.contract.Transact(opts, "addK1Owner", addr)
+}
+
+// AddK1Owner is a paid mutator transaction binding the contract method 0x23cef13e.
+//
+// Solidity: function addK1Owner(address addr) returns()
+func (_IOwnerManager *IOwnerManagerSession) AddK1Owner(addr common.Address) (*types.Transaction, error) {
+	return _IOwnerManager.Contract.AddK1Owner(&_IOwnerManager.TransactOpts, addr)
+}
+
+// AddK1Owner is a paid mutator transaction binding the contract method 0x23cef13e.
+//
+// Solidity: function addK1Owner(address addr) returns()
+func (_IOwnerManager *IOwnerManagerTransactorSession) AddK1Owner(addr common.Address) (*types.Transaction, error) {
+	return _IOwnerManager.Contract.AddK1Owner(&_IOwnerManager.TransactOpts, addr)
+}
+
+// RemoveK1Owner is a paid mutator transaction binding the contract method 0x714da018.
+//
+// Solidity: function removeK1Owner(address addr) returns()
+func (_IOwnerManager *IOwnerManagerTransactor) RemoveK1Owner(opts *bind.TransactOpts, addr common.Address) (*types.Transaction, error) {
+	return _IOwnerManager.contract.Transact(opts, "removeK1Owner", addr)
+}
+
+// RemoveK1Owner is a paid mutator transaction binding the contract method 0x714da018.
+//
+// Solidity: function removeK1Owner(address addr) returns()
+func (_IOwnerManager *IOwnerManagerSession) RemoveK1Owner(addr common.Address) (*types.Transaction, error) {
+	return _IOwnerManager.Contract.RemoveK1Owner(&_IOwnerManager.TransactOpts, addr)
+}
+
+// RemoveK1Owner is a paid mutator transaction binding the contract method 0x714da018.
+//
+// Solidity: function removeK1Owner(address addr) returns()
+func (_IOwnerManager *IOwnerManagerTransactorSession) RemoveK1Owner(addr common.Address) (*types.Transaction, error) {
+	return _IOwnerManager.Contract.RemoveK1Owner(&_IOwnerManager.TransactOpts, addr)
+}
+
+// IOwnerManagerK1OwnerAddedIterator is returned from FilterK1OwnerAdded and is used to iterate over the raw logs and unpacked data for K1OwnerAdded events raised by the IOwnerManager contract.
+type IOwnerManagerK1OwnerAddedIterator struct {
+	Event *IOwnerManagerK1OwnerAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *IOwnerManagerK1OwnerAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(IOwnerManagerK1OwnerAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(IOwnerManagerK1OwnerAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *IOwnerManagerK1OwnerAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *IOwnerManagerK1OwnerAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// IOwnerManagerK1OwnerAdded represents a K1OwnerAdded event raised by the IOwnerManager contract.
+type IOwnerManagerK1OwnerAdded struct {
+	Addr common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterK1OwnerAdded is a free log retrieval operation binding the contract event 0x40097f116787d282c09163d089084b2d950545433dad84146baf8da81064e84c.
+//
+// Solidity: event K1OwnerAdded(address indexed addr)
+func (_IOwnerManager *IOwnerManagerFilterer) FilterK1OwnerAdded(opts *bind.FilterOpts, addr []common.Address) (*IOwnerManagerK1OwnerAddedIterator, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+
+	logs, sub, err := _IOwnerManager.contract.FilterLogs(opts, "K1OwnerAdded", addrRule)
+	if err != nil {
+		return nil, err
+	}
+	return &IOwnerManagerK1OwnerAddedIterator{contract: _IOwnerManager.contract, event: "K1OwnerAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchK1OwnerAdded is a free log subscription operation binding the contract event 0x40097f116787d282c09163d089084b2d950545433dad84146baf8da81064e84c.
+//
+// Solidity: event K1OwnerAdded(address indexed addr)
+func (_IOwnerManager *IOwnerManagerFilterer) WatchK1OwnerAdded(opts *bind.WatchOpts, sink chan<- *IOwnerManagerK1OwnerAdded, addr []common.Address) (event.Subscription, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+
+	logs, sub, err := _IOwnerManager.contract.WatchLogs(opts, "K1OwnerAdded", addrRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(IOwnerManagerK1OwnerAdded)
+				if err := _IOwnerManager.contract.UnpackLog(event, "K1OwnerAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseK1OwnerAdded is a log parse operation binding the contract event 0x40097f116787d282c09163d089084b2d950545433dad84146baf8da81064e84c.
+//
+// Solidity: event K1OwnerAdded(address indexed addr)
+func (_IOwnerManager *IOwnerManagerFilterer) ParseK1OwnerAdded(log types.Log) (*IOwnerManagerK1OwnerAdded, error) {
+	event := new(IOwnerManagerK1OwnerAdded)
+	if err := _IOwnerManager.contract.UnpackLog(event, "K1OwnerAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// IOwnerManagerK1OwnerRemovedIterator is returned from FilterK1OwnerRemoved and is used to iterate over the raw logs and unpacked data for K1OwnerRemoved events raised by the IOwnerManager contract.
+type IOwnerManagerK1OwnerRemovedIterator struct {
+	Event *IOwnerManagerK1OwnerRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *IOwnerManagerK1OwnerRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(IOwnerManagerK1OwnerRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(IOwnerManagerK1OwnerRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *IOwnerManagerK1OwnerRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *IOwnerManagerK1OwnerRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// IOwnerManagerK1OwnerRemoved represents a K1OwnerRemoved event raised by the IOwnerManager contract.
+type IOwnerManagerK1OwnerRemoved struct {
+	Addr common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterK1OwnerRemoved is a free log retrieval operation binding the contract event 0xe09f0b842a072d50a0b373f3255e2a4216aeb61908e35a93a499f0ff2aa4c8fa.
+//
+// Solidity: event K1OwnerRemoved(address indexed addr)
+func (_IOwnerManager *IOwnerManagerFilterer) FilterK1OwnerRemoved(opts *bind.FilterOpts, addr []common.Address) (*IOwnerManagerK1OwnerRemovedIterator, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+
+	logs, sub, err := _IOwnerManager.contract.FilterLogs(opts, "K1OwnerRemoved", addrRule)
+	if err != nil {
+		return nil, err
+	}
+	return &IOwnerManagerK1OwnerRemovedIterator{contract: _IOwnerManager.contract, event: "K1OwnerRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchK1OwnerRemoved is a free log subscription operation binding the contract event 0xe09f0b842a072d50a0b373f3255e2a4216aeb61908e35a93a499f0ff2aa4c8fa.
+//
+// Solidity: event K1OwnerRemoved(address indexed addr)
+func (_IOwnerManager *IOwnerManagerFilterer) WatchK1OwnerRemoved(opts *bind.WatchOpts, sink chan<- *IOwnerManagerK1OwnerRemoved, addr []common.Address) (event.Subscription, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+
+	logs, sub, err := _IOwnerManager.contract.WatchLogs(opts, "K1OwnerRemoved", addrRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(IOwnerManagerK1OwnerRemoved)
+				if err := _IOwnerManager.contract.UnpackLog(event, "K1OwnerRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseK1OwnerRemoved is a log parse operation binding the contract event 0xe09f0b842a072d50a0b373f3255e2a4216aeb61908e35a93a499f0ff2aa4c8fa.
+//
+// Solidity: event K1OwnerRemoved(address indexed addr)
+func (_IOwnerManager *IOwnerManagerFilterer) ParseK1OwnerRemoved(log types.Log) (*IOwnerManagerK1OwnerRemoved, error) {
+	event := new(IOwnerManagerK1OwnerRemoved)
+	if err := _IOwnerManager.contract.UnpackLog(event, "K1OwnerRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts/zksyncsso/interfaces/issoaccount/issoaccount.go
+++ b/contracts/zksyncsso/interfaces/issoaccount/issoaccount.go
@@ -1,0 +1,1670 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package issoaccount
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// Transaction is an auto generated low-level Go binding around an user-defined struct.
+type Transaction struct {
+	TxType                 *big.Int
+	From                   *big.Int
+	To                     *big.Int
+	GasLimit               *big.Int
+	GasPerPubdataByteLimit *big.Int
+	MaxFeePerGas           *big.Int
+	MaxPriorityFeePerGas   *big.Int
+	Paymaster              *big.Int
+	Nonce                  *big.Int
+	Value                  *big.Int
+	Reserved               [4]*big.Int
+	Data                   []byte
+	Signature              []byte
+	FactoryDeps            [][32]byte
+	PaymasterInput         []byte
+	ReservedDynamic        []byte
+}
+
+// ISsoAccountMetaData contains all meta data concerning the ISsoAccount contract.
+var ISsoAccountMetaData = &bind.MetaData{
+	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"}],\"name\":\"HookAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"}],\"name\":\"HookRemoved\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"K1OwnerAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"K1OwnerRemoved\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"ValidatorAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"ValidatorRemoved\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"},{\"internalType\":\"bytes\",\"name\":\"initData\",\"type\":\"bytes\"}],\"name\":\"addHook\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"addK1Owner\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"initData\",\"type\":\"bytes\"}],\"name\":\"addModuleValidator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"_txHash\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"_suggestedSignedHash\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[]\",\"name\":\"factoryDeps\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"reservedDynamic\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"_transaction\",\"type\":\"tuple\"}],\"name\":\"executeTransaction\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[]\",\"name\":\"factoryDeps\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"reservedDynamic\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"_transaction\",\"type\":\"tuple\"}],\"name\":\"executeTransactionFromOutside\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes[]\",\"name\":\"initialValidators\",\"type\":\"bytes[]\"},{\"internalType\":\"address[]\",\"name\":\"initialK1Owners\",\"type\":\"address[]\"}],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"isHook\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"isK1Owner\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"isModuleValidator\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"hash\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"}],\"name\":\"isValidSignature\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"magicValue\",\"type\":\"bytes4\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"}],\"name\":\"listHooks\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"hookList\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"listK1Owners\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"k1OwnerList\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"listModuleValidators\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"validatorList\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"uint256[]\",\"name\":\"ids\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256[]\",\"name\":\"values\",\"type\":\"uint256[]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"onERC1155BatchReceived\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"\",\"type\":\"bytes4\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"onERC1155Received\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"\",\"type\":\"bytes4\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operator\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"tokenId\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"onERC721Received\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"\",\"type\":\"bytes4\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"_txHash\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"_suggestedSignedHash\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[]\",\"name\":\"factoryDeps\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"reservedDynamic\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"_transaction\",\"type\":\"tuple\"}],\"name\":\"payForTransaction\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"_txHash\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"_possibleSignedHash\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[]\",\"name\":\"factoryDeps\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"reservedDynamic\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"_transaction\",\"type\":\"tuple\"}],\"name\":\"prepareForPaymaster\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"},{\"internalType\":\"bytes\",\"name\":\"deinitData\",\"type\":\"bytes\"}],\"name\":\"removeHook\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"removeK1Owner\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"deinitData\",\"type\":\"bytes\"}],\"name\":\"removeModuleValidator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"}],\"name\":\"supportsInterface\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"},{\"internalType\":\"bytes\",\"name\":\"deinitData\",\"type\":\"bytes\"}],\"name\":\"unlinkHook\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"deinitData\",\"type\":\"bytes\"}],\"name\":\"unlinkModuleValidator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"_txHash\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"_suggestedSignedHash\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[]\",\"name\":\"factoryDeps\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"reservedDynamic\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"_transaction\",\"type\":\"tuple\"}],\"name\":\"validateTransaction\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"magic\",\"type\":\"bytes4\"}],\"stateMutability\":\"payable\",\"type\":\"function\"}]",
+}
+
+// ISsoAccountABI is the input ABI used to generate the binding from.
+// Deprecated: Use ISsoAccountMetaData.ABI instead.
+var ISsoAccountABI = ISsoAccountMetaData.ABI
+
+// ISsoAccount is an auto generated Go binding around an Ethereum contract.
+type ISsoAccount struct {
+	ISsoAccountCaller     // Read-only binding to the contract
+	ISsoAccountTransactor // Write-only binding to the contract
+	ISsoAccountFilterer   // Log filterer for contract events
+}
+
+// ISsoAccountCaller is an auto generated read-only Go binding around an Ethereum contract.
+type ISsoAccountCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ISsoAccountTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type ISsoAccountTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ISsoAccountFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type ISsoAccountFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ISsoAccountSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type ISsoAccountSession struct {
+	Contract     *ISsoAccount      // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// ISsoAccountCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type ISsoAccountCallerSession struct {
+	Contract *ISsoAccountCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts      // Call options to use throughout this session
+}
+
+// ISsoAccountTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type ISsoAccountTransactorSession struct {
+	Contract     *ISsoAccountTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts      // Transaction auth options to use throughout this session
+}
+
+// ISsoAccountRaw is an auto generated low-level Go binding around an Ethereum contract.
+type ISsoAccountRaw struct {
+	Contract *ISsoAccount // Generic contract binding to access the raw methods on
+}
+
+// ISsoAccountCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type ISsoAccountCallerRaw struct {
+	Contract *ISsoAccountCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// ISsoAccountTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type ISsoAccountTransactorRaw struct {
+	Contract *ISsoAccountTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewISsoAccount creates a new instance of ISsoAccount, bound to a specific deployed contract.
+func NewISsoAccount(address common.Address, backend bind.ContractBackend) (*ISsoAccount, error) {
+	contract, err := bindISsoAccount(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &ISsoAccount{ISsoAccountCaller: ISsoAccountCaller{contract: contract}, ISsoAccountTransactor: ISsoAccountTransactor{contract: contract}, ISsoAccountFilterer: ISsoAccountFilterer{contract: contract}}, nil
+}
+
+// NewISsoAccountCaller creates a new read-only instance of ISsoAccount, bound to a specific deployed contract.
+func NewISsoAccountCaller(address common.Address, caller bind.ContractCaller) (*ISsoAccountCaller, error) {
+	contract, err := bindISsoAccount(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ISsoAccountCaller{contract: contract}, nil
+}
+
+// NewISsoAccountTransactor creates a new write-only instance of ISsoAccount, bound to a specific deployed contract.
+func NewISsoAccountTransactor(address common.Address, transactor bind.ContractTransactor) (*ISsoAccountTransactor, error) {
+	contract, err := bindISsoAccount(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ISsoAccountTransactor{contract: contract}, nil
+}
+
+// NewISsoAccountFilterer creates a new log filterer instance of ISsoAccount, bound to a specific deployed contract.
+func NewISsoAccountFilterer(address common.Address, filterer bind.ContractFilterer) (*ISsoAccountFilterer, error) {
+	contract, err := bindISsoAccount(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &ISsoAccountFilterer{contract: contract}, nil
+}
+
+// bindISsoAccount binds a generic wrapper to an already deployed contract.
+func bindISsoAccount(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := ISsoAccountMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_ISsoAccount *ISsoAccountRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _ISsoAccount.Contract.ISsoAccountCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_ISsoAccount *ISsoAccountRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.ISsoAccountTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_ISsoAccount *ISsoAccountRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.ISsoAccountTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_ISsoAccount *ISsoAccountCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _ISsoAccount.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_ISsoAccount *ISsoAccountTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_ISsoAccount *ISsoAccountTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.contract.Transact(opts, method, params...)
+}
+
+// IsHook is a free data retrieval call binding the contract method 0xd2676529.
+//
+// Solidity: function isHook(address addr) view returns(bool)
+func (_ISsoAccount *ISsoAccountCaller) IsHook(opts *bind.CallOpts, addr common.Address) (bool, error) {
+	var out []interface{}
+	err := _ISsoAccount.contract.Call(opts, &out, "isHook", addr)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsHook is a free data retrieval call binding the contract method 0xd2676529.
+//
+// Solidity: function isHook(address addr) view returns(bool)
+func (_ISsoAccount *ISsoAccountSession) IsHook(addr common.Address) (bool, error) {
+	return _ISsoAccount.Contract.IsHook(&_ISsoAccount.CallOpts, addr)
+}
+
+// IsHook is a free data retrieval call binding the contract method 0xd2676529.
+//
+// Solidity: function isHook(address addr) view returns(bool)
+func (_ISsoAccount *ISsoAccountCallerSession) IsHook(addr common.Address) (bool, error) {
+	return _ISsoAccount.Contract.IsHook(&_ISsoAccount.CallOpts, addr)
+}
+
+// IsK1Owner is a free data retrieval call binding the contract method 0x6e354cb8.
+//
+// Solidity: function isK1Owner(address addr) view returns(bool)
+func (_ISsoAccount *ISsoAccountCaller) IsK1Owner(opts *bind.CallOpts, addr common.Address) (bool, error) {
+	var out []interface{}
+	err := _ISsoAccount.contract.Call(opts, &out, "isK1Owner", addr)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsK1Owner is a free data retrieval call binding the contract method 0x6e354cb8.
+//
+// Solidity: function isK1Owner(address addr) view returns(bool)
+func (_ISsoAccount *ISsoAccountSession) IsK1Owner(addr common.Address) (bool, error) {
+	return _ISsoAccount.Contract.IsK1Owner(&_ISsoAccount.CallOpts, addr)
+}
+
+// IsK1Owner is a free data retrieval call binding the contract method 0x6e354cb8.
+//
+// Solidity: function isK1Owner(address addr) view returns(bool)
+func (_ISsoAccount *ISsoAccountCallerSession) IsK1Owner(addr common.Address) (bool, error) {
+	return _ISsoAccount.Contract.IsK1Owner(&_ISsoAccount.CallOpts, addr)
+}
+
+// IsModuleValidator is a free data retrieval call binding the contract method 0x9b7be156.
+//
+// Solidity: function isModuleValidator(address validator) view returns(bool)
+func (_ISsoAccount *ISsoAccountCaller) IsModuleValidator(opts *bind.CallOpts, validator common.Address) (bool, error) {
+	var out []interface{}
+	err := _ISsoAccount.contract.Call(opts, &out, "isModuleValidator", validator)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsModuleValidator is a free data retrieval call binding the contract method 0x9b7be156.
+//
+// Solidity: function isModuleValidator(address validator) view returns(bool)
+func (_ISsoAccount *ISsoAccountSession) IsModuleValidator(validator common.Address) (bool, error) {
+	return _ISsoAccount.Contract.IsModuleValidator(&_ISsoAccount.CallOpts, validator)
+}
+
+// IsModuleValidator is a free data retrieval call binding the contract method 0x9b7be156.
+//
+// Solidity: function isModuleValidator(address validator) view returns(bool)
+func (_ISsoAccount *ISsoAccountCallerSession) IsModuleValidator(validator common.Address) (bool, error) {
+	return _ISsoAccount.Contract.IsModuleValidator(&_ISsoAccount.CallOpts, validator)
+}
+
+// IsValidSignature is a free data retrieval call binding the contract method 0x1626ba7e.
+//
+// Solidity: function isValidSignature(bytes32 hash, bytes signature) view returns(bytes4 magicValue)
+func (_ISsoAccount *ISsoAccountCaller) IsValidSignature(opts *bind.CallOpts, hash [32]byte, signature []byte) ([4]byte, error) {
+	var out []interface{}
+	err := _ISsoAccount.contract.Call(opts, &out, "isValidSignature", hash, signature)
+
+	if err != nil {
+		return *new([4]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([4]byte)).(*[4]byte)
+
+	return out0, err
+
+}
+
+// IsValidSignature is a free data retrieval call binding the contract method 0x1626ba7e.
+//
+// Solidity: function isValidSignature(bytes32 hash, bytes signature) view returns(bytes4 magicValue)
+func (_ISsoAccount *ISsoAccountSession) IsValidSignature(hash [32]byte, signature []byte) ([4]byte, error) {
+	return _ISsoAccount.Contract.IsValidSignature(&_ISsoAccount.CallOpts, hash, signature)
+}
+
+// IsValidSignature is a free data retrieval call binding the contract method 0x1626ba7e.
+//
+// Solidity: function isValidSignature(bytes32 hash, bytes signature) view returns(bytes4 magicValue)
+func (_ISsoAccount *ISsoAccountCallerSession) IsValidSignature(hash [32]byte, signature []byte) ([4]byte, error) {
+	return _ISsoAccount.Contract.IsValidSignature(&_ISsoAccount.CallOpts, hash, signature)
+}
+
+// ListHooks is a free data retrieval call binding the contract method 0xdb8a323f.
+//
+// Solidity: function listHooks(bool isValidation) view returns(address[] hookList)
+func (_ISsoAccount *ISsoAccountCaller) ListHooks(opts *bind.CallOpts, isValidation bool) ([]common.Address, error) {
+	var out []interface{}
+	err := _ISsoAccount.contract.Call(opts, &out, "listHooks", isValidation)
+
+	if err != nil {
+		return *new([]common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
+
+	return out0, err
+
+}
+
+// ListHooks is a free data retrieval call binding the contract method 0xdb8a323f.
+//
+// Solidity: function listHooks(bool isValidation) view returns(address[] hookList)
+func (_ISsoAccount *ISsoAccountSession) ListHooks(isValidation bool) ([]common.Address, error) {
+	return _ISsoAccount.Contract.ListHooks(&_ISsoAccount.CallOpts, isValidation)
+}
+
+// ListHooks is a free data retrieval call binding the contract method 0xdb8a323f.
+//
+// Solidity: function listHooks(bool isValidation) view returns(address[] hookList)
+func (_ISsoAccount *ISsoAccountCallerSession) ListHooks(isValidation bool) ([]common.Address, error) {
+	return _ISsoAccount.Contract.ListHooks(&_ISsoAccount.CallOpts, isValidation)
+}
+
+// ListK1Owners is a free data retrieval call binding the contract method 0x4f16eec8.
+//
+// Solidity: function listK1Owners() view returns(address[] k1OwnerList)
+func (_ISsoAccount *ISsoAccountCaller) ListK1Owners(opts *bind.CallOpts) ([]common.Address, error) {
+	var out []interface{}
+	err := _ISsoAccount.contract.Call(opts, &out, "listK1Owners")
+
+	if err != nil {
+		return *new([]common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
+
+	return out0, err
+
+}
+
+// ListK1Owners is a free data retrieval call binding the contract method 0x4f16eec8.
+//
+// Solidity: function listK1Owners() view returns(address[] k1OwnerList)
+func (_ISsoAccount *ISsoAccountSession) ListK1Owners() ([]common.Address, error) {
+	return _ISsoAccount.Contract.ListK1Owners(&_ISsoAccount.CallOpts)
+}
+
+// ListK1Owners is a free data retrieval call binding the contract method 0x4f16eec8.
+//
+// Solidity: function listK1Owners() view returns(address[] k1OwnerList)
+func (_ISsoAccount *ISsoAccountCallerSession) ListK1Owners() ([]common.Address, error) {
+	return _ISsoAccount.Contract.ListK1Owners(&_ISsoAccount.CallOpts)
+}
+
+// ListModuleValidators is a free data retrieval call binding the contract method 0x3d3a69bf.
+//
+// Solidity: function listModuleValidators() view returns(address[] validatorList)
+func (_ISsoAccount *ISsoAccountCaller) ListModuleValidators(opts *bind.CallOpts) ([]common.Address, error) {
+	var out []interface{}
+	err := _ISsoAccount.contract.Call(opts, &out, "listModuleValidators")
+
+	if err != nil {
+		return *new([]common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
+
+	return out0, err
+
+}
+
+// ListModuleValidators is a free data retrieval call binding the contract method 0x3d3a69bf.
+//
+// Solidity: function listModuleValidators() view returns(address[] validatorList)
+func (_ISsoAccount *ISsoAccountSession) ListModuleValidators() ([]common.Address, error) {
+	return _ISsoAccount.Contract.ListModuleValidators(&_ISsoAccount.CallOpts)
+}
+
+// ListModuleValidators is a free data retrieval call binding the contract method 0x3d3a69bf.
+//
+// Solidity: function listModuleValidators() view returns(address[] validatorList)
+func (_ISsoAccount *ISsoAccountCallerSession) ListModuleValidators() ([]common.Address, error) {
+	return _ISsoAccount.Contract.ListModuleValidators(&_ISsoAccount.CallOpts)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_ISsoAccount *ISsoAccountCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _ISsoAccount.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_ISsoAccount *ISsoAccountSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _ISsoAccount.Contract.SupportsInterface(&_ISsoAccount.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_ISsoAccount *ISsoAccountCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _ISsoAccount.Contract.SupportsInterface(&_ISsoAccount.CallOpts, interfaceId)
+}
+
+// AddHook is a paid mutator transaction binding the contract method 0x0775a94e.
+//
+// Solidity: function addHook(address hook, bool isValidation, bytes initData) returns()
+func (_ISsoAccount *ISsoAccountTransactor) AddHook(opts *bind.TransactOpts, hook common.Address, isValidation bool, initData []byte) (*types.Transaction, error) {
+	return _ISsoAccount.contract.Transact(opts, "addHook", hook, isValidation, initData)
+}
+
+// AddHook is a paid mutator transaction binding the contract method 0x0775a94e.
+//
+// Solidity: function addHook(address hook, bool isValidation, bytes initData) returns()
+func (_ISsoAccount *ISsoAccountSession) AddHook(hook common.Address, isValidation bool, initData []byte) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.AddHook(&_ISsoAccount.TransactOpts, hook, isValidation, initData)
+}
+
+// AddHook is a paid mutator transaction binding the contract method 0x0775a94e.
+//
+// Solidity: function addHook(address hook, bool isValidation, bytes initData) returns()
+func (_ISsoAccount *ISsoAccountTransactorSession) AddHook(hook common.Address, isValidation bool, initData []byte) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.AddHook(&_ISsoAccount.TransactOpts, hook, isValidation, initData)
+}
+
+// AddK1Owner is a paid mutator transaction binding the contract method 0x23cef13e.
+//
+// Solidity: function addK1Owner(address addr) returns()
+func (_ISsoAccount *ISsoAccountTransactor) AddK1Owner(opts *bind.TransactOpts, addr common.Address) (*types.Transaction, error) {
+	return _ISsoAccount.contract.Transact(opts, "addK1Owner", addr)
+}
+
+// AddK1Owner is a paid mutator transaction binding the contract method 0x23cef13e.
+//
+// Solidity: function addK1Owner(address addr) returns()
+func (_ISsoAccount *ISsoAccountSession) AddK1Owner(addr common.Address) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.AddK1Owner(&_ISsoAccount.TransactOpts, addr)
+}
+
+// AddK1Owner is a paid mutator transaction binding the contract method 0x23cef13e.
+//
+// Solidity: function addK1Owner(address addr) returns()
+func (_ISsoAccount *ISsoAccountTransactorSession) AddK1Owner(addr common.Address) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.AddK1Owner(&_ISsoAccount.TransactOpts, addr)
+}
+
+// AddModuleValidator is a paid mutator transaction binding the contract method 0x2e0b437d.
+//
+// Solidity: function addModuleValidator(address validator, bytes initData) returns()
+func (_ISsoAccount *ISsoAccountTransactor) AddModuleValidator(opts *bind.TransactOpts, validator common.Address, initData []byte) (*types.Transaction, error) {
+	return _ISsoAccount.contract.Transact(opts, "addModuleValidator", validator, initData)
+}
+
+// AddModuleValidator is a paid mutator transaction binding the contract method 0x2e0b437d.
+//
+// Solidity: function addModuleValidator(address validator, bytes initData) returns()
+func (_ISsoAccount *ISsoAccountSession) AddModuleValidator(validator common.Address, initData []byte) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.AddModuleValidator(&_ISsoAccount.TransactOpts, validator, initData)
+}
+
+// AddModuleValidator is a paid mutator transaction binding the contract method 0x2e0b437d.
+//
+// Solidity: function addModuleValidator(address validator, bytes initData) returns()
+func (_ISsoAccount *ISsoAccountTransactorSession) AddModuleValidator(validator common.Address, initData []byte) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.AddModuleValidator(&_ISsoAccount.TransactOpts, validator, initData)
+}
+
+// ExecuteTransaction is a paid mutator transaction binding the contract method 0xdf9c1589.
+//
+// Solidity: function executeTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns()
+func (_ISsoAccount *ISsoAccountTransactor) ExecuteTransaction(opts *bind.TransactOpts, _txHash [32]byte, _suggestedSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _ISsoAccount.contract.Transact(opts, "executeTransaction", _txHash, _suggestedSignedHash, _transaction)
+}
+
+// ExecuteTransaction is a paid mutator transaction binding the contract method 0xdf9c1589.
+//
+// Solidity: function executeTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns()
+func (_ISsoAccount *ISsoAccountSession) ExecuteTransaction(_txHash [32]byte, _suggestedSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.ExecuteTransaction(&_ISsoAccount.TransactOpts, _txHash, _suggestedSignedHash, _transaction)
+}
+
+// ExecuteTransaction is a paid mutator transaction binding the contract method 0xdf9c1589.
+//
+// Solidity: function executeTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns()
+func (_ISsoAccount *ISsoAccountTransactorSession) ExecuteTransaction(_txHash [32]byte, _suggestedSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.ExecuteTransaction(&_ISsoAccount.TransactOpts, _txHash, _suggestedSignedHash, _transaction)
+}
+
+// ExecuteTransactionFromOutside is a paid mutator transaction binding the contract method 0xeeb8cb09.
+//
+// Solidity: function executeTransactionFromOutside((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns()
+func (_ISsoAccount *ISsoAccountTransactor) ExecuteTransactionFromOutside(opts *bind.TransactOpts, _transaction Transaction) (*types.Transaction, error) {
+	return _ISsoAccount.contract.Transact(opts, "executeTransactionFromOutside", _transaction)
+}
+
+// ExecuteTransactionFromOutside is a paid mutator transaction binding the contract method 0xeeb8cb09.
+//
+// Solidity: function executeTransactionFromOutside((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns()
+func (_ISsoAccount *ISsoAccountSession) ExecuteTransactionFromOutside(_transaction Transaction) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.ExecuteTransactionFromOutside(&_ISsoAccount.TransactOpts, _transaction)
+}
+
+// ExecuteTransactionFromOutside is a paid mutator transaction binding the contract method 0xeeb8cb09.
+//
+// Solidity: function executeTransactionFromOutside((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns()
+func (_ISsoAccount *ISsoAccountTransactorSession) ExecuteTransactionFromOutside(_transaction Transaction) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.ExecuteTransactionFromOutside(&_ISsoAccount.TransactOpts, _transaction)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xb9094997.
+//
+// Solidity: function initialize(bytes[] initialValidators, address[] initialK1Owners) returns()
+func (_ISsoAccount *ISsoAccountTransactor) Initialize(opts *bind.TransactOpts, initialValidators [][]byte, initialK1Owners []common.Address) (*types.Transaction, error) {
+	return _ISsoAccount.contract.Transact(opts, "initialize", initialValidators, initialK1Owners)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xb9094997.
+//
+// Solidity: function initialize(bytes[] initialValidators, address[] initialK1Owners) returns()
+func (_ISsoAccount *ISsoAccountSession) Initialize(initialValidators [][]byte, initialK1Owners []common.Address) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.Initialize(&_ISsoAccount.TransactOpts, initialValidators, initialK1Owners)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xb9094997.
+//
+// Solidity: function initialize(bytes[] initialValidators, address[] initialK1Owners) returns()
+func (_ISsoAccount *ISsoAccountTransactorSession) Initialize(initialValidators [][]byte, initialK1Owners []common.Address) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.Initialize(&_ISsoAccount.TransactOpts, initialValidators, initialK1Owners)
+}
+
+// OnERC1155BatchReceived is a paid mutator transaction binding the contract method 0xbc197c81.
+//
+// Solidity: function onERC1155BatchReceived(address operator, address from, uint256[] ids, uint256[] values, bytes data) returns(bytes4)
+func (_ISsoAccount *ISsoAccountTransactor) OnERC1155BatchReceived(opts *bind.TransactOpts, operator common.Address, from common.Address, ids []*big.Int, values []*big.Int, data []byte) (*types.Transaction, error) {
+	return _ISsoAccount.contract.Transact(opts, "onERC1155BatchReceived", operator, from, ids, values, data)
+}
+
+// OnERC1155BatchReceived is a paid mutator transaction binding the contract method 0xbc197c81.
+//
+// Solidity: function onERC1155BatchReceived(address operator, address from, uint256[] ids, uint256[] values, bytes data) returns(bytes4)
+func (_ISsoAccount *ISsoAccountSession) OnERC1155BatchReceived(operator common.Address, from common.Address, ids []*big.Int, values []*big.Int, data []byte) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.OnERC1155BatchReceived(&_ISsoAccount.TransactOpts, operator, from, ids, values, data)
+}
+
+// OnERC1155BatchReceived is a paid mutator transaction binding the contract method 0xbc197c81.
+//
+// Solidity: function onERC1155BatchReceived(address operator, address from, uint256[] ids, uint256[] values, bytes data) returns(bytes4)
+func (_ISsoAccount *ISsoAccountTransactorSession) OnERC1155BatchReceived(operator common.Address, from common.Address, ids []*big.Int, values []*big.Int, data []byte) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.OnERC1155BatchReceived(&_ISsoAccount.TransactOpts, operator, from, ids, values, data)
+}
+
+// OnERC1155Received is a paid mutator transaction binding the contract method 0xf23a6e61.
+//
+// Solidity: function onERC1155Received(address operator, address from, uint256 id, uint256 value, bytes data) returns(bytes4)
+func (_ISsoAccount *ISsoAccountTransactor) OnERC1155Received(opts *bind.TransactOpts, operator common.Address, from common.Address, id *big.Int, value *big.Int, data []byte) (*types.Transaction, error) {
+	return _ISsoAccount.contract.Transact(opts, "onERC1155Received", operator, from, id, value, data)
+}
+
+// OnERC1155Received is a paid mutator transaction binding the contract method 0xf23a6e61.
+//
+// Solidity: function onERC1155Received(address operator, address from, uint256 id, uint256 value, bytes data) returns(bytes4)
+func (_ISsoAccount *ISsoAccountSession) OnERC1155Received(operator common.Address, from common.Address, id *big.Int, value *big.Int, data []byte) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.OnERC1155Received(&_ISsoAccount.TransactOpts, operator, from, id, value, data)
+}
+
+// OnERC1155Received is a paid mutator transaction binding the contract method 0xf23a6e61.
+//
+// Solidity: function onERC1155Received(address operator, address from, uint256 id, uint256 value, bytes data) returns(bytes4)
+func (_ISsoAccount *ISsoAccountTransactorSession) OnERC1155Received(operator common.Address, from common.Address, id *big.Int, value *big.Int, data []byte) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.OnERC1155Received(&_ISsoAccount.TransactOpts, operator, from, id, value, data)
+}
+
+// OnERC721Received is a paid mutator transaction binding the contract method 0x150b7a02.
+//
+// Solidity: function onERC721Received(address operator, address from, uint256 tokenId, bytes data) returns(bytes4)
+func (_ISsoAccount *ISsoAccountTransactor) OnERC721Received(opts *bind.TransactOpts, operator common.Address, from common.Address, tokenId *big.Int, data []byte) (*types.Transaction, error) {
+	return _ISsoAccount.contract.Transact(opts, "onERC721Received", operator, from, tokenId, data)
+}
+
+// OnERC721Received is a paid mutator transaction binding the contract method 0x150b7a02.
+//
+// Solidity: function onERC721Received(address operator, address from, uint256 tokenId, bytes data) returns(bytes4)
+func (_ISsoAccount *ISsoAccountSession) OnERC721Received(operator common.Address, from common.Address, tokenId *big.Int, data []byte) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.OnERC721Received(&_ISsoAccount.TransactOpts, operator, from, tokenId, data)
+}
+
+// OnERC721Received is a paid mutator transaction binding the contract method 0x150b7a02.
+//
+// Solidity: function onERC721Received(address operator, address from, uint256 tokenId, bytes data) returns(bytes4)
+func (_ISsoAccount *ISsoAccountTransactorSession) OnERC721Received(operator common.Address, from common.Address, tokenId *big.Int, data []byte) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.OnERC721Received(&_ISsoAccount.TransactOpts, operator, from, tokenId, data)
+}
+
+// PayForTransaction is a paid mutator transaction binding the contract method 0xe2f318e3.
+//
+// Solidity: function payForTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns()
+func (_ISsoAccount *ISsoAccountTransactor) PayForTransaction(opts *bind.TransactOpts, _txHash [32]byte, _suggestedSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _ISsoAccount.contract.Transact(opts, "payForTransaction", _txHash, _suggestedSignedHash, _transaction)
+}
+
+// PayForTransaction is a paid mutator transaction binding the contract method 0xe2f318e3.
+//
+// Solidity: function payForTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns()
+func (_ISsoAccount *ISsoAccountSession) PayForTransaction(_txHash [32]byte, _suggestedSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.PayForTransaction(&_ISsoAccount.TransactOpts, _txHash, _suggestedSignedHash, _transaction)
+}
+
+// PayForTransaction is a paid mutator transaction binding the contract method 0xe2f318e3.
+//
+// Solidity: function payForTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns()
+func (_ISsoAccount *ISsoAccountTransactorSession) PayForTransaction(_txHash [32]byte, _suggestedSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.PayForTransaction(&_ISsoAccount.TransactOpts, _txHash, _suggestedSignedHash, _transaction)
+}
+
+// PrepareForPaymaster is a paid mutator transaction binding the contract method 0xa28c1aee.
+//
+// Solidity: function prepareForPaymaster(bytes32 _txHash, bytes32 _possibleSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns()
+func (_ISsoAccount *ISsoAccountTransactor) PrepareForPaymaster(opts *bind.TransactOpts, _txHash [32]byte, _possibleSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _ISsoAccount.contract.Transact(opts, "prepareForPaymaster", _txHash, _possibleSignedHash, _transaction)
+}
+
+// PrepareForPaymaster is a paid mutator transaction binding the contract method 0xa28c1aee.
+//
+// Solidity: function prepareForPaymaster(bytes32 _txHash, bytes32 _possibleSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns()
+func (_ISsoAccount *ISsoAccountSession) PrepareForPaymaster(_txHash [32]byte, _possibleSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.PrepareForPaymaster(&_ISsoAccount.TransactOpts, _txHash, _possibleSignedHash, _transaction)
+}
+
+// PrepareForPaymaster is a paid mutator transaction binding the contract method 0xa28c1aee.
+//
+// Solidity: function prepareForPaymaster(bytes32 _txHash, bytes32 _possibleSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns()
+func (_ISsoAccount *ISsoAccountTransactorSession) PrepareForPaymaster(_txHash [32]byte, _possibleSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.PrepareForPaymaster(&_ISsoAccount.TransactOpts, _txHash, _possibleSignedHash, _transaction)
+}
+
+// RemoveHook is a paid mutator transaction binding the contract method 0xe1551286.
+//
+// Solidity: function removeHook(address hook, bool isValidation, bytes deinitData) returns()
+func (_ISsoAccount *ISsoAccountTransactor) RemoveHook(opts *bind.TransactOpts, hook common.Address, isValidation bool, deinitData []byte) (*types.Transaction, error) {
+	return _ISsoAccount.contract.Transact(opts, "removeHook", hook, isValidation, deinitData)
+}
+
+// RemoveHook is a paid mutator transaction binding the contract method 0xe1551286.
+//
+// Solidity: function removeHook(address hook, bool isValidation, bytes deinitData) returns()
+func (_ISsoAccount *ISsoAccountSession) RemoveHook(hook common.Address, isValidation bool, deinitData []byte) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.RemoveHook(&_ISsoAccount.TransactOpts, hook, isValidation, deinitData)
+}
+
+// RemoveHook is a paid mutator transaction binding the contract method 0xe1551286.
+//
+// Solidity: function removeHook(address hook, bool isValidation, bytes deinitData) returns()
+func (_ISsoAccount *ISsoAccountTransactorSession) RemoveHook(hook common.Address, isValidation bool, deinitData []byte) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.RemoveHook(&_ISsoAccount.TransactOpts, hook, isValidation, deinitData)
+}
+
+// RemoveK1Owner is a paid mutator transaction binding the contract method 0x714da018.
+//
+// Solidity: function removeK1Owner(address addr) returns()
+func (_ISsoAccount *ISsoAccountTransactor) RemoveK1Owner(opts *bind.TransactOpts, addr common.Address) (*types.Transaction, error) {
+	return _ISsoAccount.contract.Transact(opts, "removeK1Owner", addr)
+}
+
+// RemoveK1Owner is a paid mutator transaction binding the contract method 0x714da018.
+//
+// Solidity: function removeK1Owner(address addr) returns()
+func (_ISsoAccount *ISsoAccountSession) RemoveK1Owner(addr common.Address) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.RemoveK1Owner(&_ISsoAccount.TransactOpts, addr)
+}
+
+// RemoveK1Owner is a paid mutator transaction binding the contract method 0x714da018.
+//
+// Solidity: function removeK1Owner(address addr) returns()
+func (_ISsoAccount *ISsoAccountTransactorSession) RemoveK1Owner(addr common.Address) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.RemoveK1Owner(&_ISsoAccount.TransactOpts, addr)
+}
+
+// RemoveModuleValidator is a paid mutator transaction binding the contract method 0xb027e50a.
+//
+// Solidity: function removeModuleValidator(address validator, bytes deinitData) returns()
+func (_ISsoAccount *ISsoAccountTransactor) RemoveModuleValidator(opts *bind.TransactOpts, validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _ISsoAccount.contract.Transact(opts, "removeModuleValidator", validator, deinitData)
+}
+
+// RemoveModuleValidator is a paid mutator transaction binding the contract method 0xb027e50a.
+//
+// Solidity: function removeModuleValidator(address validator, bytes deinitData) returns()
+func (_ISsoAccount *ISsoAccountSession) RemoveModuleValidator(validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.RemoveModuleValidator(&_ISsoAccount.TransactOpts, validator, deinitData)
+}
+
+// RemoveModuleValidator is a paid mutator transaction binding the contract method 0xb027e50a.
+//
+// Solidity: function removeModuleValidator(address validator, bytes deinitData) returns()
+func (_ISsoAccount *ISsoAccountTransactorSession) RemoveModuleValidator(validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.RemoveModuleValidator(&_ISsoAccount.TransactOpts, validator, deinitData)
+}
+
+// UnlinkHook is a paid mutator transaction binding the contract method 0x126c46c1.
+//
+// Solidity: function unlinkHook(address hook, bool isValidation, bytes deinitData) returns()
+func (_ISsoAccount *ISsoAccountTransactor) UnlinkHook(opts *bind.TransactOpts, hook common.Address, isValidation bool, deinitData []byte) (*types.Transaction, error) {
+	return _ISsoAccount.contract.Transact(opts, "unlinkHook", hook, isValidation, deinitData)
+}
+
+// UnlinkHook is a paid mutator transaction binding the contract method 0x126c46c1.
+//
+// Solidity: function unlinkHook(address hook, bool isValidation, bytes deinitData) returns()
+func (_ISsoAccount *ISsoAccountSession) UnlinkHook(hook common.Address, isValidation bool, deinitData []byte) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.UnlinkHook(&_ISsoAccount.TransactOpts, hook, isValidation, deinitData)
+}
+
+// UnlinkHook is a paid mutator transaction binding the contract method 0x126c46c1.
+//
+// Solidity: function unlinkHook(address hook, bool isValidation, bytes deinitData) returns()
+func (_ISsoAccount *ISsoAccountTransactorSession) UnlinkHook(hook common.Address, isValidation bool, deinitData []byte) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.UnlinkHook(&_ISsoAccount.TransactOpts, hook, isValidation, deinitData)
+}
+
+// UnlinkModuleValidator is a paid mutator transaction binding the contract method 0xa7d525e8.
+//
+// Solidity: function unlinkModuleValidator(address validator, bytes deinitData) returns()
+func (_ISsoAccount *ISsoAccountTransactor) UnlinkModuleValidator(opts *bind.TransactOpts, validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _ISsoAccount.contract.Transact(opts, "unlinkModuleValidator", validator, deinitData)
+}
+
+// UnlinkModuleValidator is a paid mutator transaction binding the contract method 0xa7d525e8.
+//
+// Solidity: function unlinkModuleValidator(address validator, bytes deinitData) returns()
+func (_ISsoAccount *ISsoAccountSession) UnlinkModuleValidator(validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.UnlinkModuleValidator(&_ISsoAccount.TransactOpts, validator, deinitData)
+}
+
+// UnlinkModuleValidator is a paid mutator transaction binding the contract method 0xa7d525e8.
+//
+// Solidity: function unlinkModuleValidator(address validator, bytes deinitData) returns()
+func (_ISsoAccount *ISsoAccountTransactorSession) UnlinkModuleValidator(validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.UnlinkModuleValidator(&_ISsoAccount.TransactOpts, validator, deinitData)
+}
+
+// ValidateTransaction is a paid mutator transaction binding the contract method 0x202bcce7.
+//
+// Solidity: function validateTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns(bytes4 magic)
+func (_ISsoAccount *ISsoAccountTransactor) ValidateTransaction(opts *bind.TransactOpts, _txHash [32]byte, _suggestedSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _ISsoAccount.contract.Transact(opts, "validateTransaction", _txHash, _suggestedSignedHash, _transaction)
+}
+
+// ValidateTransaction is a paid mutator transaction binding the contract method 0x202bcce7.
+//
+// Solidity: function validateTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns(bytes4 magic)
+func (_ISsoAccount *ISsoAccountSession) ValidateTransaction(_txHash [32]byte, _suggestedSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.ValidateTransaction(&_ISsoAccount.TransactOpts, _txHash, _suggestedSignedHash, _transaction)
+}
+
+// ValidateTransaction is a paid mutator transaction binding the contract method 0x202bcce7.
+//
+// Solidity: function validateTransaction(bytes32 _txHash, bytes32 _suggestedSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns(bytes4 magic)
+func (_ISsoAccount *ISsoAccountTransactorSession) ValidateTransaction(_txHash [32]byte, _suggestedSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _ISsoAccount.Contract.ValidateTransaction(&_ISsoAccount.TransactOpts, _txHash, _suggestedSignedHash, _transaction)
+}
+
+// ISsoAccountHookAddedIterator is returned from FilterHookAdded and is used to iterate over the raw logs and unpacked data for HookAdded events raised by the ISsoAccount contract.
+type ISsoAccountHookAddedIterator struct {
+	Event *ISsoAccountHookAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ISsoAccountHookAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ISsoAccountHookAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ISsoAccountHookAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ISsoAccountHookAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ISsoAccountHookAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ISsoAccountHookAdded represents a HookAdded event raised by the ISsoAccount contract.
+type ISsoAccountHookAdded struct {
+	Hook common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterHookAdded is a free log retrieval operation binding the contract event 0x28e00134722f84e69c391c81e4fe022ee3e61048222a8ea2f98c9f235f797508.
+//
+// Solidity: event HookAdded(address indexed hook)
+func (_ISsoAccount *ISsoAccountFilterer) FilterHookAdded(opts *bind.FilterOpts, hook []common.Address) (*ISsoAccountHookAddedIterator, error) {
+
+	var hookRule []interface{}
+	for _, hookItem := range hook {
+		hookRule = append(hookRule, hookItem)
+	}
+
+	logs, sub, err := _ISsoAccount.contract.FilterLogs(opts, "HookAdded", hookRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ISsoAccountHookAddedIterator{contract: _ISsoAccount.contract, event: "HookAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchHookAdded is a free log subscription operation binding the contract event 0x28e00134722f84e69c391c81e4fe022ee3e61048222a8ea2f98c9f235f797508.
+//
+// Solidity: event HookAdded(address indexed hook)
+func (_ISsoAccount *ISsoAccountFilterer) WatchHookAdded(opts *bind.WatchOpts, sink chan<- *ISsoAccountHookAdded, hook []common.Address) (event.Subscription, error) {
+
+	var hookRule []interface{}
+	for _, hookItem := range hook {
+		hookRule = append(hookRule, hookItem)
+	}
+
+	logs, sub, err := _ISsoAccount.contract.WatchLogs(opts, "HookAdded", hookRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ISsoAccountHookAdded)
+				if err := _ISsoAccount.contract.UnpackLog(event, "HookAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseHookAdded is a log parse operation binding the contract event 0x28e00134722f84e69c391c81e4fe022ee3e61048222a8ea2f98c9f235f797508.
+//
+// Solidity: event HookAdded(address indexed hook)
+func (_ISsoAccount *ISsoAccountFilterer) ParseHookAdded(log types.Log) (*ISsoAccountHookAdded, error) {
+	event := new(ISsoAccountHookAdded)
+	if err := _ISsoAccount.contract.UnpackLog(event, "HookAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ISsoAccountHookRemovedIterator is returned from FilterHookRemoved and is used to iterate over the raw logs and unpacked data for HookRemoved events raised by the ISsoAccount contract.
+type ISsoAccountHookRemovedIterator struct {
+	Event *ISsoAccountHookRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ISsoAccountHookRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ISsoAccountHookRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ISsoAccountHookRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ISsoAccountHookRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ISsoAccountHookRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ISsoAccountHookRemoved represents a HookRemoved event raised by the ISsoAccount contract.
+type ISsoAccountHookRemoved struct {
+	Hook common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterHookRemoved is a free log retrieval operation binding the contract event 0x47d0871e905ac6550f54ba266e0d90d2dc8ed67a957c064ca3438eddf4e3fd89.
+//
+// Solidity: event HookRemoved(address indexed hook)
+func (_ISsoAccount *ISsoAccountFilterer) FilterHookRemoved(opts *bind.FilterOpts, hook []common.Address) (*ISsoAccountHookRemovedIterator, error) {
+
+	var hookRule []interface{}
+	for _, hookItem := range hook {
+		hookRule = append(hookRule, hookItem)
+	}
+
+	logs, sub, err := _ISsoAccount.contract.FilterLogs(opts, "HookRemoved", hookRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ISsoAccountHookRemovedIterator{contract: _ISsoAccount.contract, event: "HookRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchHookRemoved is a free log subscription operation binding the contract event 0x47d0871e905ac6550f54ba266e0d90d2dc8ed67a957c064ca3438eddf4e3fd89.
+//
+// Solidity: event HookRemoved(address indexed hook)
+func (_ISsoAccount *ISsoAccountFilterer) WatchHookRemoved(opts *bind.WatchOpts, sink chan<- *ISsoAccountHookRemoved, hook []common.Address) (event.Subscription, error) {
+
+	var hookRule []interface{}
+	for _, hookItem := range hook {
+		hookRule = append(hookRule, hookItem)
+	}
+
+	logs, sub, err := _ISsoAccount.contract.WatchLogs(opts, "HookRemoved", hookRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ISsoAccountHookRemoved)
+				if err := _ISsoAccount.contract.UnpackLog(event, "HookRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseHookRemoved is a log parse operation binding the contract event 0x47d0871e905ac6550f54ba266e0d90d2dc8ed67a957c064ca3438eddf4e3fd89.
+//
+// Solidity: event HookRemoved(address indexed hook)
+func (_ISsoAccount *ISsoAccountFilterer) ParseHookRemoved(log types.Log) (*ISsoAccountHookRemoved, error) {
+	event := new(ISsoAccountHookRemoved)
+	if err := _ISsoAccount.contract.UnpackLog(event, "HookRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ISsoAccountK1OwnerAddedIterator is returned from FilterK1OwnerAdded and is used to iterate over the raw logs and unpacked data for K1OwnerAdded events raised by the ISsoAccount contract.
+type ISsoAccountK1OwnerAddedIterator struct {
+	Event *ISsoAccountK1OwnerAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ISsoAccountK1OwnerAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ISsoAccountK1OwnerAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ISsoAccountK1OwnerAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ISsoAccountK1OwnerAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ISsoAccountK1OwnerAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ISsoAccountK1OwnerAdded represents a K1OwnerAdded event raised by the ISsoAccount contract.
+type ISsoAccountK1OwnerAdded struct {
+	Addr common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterK1OwnerAdded is a free log retrieval operation binding the contract event 0x40097f116787d282c09163d089084b2d950545433dad84146baf8da81064e84c.
+//
+// Solidity: event K1OwnerAdded(address indexed addr)
+func (_ISsoAccount *ISsoAccountFilterer) FilterK1OwnerAdded(opts *bind.FilterOpts, addr []common.Address) (*ISsoAccountK1OwnerAddedIterator, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+
+	logs, sub, err := _ISsoAccount.contract.FilterLogs(opts, "K1OwnerAdded", addrRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ISsoAccountK1OwnerAddedIterator{contract: _ISsoAccount.contract, event: "K1OwnerAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchK1OwnerAdded is a free log subscription operation binding the contract event 0x40097f116787d282c09163d089084b2d950545433dad84146baf8da81064e84c.
+//
+// Solidity: event K1OwnerAdded(address indexed addr)
+func (_ISsoAccount *ISsoAccountFilterer) WatchK1OwnerAdded(opts *bind.WatchOpts, sink chan<- *ISsoAccountK1OwnerAdded, addr []common.Address) (event.Subscription, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+
+	logs, sub, err := _ISsoAccount.contract.WatchLogs(opts, "K1OwnerAdded", addrRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ISsoAccountK1OwnerAdded)
+				if err := _ISsoAccount.contract.UnpackLog(event, "K1OwnerAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseK1OwnerAdded is a log parse operation binding the contract event 0x40097f116787d282c09163d089084b2d950545433dad84146baf8da81064e84c.
+//
+// Solidity: event K1OwnerAdded(address indexed addr)
+func (_ISsoAccount *ISsoAccountFilterer) ParseK1OwnerAdded(log types.Log) (*ISsoAccountK1OwnerAdded, error) {
+	event := new(ISsoAccountK1OwnerAdded)
+	if err := _ISsoAccount.contract.UnpackLog(event, "K1OwnerAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ISsoAccountK1OwnerRemovedIterator is returned from FilterK1OwnerRemoved and is used to iterate over the raw logs and unpacked data for K1OwnerRemoved events raised by the ISsoAccount contract.
+type ISsoAccountK1OwnerRemovedIterator struct {
+	Event *ISsoAccountK1OwnerRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ISsoAccountK1OwnerRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ISsoAccountK1OwnerRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ISsoAccountK1OwnerRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ISsoAccountK1OwnerRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ISsoAccountK1OwnerRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ISsoAccountK1OwnerRemoved represents a K1OwnerRemoved event raised by the ISsoAccount contract.
+type ISsoAccountK1OwnerRemoved struct {
+	Addr common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterK1OwnerRemoved is a free log retrieval operation binding the contract event 0xe09f0b842a072d50a0b373f3255e2a4216aeb61908e35a93a499f0ff2aa4c8fa.
+//
+// Solidity: event K1OwnerRemoved(address indexed addr)
+func (_ISsoAccount *ISsoAccountFilterer) FilterK1OwnerRemoved(opts *bind.FilterOpts, addr []common.Address) (*ISsoAccountK1OwnerRemovedIterator, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+
+	logs, sub, err := _ISsoAccount.contract.FilterLogs(opts, "K1OwnerRemoved", addrRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ISsoAccountK1OwnerRemovedIterator{contract: _ISsoAccount.contract, event: "K1OwnerRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchK1OwnerRemoved is a free log subscription operation binding the contract event 0xe09f0b842a072d50a0b373f3255e2a4216aeb61908e35a93a499f0ff2aa4c8fa.
+//
+// Solidity: event K1OwnerRemoved(address indexed addr)
+func (_ISsoAccount *ISsoAccountFilterer) WatchK1OwnerRemoved(opts *bind.WatchOpts, sink chan<- *ISsoAccountK1OwnerRemoved, addr []common.Address) (event.Subscription, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+
+	logs, sub, err := _ISsoAccount.contract.WatchLogs(opts, "K1OwnerRemoved", addrRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ISsoAccountK1OwnerRemoved)
+				if err := _ISsoAccount.contract.UnpackLog(event, "K1OwnerRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseK1OwnerRemoved is a log parse operation binding the contract event 0xe09f0b842a072d50a0b373f3255e2a4216aeb61908e35a93a499f0ff2aa4c8fa.
+//
+// Solidity: event K1OwnerRemoved(address indexed addr)
+func (_ISsoAccount *ISsoAccountFilterer) ParseK1OwnerRemoved(log types.Log) (*ISsoAccountK1OwnerRemoved, error) {
+	event := new(ISsoAccountK1OwnerRemoved)
+	if err := _ISsoAccount.contract.UnpackLog(event, "K1OwnerRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ISsoAccountValidatorAddedIterator is returned from FilterValidatorAdded and is used to iterate over the raw logs and unpacked data for ValidatorAdded events raised by the ISsoAccount contract.
+type ISsoAccountValidatorAddedIterator struct {
+	Event *ISsoAccountValidatorAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ISsoAccountValidatorAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ISsoAccountValidatorAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ISsoAccountValidatorAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ISsoAccountValidatorAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ISsoAccountValidatorAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ISsoAccountValidatorAdded represents a ValidatorAdded event raised by the ISsoAccount contract.
+type ISsoAccountValidatorAdded struct {
+	Validator common.Address
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterValidatorAdded is a free log retrieval operation binding the contract event 0xe366c1c0452ed8eec96861e9e54141ebff23c9ec89fe27b996b45f5ec3884987.
+//
+// Solidity: event ValidatorAdded(address indexed validator)
+func (_ISsoAccount *ISsoAccountFilterer) FilterValidatorAdded(opts *bind.FilterOpts, validator []common.Address) (*ISsoAccountValidatorAddedIterator, error) {
+
+	var validatorRule []interface{}
+	for _, validatorItem := range validator {
+		validatorRule = append(validatorRule, validatorItem)
+	}
+
+	logs, sub, err := _ISsoAccount.contract.FilterLogs(opts, "ValidatorAdded", validatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ISsoAccountValidatorAddedIterator{contract: _ISsoAccount.contract, event: "ValidatorAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchValidatorAdded is a free log subscription operation binding the contract event 0xe366c1c0452ed8eec96861e9e54141ebff23c9ec89fe27b996b45f5ec3884987.
+//
+// Solidity: event ValidatorAdded(address indexed validator)
+func (_ISsoAccount *ISsoAccountFilterer) WatchValidatorAdded(opts *bind.WatchOpts, sink chan<- *ISsoAccountValidatorAdded, validator []common.Address) (event.Subscription, error) {
+
+	var validatorRule []interface{}
+	for _, validatorItem := range validator {
+		validatorRule = append(validatorRule, validatorItem)
+	}
+
+	logs, sub, err := _ISsoAccount.contract.WatchLogs(opts, "ValidatorAdded", validatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ISsoAccountValidatorAdded)
+				if err := _ISsoAccount.contract.UnpackLog(event, "ValidatorAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseValidatorAdded is a log parse operation binding the contract event 0xe366c1c0452ed8eec96861e9e54141ebff23c9ec89fe27b996b45f5ec3884987.
+//
+// Solidity: event ValidatorAdded(address indexed validator)
+func (_ISsoAccount *ISsoAccountFilterer) ParseValidatorAdded(log types.Log) (*ISsoAccountValidatorAdded, error) {
+	event := new(ISsoAccountValidatorAdded)
+	if err := _ISsoAccount.contract.UnpackLog(event, "ValidatorAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ISsoAccountValidatorRemovedIterator is returned from FilterValidatorRemoved and is used to iterate over the raw logs and unpacked data for ValidatorRemoved events raised by the ISsoAccount contract.
+type ISsoAccountValidatorRemovedIterator struct {
+	Event *ISsoAccountValidatorRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ISsoAccountValidatorRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ISsoAccountValidatorRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ISsoAccountValidatorRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ISsoAccountValidatorRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ISsoAccountValidatorRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ISsoAccountValidatorRemoved represents a ValidatorRemoved event raised by the ISsoAccount contract.
+type ISsoAccountValidatorRemoved struct {
+	Validator common.Address
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterValidatorRemoved is a free log retrieval operation binding the contract event 0xe1434e25d6611e0db941968fdc97811c982ac1602e951637d206f5fdda9dd8f1.
+//
+// Solidity: event ValidatorRemoved(address indexed validator)
+func (_ISsoAccount *ISsoAccountFilterer) FilterValidatorRemoved(opts *bind.FilterOpts, validator []common.Address) (*ISsoAccountValidatorRemovedIterator, error) {
+
+	var validatorRule []interface{}
+	for _, validatorItem := range validator {
+		validatorRule = append(validatorRule, validatorItem)
+	}
+
+	logs, sub, err := _ISsoAccount.contract.FilterLogs(opts, "ValidatorRemoved", validatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ISsoAccountValidatorRemovedIterator{contract: _ISsoAccount.contract, event: "ValidatorRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchValidatorRemoved is a free log subscription operation binding the contract event 0xe1434e25d6611e0db941968fdc97811c982ac1602e951637d206f5fdda9dd8f1.
+//
+// Solidity: event ValidatorRemoved(address indexed validator)
+func (_ISsoAccount *ISsoAccountFilterer) WatchValidatorRemoved(opts *bind.WatchOpts, sink chan<- *ISsoAccountValidatorRemoved, validator []common.Address) (event.Subscription, error) {
+
+	var validatorRule []interface{}
+	for _, validatorItem := range validator {
+		validatorRule = append(validatorRule, validatorItem)
+	}
+
+	logs, sub, err := _ISsoAccount.contract.WatchLogs(opts, "ValidatorRemoved", validatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ISsoAccountValidatorRemoved)
+				if err := _ISsoAccount.contract.UnpackLog(event, "ValidatorRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseValidatorRemoved is a log parse operation binding the contract event 0xe1434e25d6611e0db941968fdc97811c982ac1602e951637d206f5fdda9dd8f1.
+//
+// Solidity: event ValidatorRemoved(address indexed validator)
+func (_ISsoAccount *ISsoAccountFilterer) ParseValidatorRemoved(log types.Log) (*ISsoAccountValidatorRemoved, error) {
+	event := new(ISsoAccountValidatorRemoved)
+	if err := _ISsoAccount.contract.UnpackLog(event, "ValidatorRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts/zksyncsso/interfaces/itimestampasserter/itimestampasserter.go
+++ b/contracts/zksyncsso/interfaces/itimestampasserter/itimestampasserter.go
@@ -1,0 +1,210 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package itimestampasserter
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// ITimestampAsserterMetaData contains all meta data concerning the ITimestampAsserter contract.
+var ITimestampAsserterMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"start\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"end\",\"type\":\"uint256\"}],\"name\":\"assertTimestampInRange\",\"outputs\":[],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+}
+
+// ITimestampAsserterABI is the input ABI used to generate the binding from.
+// Deprecated: Use ITimestampAsserterMetaData.ABI instead.
+var ITimestampAsserterABI = ITimestampAsserterMetaData.ABI
+
+// ITimestampAsserter is an auto generated Go binding around an Ethereum contract.
+type ITimestampAsserter struct {
+	ITimestampAsserterCaller     // Read-only binding to the contract
+	ITimestampAsserterTransactor // Write-only binding to the contract
+	ITimestampAsserterFilterer   // Log filterer for contract events
+}
+
+// ITimestampAsserterCaller is an auto generated read-only Go binding around an Ethereum contract.
+type ITimestampAsserterCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ITimestampAsserterTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type ITimestampAsserterTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ITimestampAsserterFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type ITimestampAsserterFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ITimestampAsserterSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type ITimestampAsserterSession struct {
+	Contract     *ITimestampAsserter // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts       // Call options to use throughout this session
+	TransactOpts bind.TransactOpts   // Transaction auth options to use throughout this session
+}
+
+// ITimestampAsserterCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type ITimestampAsserterCallerSession struct {
+	Contract *ITimestampAsserterCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts             // Call options to use throughout this session
+}
+
+// ITimestampAsserterTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type ITimestampAsserterTransactorSession struct {
+	Contract     *ITimestampAsserterTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts             // Transaction auth options to use throughout this session
+}
+
+// ITimestampAsserterRaw is an auto generated low-level Go binding around an Ethereum contract.
+type ITimestampAsserterRaw struct {
+	Contract *ITimestampAsserter // Generic contract binding to access the raw methods on
+}
+
+// ITimestampAsserterCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type ITimestampAsserterCallerRaw struct {
+	Contract *ITimestampAsserterCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// ITimestampAsserterTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type ITimestampAsserterTransactorRaw struct {
+	Contract *ITimestampAsserterTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewITimestampAsserter creates a new instance of ITimestampAsserter, bound to a specific deployed contract.
+func NewITimestampAsserter(address common.Address, backend bind.ContractBackend) (*ITimestampAsserter, error) {
+	contract, err := bindITimestampAsserter(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &ITimestampAsserter{ITimestampAsserterCaller: ITimestampAsserterCaller{contract: contract}, ITimestampAsserterTransactor: ITimestampAsserterTransactor{contract: contract}, ITimestampAsserterFilterer: ITimestampAsserterFilterer{contract: contract}}, nil
+}
+
+// NewITimestampAsserterCaller creates a new read-only instance of ITimestampAsserter, bound to a specific deployed contract.
+func NewITimestampAsserterCaller(address common.Address, caller bind.ContractCaller) (*ITimestampAsserterCaller, error) {
+	contract, err := bindITimestampAsserter(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ITimestampAsserterCaller{contract: contract}, nil
+}
+
+// NewITimestampAsserterTransactor creates a new write-only instance of ITimestampAsserter, bound to a specific deployed contract.
+func NewITimestampAsserterTransactor(address common.Address, transactor bind.ContractTransactor) (*ITimestampAsserterTransactor, error) {
+	contract, err := bindITimestampAsserter(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ITimestampAsserterTransactor{contract: contract}, nil
+}
+
+// NewITimestampAsserterFilterer creates a new log filterer instance of ITimestampAsserter, bound to a specific deployed contract.
+func NewITimestampAsserterFilterer(address common.Address, filterer bind.ContractFilterer) (*ITimestampAsserterFilterer, error) {
+	contract, err := bindITimestampAsserter(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &ITimestampAsserterFilterer{contract: contract}, nil
+}
+
+// bindITimestampAsserter binds a generic wrapper to an already deployed contract.
+func bindITimestampAsserter(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := ITimestampAsserterMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_ITimestampAsserter *ITimestampAsserterRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _ITimestampAsserter.Contract.ITimestampAsserterCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_ITimestampAsserter *ITimestampAsserterRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ITimestampAsserter.Contract.ITimestampAsserterTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_ITimestampAsserter *ITimestampAsserterRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _ITimestampAsserter.Contract.ITimestampAsserterTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_ITimestampAsserter *ITimestampAsserterCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _ITimestampAsserter.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_ITimestampAsserter *ITimestampAsserterTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ITimestampAsserter.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_ITimestampAsserter *ITimestampAsserterTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _ITimestampAsserter.Contract.contract.Transact(opts, method, params...)
+}
+
+// AssertTimestampInRange is a free data retrieval call binding the contract method 0x5b1a0c91.
+//
+// Solidity: function assertTimestampInRange(uint256 start, uint256 end) view returns()
+func (_ITimestampAsserter *ITimestampAsserterCaller) AssertTimestampInRange(opts *bind.CallOpts, start *big.Int, end *big.Int) error {
+	var out []interface{}
+	err := _ITimestampAsserter.contract.Call(opts, &out, "assertTimestampInRange", start, end)
+
+	if err != nil {
+		return err
+	}
+
+	return err
+
+}
+
+// AssertTimestampInRange is a free data retrieval call binding the contract method 0x5b1a0c91.
+//
+// Solidity: function assertTimestampInRange(uint256 start, uint256 end) view returns()
+func (_ITimestampAsserter *ITimestampAsserterSession) AssertTimestampInRange(start *big.Int, end *big.Int) error {
+	return _ITimestampAsserter.Contract.AssertTimestampInRange(&_ITimestampAsserter.CallOpts, start, end)
+}
+
+// AssertTimestampInRange is a free data retrieval call binding the contract method 0x5b1a0c91.
+//
+// Solidity: function assertTimestampInRange(uint256 start, uint256 end) view returns()
+func (_ITimestampAsserter *ITimestampAsserterCallerSession) AssertTimestampInRange(start *big.Int, end *big.Int) error {
+	return _ITimestampAsserter.Contract.AssertTimestampInRange(&_ITimestampAsserter.CallOpts, start, end)
+}

--- a/contracts/zksyncsso/interfaces/ivalidationhook/ivalidationhook.go
+++ b/contracts/zksyncsso/interfaces/ivalidationhook/ivalidationhook.go
@@ -1,0 +1,295 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package ivalidationhook
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// Transaction is an auto generated low-level Go binding around an user-defined struct.
+type Transaction struct {
+	TxType                 *big.Int
+	From                   *big.Int
+	To                     *big.Int
+	GasLimit               *big.Int
+	GasPerPubdataByteLimit *big.Int
+	MaxFeePerGas           *big.Int
+	MaxPriorityFeePerGas   *big.Int
+	Paymaster              *big.Int
+	Nonce                  *big.Int
+	Value                  *big.Int
+	Reserved               [4]*big.Int
+	Data                   []byte
+	Signature              []byte
+	FactoryDeps            [][32]byte
+	PaymasterInput         []byte
+	ReservedDynamic        []byte
+}
+
+// IValidationHookMetaData contains all meta data concerning the IValidationHook contract.
+var IValidationHookMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"onInstall\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"onUninstall\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"}],\"name\":\"supportsInterface\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"signedHash\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[]\",\"name\":\"factoryDeps\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"reservedDynamic\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"transaction\",\"type\":\"tuple\"}],\"name\":\"validationHook\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+}
+
+// IValidationHookABI is the input ABI used to generate the binding from.
+// Deprecated: Use IValidationHookMetaData.ABI instead.
+var IValidationHookABI = IValidationHookMetaData.ABI
+
+// IValidationHook is an auto generated Go binding around an Ethereum contract.
+type IValidationHook struct {
+	IValidationHookCaller     // Read-only binding to the contract
+	IValidationHookTransactor // Write-only binding to the contract
+	IValidationHookFilterer   // Log filterer for contract events
+}
+
+// IValidationHookCaller is an auto generated read-only Go binding around an Ethereum contract.
+type IValidationHookCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IValidationHookTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type IValidationHookTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IValidationHookFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type IValidationHookFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IValidationHookSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type IValidationHookSession struct {
+	Contract     *IValidationHook  // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// IValidationHookCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type IValidationHookCallerSession struct {
+	Contract *IValidationHookCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts          // Call options to use throughout this session
+}
+
+// IValidationHookTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type IValidationHookTransactorSession struct {
+	Contract     *IValidationHookTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts          // Transaction auth options to use throughout this session
+}
+
+// IValidationHookRaw is an auto generated low-level Go binding around an Ethereum contract.
+type IValidationHookRaw struct {
+	Contract *IValidationHook // Generic contract binding to access the raw methods on
+}
+
+// IValidationHookCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type IValidationHookCallerRaw struct {
+	Contract *IValidationHookCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// IValidationHookTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type IValidationHookTransactorRaw struct {
+	Contract *IValidationHookTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewIValidationHook creates a new instance of IValidationHook, bound to a specific deployed contract.
+func NewIValidationHook(address common.Address, backend bind.ContractBackend) (*IValidationHook, error) {
+	contract, err := bindIValidationHook(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &IValidationHook{IValidationHookCaller: IValidationHookCaller{contract: contract}, IValidationHookTransactor: IValidationHookTransactor{contract: contract}, IValidationHookFilterer: IValidationHookFilterer{contract: contract}}, nil
+}
+
+// NewIValidationHookCaller creates a new read-only instance of IValidationHook, bound to a specific deployed contract.
+func NewIValidationHookCaller(address common.Address, caller bind.ContractCaller) (*IValidationHookCaller, error) {
+	contract, err := bindIValidationHook(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IValidationHookCaller{contract: contract}, nil
+}
+
+// NewIValidationHookTransactor creates a new write-only instance of IValidationHook, bound to a specific deployed contract.
+func NewIValidationHookTransactor(address common.Address, transactor bind.ContractTransactor) (*IValidationHookTransactor, error) {
+	contract, err := bindIValidationHook(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IValidationHookTransactor{contract: contract}, nil
+}
+
+// NewIValidationHookFilterer creates a new log filterer instance of IValidationHook, bound to a specific deployed contract.
+func NewIValidationHookFilterer(address common.Address, filterer bind.ContractFilterer) (*IValidationHookFilterer, error) {
+	contract, err := bindIValidationHook(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &IValidationHookFilterer{contract: contract}, nil
+}
+
+// bindIValidationHook binds a generic wrapper to an already deployed contract.
+func bindIValidationHook(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := IValidationHookMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IValidationHook *IValidationHookRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _IValidationHook.Contract.IValidationHookCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IValidationHook *IValidationHookRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IValidationHook.Contract.IValidationHookTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IValidationHook *IValidationHookRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IValidationHook.Contract.IValidationHookTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IValidationHook *IValidationHookCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _IValidationHook.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IValidationHook *IValidationHookTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IValidationHook.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IValidationHook *IValidationHookTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IValidationHook.Contract.contract.Transact(opts, method, params...)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_IValidationHook *IValidationHookCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _IValidationHook.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_IValidationHook *IValidationHookSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _IValidationHook.Contract.SupportsInterface(&_IValidationHook.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_IValidationHook *IValidationHookCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _IValidationHook.Contract.SupportsInterface(&_IValidationHook.CallOpts, interfaceId)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_IValidationHook *IValidationHookTransactor) OnInstall(opts *bind.TransactOpts, data []byte) (*types.Transaction, error) {
+	return _IValidationHook.contract.Transact(opts, "onInstall", data)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_IValidationHook *IValidationHookSession) OnInstall(data []byte) (*types.Transaction, error) {
+	return _IValidationHook.Contract.OnInstall(&_IValidationHook.TransactOpts, data)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_IValidationHook *IValidationHookTransactorSession) OnInstall(data []byte) (*types.Transaction, error) {
+	return _IValidationHook.Contract.OnInstall(&_IValidationHook.TransactOpts, data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_IValidationHook *IValidationHookTransactor) OnUninstall(opts *bind.TransactOpts, data []byte) (*types.Transaction, error) {
+	return _IValidationHook.contract.Transact(opts, "onUninstall", data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_IValidationHook *IValidationHookSession) OnUninstall(data []byte) (*types.Transaction, error) {
+	return _IValidationHook.Contract.OnUninstall(&_IValidationHook.TransactOpts, data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_IValidationHook *IValidationHookTransactorSession) OnUninstall(data []byte) (*types.Transaction, error) {
+	return _IValidationHook.Contract.OnUninstall(&_IValidationHook.TransactOpts, data)
+}
+
+// ValidationHook is a paid mutator transaction binding the contract method 0x37d5f03a.
+//
+// Solidity: function validationHook(bytes32 signedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) returns()
+func (_IValidationHook *IValidationHookTransactor) ValidationHook(opts *bind.TransactOpts, signedHash [32]byte, transaction Transaction) (*types.Transaction, error) {
+	return _IValidationHook.contract.Transact(opts, "validationHook", signedHash, transaction)
+}
+
+// ValidationHook is a paid mutator transaction binding the contract method 0x37d5f03a.
+//
+// Solidity: function validationHook(bytes32 signedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) returns()
+func (_IValidationHook *IValidationHookSession) ValidationHook(signedHash [32]byte, transaction Transaction) (*types.Transaction, error) {
+	return _IValidationHook.Contract.ValidationHook(&_IValidationHook.TransactOpts, signedHash, transaction)
+}
+
+// ValidationHook is a paid mutator transaction binding the contract method 0x37d5f03a.
+//
+// Solidity: function validationHook(bytes32 signedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) returns()
+func (_IValidationHook *IValidationHookTransactorSession) ValidationHook(signedHash [32]byte, transaction Transaction) (*types.Transaction, error) {
+	return _IValidationHook.Contract.ValidationHook(&_IValidationHook.TransactOpts, signedHash, transaction)
+}

--- a/contracts/zksyncsso/interfaces/ivalidatormanager/ivalidatormanager.go
+++ b/contracts/zksyncsso/interfaces/ivalidatormanager/ivalidatormanager.go
@@ -1,0 +1,594 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package ivalidatormanager
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// IValidatorManagerMetaData contains all meta data concerning the IValidatorManager contract.
+var IValidatorManagerMetaData = &bind.MetaData{
+	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"ValidatorAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"ValidatorRemoved\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"initData\",\"type\":\"bytes\"}],\"name\":\"addModuleValidator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"isModuleValidator\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"listModuleValidators\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"validatorList\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"deinitData\",\"type\":\"bytes\"}],\"name\":\"removeModuleValidator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"deinitData\",\"type\":\"bytes\"}],\"name\":\"unlinkModuleValidator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+}
+
+// IValidatorManagerABI is the input ABI used to generate the binding from.
+// Deprecated: Use IValidatorManagerMetaData.ABI instead.
+var IValidatorManagerABI = IValidatorManagerMetaData.ABI
+
+// IValidatorManager is an auto generated Go binding around an Ethereum contract.
+type IValidatorManager struct {
+	IValidatorManagerCaller     // Read-only binding to the contract
+	IValidatorManagerTransactor // Write-only binding to the contract
+	IValidatorManagerFilterer   // Log filterer for contract events
+}
+
+// IValidatorManagerCaller is an auto generated read-only Go binding around an Ethereum contract.
+type IValidatorManagerCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IValidatorManagerTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type IValidatorManagerTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IValidatorManagerFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type IValidatorManagerFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IValidatorManagerSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type IValidatorManagerSession struct {
+	Contract     *IValidatorManager // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts      // Call options to use throughout this session
+	TransactOpts bind.TransactOpts  // Transaction auth options to use throughout this session
+}
+
+// IValidatorManagerCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type IValidatorManagerCallerSession struct {
+	Contract *IValidatorManagerCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts            // Call options to use throughout this session
+}
+
+// IValidatorManagerTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type IValidatorManagerTransactorSession struct {
+	Contract     *IValidatorManagerTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts            // Transaction auth options to use throughout this session
+}
+
+// IValidatorManagerRaw is an auto generated low-level Go binding around an Ethereum contract.
+type IValidatorManagerRaw struct {
+	Contract *IValidatorManager // Generic contract binding to access the raw methods on
+}
+
+// IValidatorManagerCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type IValidatorManagerCallerRaw struct {
+	Contract *IValidatorManagerCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// IValidatorManagerTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type IValidatorManagerTransactorRaw struct {
+	Contract *IValidatorManagerTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewIValidatorManager creates a new instance of IValidatorManager, bound to a specific deployed contract.
+func NewIValidatorManager(address common.Address, backend bind.ContractBackend) (*IValidatorManager, error) {
+	contract, err := bindIValidatorManager(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &IValidatorManager{IValidatorManagerCaller: IValidatorManagerCaller{contract: contract}, IValidatorManagerTransactor: IValidatorManagerTransactor{contract: contract}, IValidatorManagerFilterer: IValidatorManagerFilterer{contract: contract}}, nil
+}
+
+// NewIValidatorManagerCaller creates a new read-only instance of IValidatorManager, bound to a specific deployed contract.
+func NewIValidatorManagerCaller(address common.Address, caller bind.ContractCaller) (*IValidatorManagerCaller, error) {
+	contract, err := bindIValidatorManager(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IValidatorManagerCaller{contract: contract}, nil
+}
+
+// NewIValidatorManagerTransactor creates a new write-only instance of IValidatorManager, bound to a specific deployed contract.
+func NewIValidatorManagerTransactor(address common.Address, transactor bind.ContractTransactor) (*IValidatorManagerTransactor, error) {
+	contract, err := bindIValidatorManager(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IValidatorManagerTransactor{contract: contract}, nil
+}
+
+// NewIValidatorManagerFilterer creates a new log filterer instance of IValidatorManager, bound to a specific deployed contract.
+func NewIValidatorManagerFilterer(address common.Address, filterer bind.ContractFilterer) (*IValidatorManagerFilterer, error) {
+	contract, err := bindIValidatorManager(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &IValidatorManagerFilterer{contract: contract}, nil
+}
+
+// bindIValidatorManager binds a generic wrapper to an already deployed contract.
+func bindIValidatorManager(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := IValidatorManagerMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IValidatorManager *IValidatorManagerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _IValidatorManager.Contract.IValidatorManagerCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IValidatorManager *IValidatorManagerRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IValidatorManager.Contract.IValidatorManagerTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IValidatorManager *IValidatorManagerRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IValidatorManager.Contract.IValidatorManagerTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IValidatorManager *IValidatorManagerCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _IValidatorManager.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IValidatorManager *IValidatorManagerTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IValidatorManager.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IValidatorManager *IValidatorManagerTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IValidatorManager.Contract.contract.Transact(opts, method, params...)
+}
+
+// IsModuleValidator is a free data retrieval call binding the contract method 0x9b7be156.
+//
+// Solidity: function isModuleValidator(address validator) view returns(bool)
+func (_IValidatorManager *IValidatorManagerCaller) IsModuleValidator(opts *bind.CallOpts, validator common.Address) (bool, error) {
+	var out []interface{}
+	err := _IValidatorManager.contract.Call(opts, &out, "isModuleValidator", validator)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsModuleValidator is a free data retrieval call binding the contract method 0x9b7be156.
+//
+// Solidity: function isModuleValidator(address validator) view returns(bool)
+func (_IValidatorManager *IValidatorManagerSession) IsModuleValidator(validator common.Address) (bool, error) {
+	return _IValidatorManager.Contract.IsModuleValidator(&_IValidatorManager.CallOpts, validator)
+}
+
+// IsModuleValidator is a free data retrieval call binding the contract method 0x9b7be156.
+//
+// Solidity: function isModuleValidator(address validator) view returns(bool)
+func (_IValidatorManager *IValidatorManagerCallerSession) IsModuleValidator(validator common.Address) (bool, error) {
+	return _IValidatorManager.Contract.IsModuleValidator(&_IValidatorManager.CallOpts, validator)
+}
+
+// ListModuleValidators is a free data retrieval call binding the contract method 0x3d3a69bf.
+//
+// Solidity: function listModuleValidators() view returns(address[] validatorList)
+func (_IValidatorManager *IValidatorManagerCaller) ListModuleValidators(opts *bind.CallOpts) ([]common.Address, error) {
+	var out []interface{}
+	err := _IValidatorManager.contract.Call(opts, &out, "listModuleValidators")
+
+	if err != nil {
+		return *new([]common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
+
+	return out0, err
+
+}
+
+// ListModuleValidators is a free data retrieval call binding the contract method 0x3d3a69bf.
+//
+// Solidity: function listModuleValidators() view returns(address[] validatorList)
+func (_IValidatorManager *IValidatorManagerSession) ListModuleValidators() ([]common.Address, error) {
+	return _IValidatorManager.Contract.ListModuleValidators(&_IValidatorManager.CallOpts)
+}
+
+// ListModuleValidators is a free data retrieval call binding the contract method 0x3d3a69bf.
+//
+// Solidity: function listModuleValidators() view returns(address[] validatorList)
+func (_IValidatorManager *IValidatorManagerCallerSession) ListModuleValidators() ([]common.Address, error) {
+	return _IValidatorManager.Contract.ListModuleValidators(&_IValidatorManager.CallOpts)
+}
+
+// AddModuleValidator is a paid mutator transaction binding the contract method 0x2e0b437d.
+//
+// Solidity: function addModuleValidator(address validator, bytes initData) returns()
+func (_IValidatorManager *IValidatorManagerTransactor) AddModuleValidator(opts *bind.TransactOpts, validator common.Address, initData []byte) (*types.Transaction, error) {
+	return _IValidatorManager.contract.Transact(opts, "addModuleValidator", validator, initData)
+}
+
+// AddModuleValidator is a paid mutator transaction binding the contract method 0x2e0b437d.
+//
+// Solidity: function addModuleValidator(address validator, bytes initData) returns()
+func (_IValidatorManager *IValidatorManagerSession) AddModuleValidator(validator common.Address, initData []byte) (*types.Transaction, error) {
+	return _IValidatorManager.Contract.AddModuleValidator(&_IValidatorManager.TransactOpts, validator, initData)
+}
+
+// AddModuleValidator is a paid mutator transaction binding the contract method 0x2e0b437d.
+//
+// Solidity: function addModuleValidator(address validator, bytes initData) returns()
+func (_IValidatorManager *IValidatorManagerTransactorSession) AddModuleValidator(validator common.Address, initData []byte) (*types.Transaction, error) {
+	return _IValidatorManager.Contract.AddModuleValidator(&_IValidatorManager.TransactOpts, validator, initData)
+}
+
+// RemoveModuleValidator is a paid mutator transaction binding the contract method 0xb027e50a.
+//
+// Solidity: function removeModuleValidator(address validator, bytes deinitData) returns()
+func (_IValidatorManager *IValidatorManagerTransactor) RemoveModuleValidator(opts *bind.TransactOpts, validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _IValidatorManager.contract.Transact(opts, "removeModuleValidator", validator, deinitData)
+}
+
+// RemoveModuleValidator is a paid mutator transaction binding the contract method 0xb027e50a.
+//
+// Solidity: function removeModuleValidator(address validator, bytes deinitData) returns()
+func (_IValidatorManager *IValidatorManagerSession) RemoveModuleValidator(validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _IValidatorManager.Contract.RemoveModuleValidator(&_IValidatorManager.TransactOpts, validator, deinitData)
+}
+
+// RemoveModuleValidator is a paid mutator transaction binding the contract method 0xb027e50a.
+//
+// Solidity: function removeModuleValidator(address validator, bytes deinitData) returns()
+func (_IValidatorManager *IValidatorManagerTransactorSession) RemoveModuleValidator(validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _IValidatorManager.Contract.RemoveModuleValidator(&_IValidatorManager.TransactOpts, validator, deinitData)
+}
+
+// UnlinkModuleValidator is a paid mutator transaction binding the contract method 0xa7d525e8.
+//
+// Solidity: function unlinkModuleValidator(address validator, bytes deinitData) returns()
+func (_IValidatorManager *IValidatorManagerTransactor) UnlinkModuleValidator(opts *bind.TransactOpts, validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _IValidatorManager.contract.Transact(opts, "unlinkModuleValidator", validator, deinitData)
+}
+
+// UnlinkModuleValidator is a paid mutator transaction binding the contract method 0xa7d525e8.
+//
+// Solidity: function unlinkModuleValidator(address validator, bytes deinitData) returns()
+func (_IValidatorManager *IValidatorManagerSession) UnlinkModuleValidator(validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _IValidatorManager.Contract.UnlinkModuleValidator(&_IValidatorManager.TransactOpts, validator, deinitData)
+}
+
+// UnlinkModuleValidator is a paid mutator transaction binding the contract method 0xa7d525e8.
+//
+// Solidity: function unlinkModuleValidator(address validator, bytes deinitData) returns()
+func (_IValidatorManager *IValidatorManagerTransactorSession) UnlinkModuleValidator(validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _IValidatorManager.Contract.UnlinkModuleValidator(&_IValidatorManager.TransactOpts, validator, deinitData)
+}
+
+// IValidatorManagerValidatorAddedIterator is returned from FilterValidatorAdded and is used to iterate over the raw logs and unpacked data for ValidatorAdded events raised by the IValidatorManager contract.
+type IValidatorManagerValidatorAddedIterator struct {
+	Event *IValidatorManagerValidatorAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *IValidatorManagerValidatorAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(IValidatorManagerValidatorAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(IValidatorManagerValidatorAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *IValidatorManagerValidatorAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *IValidatorManagerValidatorAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// IValidatorManagerValidatorAdded represents a ValidatorAdded event raised by the IValidatorManager contract.
+type IValidatorManagerValidatorAdded struct {
+	Validator common.Address
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterValidatorAdded is a free log retrieval operation binding the contract event 0xe366c1c0452ed8eec96861e9e54141ebff23c9ec89fe27b996b45f5ec3884987.
+//
+// Solidity: event ValidatorAdded(address indexed validator)
+func (_IValidatorManager *IValidatorManagerFilterer) FilterValidatorAdded(opts *bind.FilterOpts, validator []common.Address) (*IValidatorManagerValidatorAddedIterator, error) {
+
+	var validatorRule []interface{}
+	for _, validatorItem := range validator {
+		validatorRule = append(validatorRule, validatorItem)
+	}
+
+	logs, sub, err := _IValidatorManager.contract.FilterLogs(opts, "ValidatorAdded", validatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &IValidatorManagerValidatorAddedIterator{contract: _IValidatorManager.contract, event: "ValidatorAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchValidatorAdded is a free log subscription operation binding the contract event 0xe366c1c0452ed8eec96861e9e54141ebff23c9ec89fe27b996b45f5ec3884987.
+//
+// Solidity: event ValidatorAdded(address indexed validator)
+func (_IValidatorManager *IValidatorManagerFilterer) WatchValidatorAdded(opts *bind.WatchOpts, sink chan<- *IValidatorManagerValidatorAdded, validator []common.Address) (event.Subscription, error) {
+
+	var validatorRule []interface{}
+	for _, validatorItem := range validator {
+		validatorRule = append(validatorRule, validatorItem)
+	}
+
+	logs, sub, err := _IValidatorManager.contract.WatchLogs(opts, "ValidatorAdded", validatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(IValidatorManagerValidatorAdded)
+				if err := _IValidatorManager.contract.UnpackLog(event, "ValidatorAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseValidatorAdded is a log parse operation binding the contract event 0xe366c1c0452ed8eec96861e9e54141ebff23c9ec89fe27b996b45f5ec3884987.
+//
+// Solidity: event ValidatorAdded(address indexed validator)
+func (_IValidatorManager *IValidatorManagerFilterer) ParseValidatorAdded(log types.Log) (*IValidatorManagerValidatorAdded, error) {
+	event := new(IValidatorManagerValidatorAdded)
+	if err := _IValidatorManager.contract.UnpackLog(event, "ValidatorAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// IValidatorManagerValidatorRemovedIterator is returned from FilterValidatorRemoved and is used to iterate over the raw logs and unpacked data for ValidatorRemoved events raised by the IValidatorManager contract.
+type IValidatorManagerValidatorRemovedIterator struct {
+	Event *IValidatorManagerValidatorRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *IValidatorManagerValidatorRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(IValidatorManagerValidatorRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(IValidatorManagerValidatorRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *IValidatorManagerValidatorRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *IValidatorManagerValidatorRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// IValidatorManagerValidatorRemoved represents a ValidatorRemoved event raised by the IValidatorManager contract.
+type IValidatorManagerValidatorRemoved struct {
+	Validator common.Address
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterValidatorRemoved is a free log retrieval operation binding the contract event 0xe1434e25d6611e0db941968fdc97811c982ac1602e951637d206f5fdda9dd8f1.
+//
+// Solidity: event ValidatorRemoved(address indexed validator)
+func (_IValidatorManager *IValidatorManagerFilterer) FilterValidatorRemoved(opts *bind.FilterOpts, validator []common.Address) (*IValidatorManagerValidatorRemovedIterator, error) {
+
+	var validatorRule []interface{}
+	for _, validatorItem := range validator {
+		validatorRule = append(validatorRule, validatorItem)
+	}
+
+	logs, sub, err := _IValidatorManager.contract.FilterLogs(opts, "ValidatorRemoved", validatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &IValidatorManagerValidatorRemovedIterator{contract: _IValidatorManager.contract, event: "ValidatorRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchValidatorRemoved is a free log subscription operation binding the contract event 0xe1434e25d6611e0db941968fdc97811c982ac1602e951637d206f5fdda9dd8f1.
+//
+// Solidity: event ValidatorRemoved(address indexed validator)
+func (_IValidatorManager *IValidatorManagerFilterer) WatchValidatorRemoved(opts *bind.WatchOpts, sink chan<- *IValidatorManagerValidatorRemoved, validator []common.Address) (event.Subscription, error) {
+
+	var validatorRule []interface{}
+	for _, validatorItem := range validator {
+		validatorRule = append(validatorRule, validatorItem)
+	}
+
+	logs, sub, err := _IValidatorManager.contract.WatchLogs(opts, "ValidatorRemoved", validatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(IValidatorManagerValidatorRemoved)
+				if err := _IValidatorManager.contract.UnpackLog(event, "ValidatorRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseValidatorRemoved is a log parse operation binding the contract event 0xe1434e25d6611e0db941968fdc97811c982ac1602e951637d206f5fdda9dd8f1.
+//
+// Solidity: event ValidatorRemoved(address indexed validator)
+func (_IValidatorManager *IValidatorManagerFilterer) ParseValidatorRemoved(log types.Log) (*IValidatorManagerValidatorRemoved, error) {
+	event := new(IValidatorManagerValidatorRemoved)
+	if err := _IValidatorManager.contract.UnpackLog(event, "ValidatorRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts/zksyncsso/libraries/errors/errors.go
+++ b/contracts/zksyncsso/libraries/errors/errors.go
@@ -1,0 +1,181 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package errors
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// ErrorsMetaData contains all meta data concerning the Errors contract.
+var ErrorsMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"ACCOUNT_ALREADY_EXISTS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"ADDRESS_CAST_OVERFLOW\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"actualValue\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expectedValue\",\"type\":\"uint256\"}],\"name\":\"BATCH_MSG_VALUE_MISMATCH\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"FEE_PAYMENT_FAILED\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"}],\"name\":\"HOOK_ALREADY_EXISTS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"hookAddress\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"}],\"name\":\"HOOK_ERC165_FAIL\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"}],\"name\":\"HOOK_NOT_FOUND\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"required\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"available\",\"type\":\"uint256\"}],\"name\":\"INSUFFICIENT_FUNDS\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"INVALID_ACCOUNT_KEYS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"input\",\"type\":\"bytes\"}],\"name\":\"INVALID_PAYMASTER_INPUT\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"METHOD_NOT_IMPLEMENTED\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"notBootloader\",\"type\":\"address\"}],\"name\":\"NOT_FROM_BOOTLOADER\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"notInitialized\",\"type\":\"address\"}],\"name\":\"NOT_FROM_INITIALIZED_ACCOUNT\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"notSelf\",\"type\":\"address\"}],\"name\":\"NOT_FROM_SELF\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"chainId\",\"type\":\"uint256\"}],\"name\":\"NO_TIMESTAMP_ASSERTER\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OWNER_ALREADY_EXISTS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OWNER_NOT_FOUND\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"allowance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxAllowance\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"period\",\"type\":\"uint64\"}],\"name\":\"SESSION_ALLOWANCE_EXCEEDED\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"sessionHash\",\"type\":\"bytes32\"}],\"name\":\"SESSION_ALREADY_EXISTS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"},{\"internalType\":\"bytes4\",\"name\":\"selector\",\"type\":\"bytes4\"}],\"name\":\"SESSION_CALL_POLICY_VIOLATED\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"param\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"refValue\",\"type\":\"bytes32\"},{\"internalType\":\"uint8\",\"name\":\"condition\",\"type\":\"uint8\"}],\"name\":\"SESSION_CONDITION_FAILED\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"expiresAt\",\"type\":\"uint256\"}],\"name\":\"SESSION_EXPIRES_TOO_SOON\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"actualLength\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expectedMinimumLength\",\"type\":\"uint256\"}],\"name\":\"SESSION_INVALID_DATA_LENGTH\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"recovered\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"expected\",\"type\":\"address\"}],\"name\":\"SESSION_INVALID_SIGNER\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"lifetimeUsage\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxUsage\",\"type\":\"uint256\"}],\"name\":\"SESSION_LIFETIME_USAGE_EXCEEDED\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"usedValue\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxValuePerUse\",\"type\":\"uint256\"}],\"name\":\"SESSION_MAX_VALUE_EXCEEDED\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"SESSION_NOT_ACTIVE\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"}],\"name\":\"SESSION_TRANSFER_POLICY_VIOLATED\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"SESSION_UNLIMITED_FEES\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"SESSION_ZERO_SIGNER\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"openSessions\",\"type\":\"uint256\"}],\"name\":\"UNINSTALL_WITH_OPEN_SESSIONS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"VALIDATOR_ALREADY_EXISTS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"VALIDATOR_ERC165_FAIL\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"VALIDATOR_NOT_FOUND\",\"type\":\"error\"}]",
+}
+
+// ErrorsABI is the input ABI used to generate the binding from.
+// Deprecated: Use ErrorsMetaData.ABI instead.
+var ErrorsABI = ErrorsMetaData.ABI
+
+// Errors is an auto generated Go binding around an Ethereum contract.
+type Errors struct {
+	ErrorsCaller     // Read-only binding to the contract
+	ErrorsTransactor // Write-only binding to the contract
+	ErrorsFilterer   // Log filterer for contract events
+}
+
+// ErrorsCaller is an auto generated read-only Go binding around an Ethereum contract.
+type ErrorsCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ErrorsTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type ErrorsTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ErrorsFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type ErrorsFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ErrorsSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type ErrorsSession struct {
+	Contract     *Errors           // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// ErrorsCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type ErrorsCallerSession struct {
+	Contract *ErrorsCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts // Call options to use throughout this session
+}
+
+// ErrorsTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type ErrorsTransactorSession struct {
+	Contract     *ErrorsTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// ErrorsRaw is an auto generated low-level Go binding around an Ethereum contract.
+type ErrorsRaw struct {
+	Contract *Errors // Generic contract binding to access the raw methods on
+}
+
+// ErrorsCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type ErrorsCallerRaw struct {
+	Contract *ErrorsCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// ErrorsTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type ErrorsTransactorRaw struct {
+	Contract *ErrorsTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewErrors creates a new instance of Errors, bound to a specific deployed contract.
+func NewErrors(address common.Address, backend bind.ContractBackend) (*Errors, error) {
+	contract, err := bindErrors(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Errors{ErrorsCaller: ErrorsCaller{contract: contract}, ErrorsTransactor: ErrorsTransactor{contract: contract}, ErrorsFilterer: ErrorsFilterer{contract: contract}}, nil
+}
+
+// NewErrorsCaller creates a new read-only instance of Errors, bound to a specific deployed contract.
+func NewErrorsCaller(address common.Address, caller bind.ContractCaller) (*ErrorsCaller, error) {
+	contract, err := bindErrors(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ErrorsCaller{contract: contract}, nil
+}
+
+// NewErrorsTransactor creates a new write-only instance of Errors, bound to a specific deployed contract.
+func NewErrorsTransactor(address common.Address, transactor bind.ContractTransactor) (*ErrorsTransactor, error) {
+	contract, err := bindErrors(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ErrorsTransactor{contract: contract}, nil
+}
+
+// NewErrorsFilterer creates a new log filterer instance of Errors, bound to a specific deployed contract.
+func NewErrorsFilterer(address common.Address, filterer bind.ContractFilterer) (*ErrorsFilterer, error) {
+	contract, err := bindErrors(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &ErrorsFilterer{contract: contract}, nil
+}
+
+// bindErrors binds a generic wrapper to an already deployed contract.
+func bindErrors(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := ErrorsMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Errors *ErrorsRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Errors.Contract.ErrorsCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Errors *ErrorsRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Errors.Contract.ErrorsTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Errors *ErrorsRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Errors.Contract.ErrorsTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Errors *ErrorsCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Errors.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Errors *ErrorsTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Errors.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Errors *ErrorsTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Errors.Contract.contract.Transact(opts, method, params...)
+}

--- a/contracts/zksyncsso/libraries/sessionlib/sessionlib.go
+++ b/contracts/zksyncsso/libraries/sessionlib/sessionlib.go
@@ -1,0 +1,181 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package sessionlib
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// SessionLibMetaData contains all meta data concerning the SessionLib contract.
+var SessionLibMetaData = &bind.MetaData{
+	ABI: "[]",
+}
+
+// SessionLibABI is the input ABI used to generate the binding from.
+// Deprecated: Use SessionLibMetaData.ABI instead.
+var SessionLibABI = SessionLibMetaData.ABI
+
+// SessionLib is an auto generated Go binding around an Ethereum contract.
+type SessionLib struct {
+	SessionLibCaller     // Read-only binding to the contract
+	SessionLibTransactor // Write-only binding to the contract
+	SessionLibFilterer   // Log filterer for contract events
+}
+
+// SessionLibCaller is an auto generated read-only Go binding around an Ethereum contract.
+type SessionLibCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// SessionLibTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type SessionLibTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// SessionLibFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type SessionLibFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// SessionLibSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type SessionLibSession struct {
+	Contract     *SessionLib       // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// SessionLibCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type SessionLibCallerSession struct {
+	Contract *SessionLibCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts     // Call options to use throughout this session
+}
+
+// SessionLibTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type SessionLibTransactorSession struct {
+	Contract     *SessionLibTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts     // Transaction auth options to use throughout this session
+}
+
+// SessionLibRaw is an auto generated low-level Go binding around an Ethereum contract.
+type SessionLibRaw struct {
+	Contract *SessionLib // Generic contract binding to access the raw methods on
+}
+
+// SessionLibCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type SessionLibCallerRaw struct {
+	Contract *SessionLibCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// SessionLibTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type SessionLibTransactorRaw struct {
+	Contract *SessionLibTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewSessionLib creates a new instance of SessionLib, bound to a specific deployed contract.
+func NewSessionLib(address common.Address, backend bind.ContractBackend) (*SessionLib, error) {
+	contract, err := bindSessionLib(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &SessionLib{SessionLibCaller: SessionLibCaller{contract: contract}, SessionLibTransactor: SessionLibTransactor{contract: contract}, SessionLibFilterer: SessionLibFilterer{contract: contract}}, nil
+}
+
+// NewSessionLibCaller creates a new read-only instance of SessionLib, bound to a specific deployed contract.
+func NewSessionLibCaller(address common.Address, caller bind.ContractCaller) (*SessionLibCaller, error) {
+	contract, err := bindSessionLib(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &SessionLibCaller{contract: contract}, nil
+}
+
+// NewSessionLibTransactor creates a new write-only instance of SessionLib, bound to a specific deployed contract.
+func NewSessionLibTransactor(address common.Address, transactor bind.ContractTransactor) (*SessionLibTransactor, error) {
+	contract, err := bindSessionLib(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &SessionLibTransactor{contract: contract}, nil
+}
+
+// NewSessionLibFilterer creates a new log filterer instance of SessionLib, bound to a specific deployed contract.
+func NewSessionLibFilterer(address common.Address, filterer bind.ContractFilterer) (*SessionLibFilterer, error) {
+	contract, err := bindSessionLib(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &SessionLibFilterer{contract: contract}, nil
+}
+
+// bindSessionLib binds a generic wrapper to an already deployed contract.
+func bindSessionLib(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := SessionLibMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_SessionLib *SessionLibRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _SessionLib.Contract.SessionLibCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_SessionLib *SessionLibRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _SessionLib.Contract.SessionLibTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_SessionLib *SessionLibRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _SessionLib.Contract.SessionLibTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_SessionLib *SessionLibCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _SessionLib.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_SessionLib *SessionLibTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _SessionLib.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_SessionLib *SessionLibTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _SessionLib.Contract.contract.Transact(opts, method, params...)
+}

--- a/contracts/zksyncsso/libraries/signaturedecoder/signaturedecoder.go
+++ b/contracts/zksyncsso/libraries/signaturedecoder/signaturedecoder.go
@@ -1,0 +1,181 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package signaturedecoder
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// SignatureDecoderMetaData contains all meta data concerning the SignatureDecoder contract.
+var SignatureDecoderMetaData = &bind.MetaData{
+	ABI: "[]",
+}
+
+// SignatureDecoderABI is the input ABI used to generate the binding from.
+// Deprecated: Use SignatureDecoderMetaData.ABI instead.
+var SignatureDecoderABI = SignatureDecoderMetaData.ABI
+
+// SignatureDecoder is an auto generated Go binding around an Ethereum contract.
+type SignatureDecoder struct {
+	SignatureDecoderCaller     // Read-only binding to the contract
+	SignatureDecoderTransactor // Write-only binding to the contract
+	SignatureDecoderFilterer   // Log filterer for contract events
+}
+
+// SignatureDecoderCaller is an auto generated read-only Go binding around an Ethereum contract.
+type SignatureDecoderCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// SignatureDecoderTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type SignatureDecoderTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// SignatureDecoderFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type SignatureDecoderFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// SignatureDecoderSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type SignatureDecoderSession struct {
+	Contract     *SignatureDecoder // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// SignatureDecoderCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type SignatureDecoderCallerSession struct {
+	Contract *SignatureDecoderCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts           // Call options to use throughout this session
+}
+
+// SignatureDecoderTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type SignatureDecoderTransactorSession struct {
+	Contract     *SignatureDecoderTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts           // Transaction auth options to use throughout this session
+}
+
+// SignatureDecoderRaw is an auto generated low-level Go binding around an Ethereum contract.
+type SignatureDecoderRaw struct {
+	Contract *SignatureDecoder // Generic contract binding to access the raw methods on
+}
+
+// SignatureDecoderCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type SignatureDecoderCallerRaw struct {
+	Contract *SignatureDecoderCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// SignatureDecoderTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type SignatureDecoderTransactorRaw struct {
+	Contract *SignatureDecoderTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewSignatureDecoder creates a new instance of SignatureDecoder, bound to a specific deployed contract.
+func NewSignatureDecoder(address common.Address, backend bind.ContractBackend) (*SignatureDecoder, error) {
+	contract, err := bindSignatureDecoder(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &SignatureDecoder{SignatureDecoderCaller: SignatureDecoderCaller{contract: contract}, SignatureDecoderTransactor: SignatureDecoderTransactor{contract: contract}, SignatureDecoderFilterer: SignatureDecoderFilterer{contract: contract}}, nil
+}
+
+// NewSignatureDecoderCaller creates a new read-only instance of SignatureDecoder, bound to a specific deployed contract.
+func NewSignatureDecoderCaller(address common.Address, caller bind.ContractCaller) (*SignatureDecoderCaller, error) {
+	contract, err := bindSignatureDecoder(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &SignatureDecoderCaller{contract: contract}, nil
+}
+
+// NewSignatureDecoderTransactor creates a new write-only instance of SignatureDecoder, bound to a specific deployed contract.
+func NewSignatureDecoderTransactor(address common.Address, transactor bind.ContractTransactor) (*SignatureDecoderTransactor, error) {
+	contract, err := bindSignatureDecoder(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &SignatureDecoderTransactor{contract: contract}, nil
+}
+
+// NewSignatureDecoderFilterer creates a new log filterer instance of SignatureDecoder, bound to a specific deployed contract.
+func NewSignatureDecoderFilterer(address common.Address, filterer bind.ContractFilterer) (*SignatureDecoderFilterer, error) {
+	contract, err := bindSignatureDecoder(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &SignatureDecoderFilterer{contract: contract}, nil
+}
+
+// bindSignatureDecoder binds a generic wrapper to an already deployed contract.
+func bindSignatureDecoder(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := SignatureDecoderMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_SignatureDecoder *SignatureDecoderRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _SignatureDecoder.Contract.SignatureDecoderCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_SignatureDecoder *SignatureDecoderRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _SignatureDecoder.Contract.SignatureDecoderTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_SignatureDecoder *SignatureDecoderRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _SignatureDecoder.Contract.SignatureDecoderTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_SignatureDecoder *SignatureDecoderCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _SignatureDecoder.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_SignatureDecoder *SignatureDecoderTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _SignatureDecoder.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_SignatureDecoder *SignatureDecoderTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _SignatureDecoder.Contract.contract.Transact(opts, method, params...)
+}

--- a/contracts/zksyncsso/libraries/ssostorage/ssostorage.go
+++ b/contracts/zksyncsso/libraries/ssostorage/ssostorage.go
@@ -1,0 +1,181 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package ssostorage
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// SsoStorageMetaData contains all meta data concerning the SsoStorage contract.
+var SsoStorageMetaData = &bind.MetaData{
+	ABI: "[]",
+}
+
+// SsoStorageABI is the input ABI used to generate the binding from.
+// Deprecated: Use SsoStorageMetaData.ABI instead.
+var SsoStorageABI = SsoStorageMetaData.ABI
+
+// SsoStorage is an auto generated Go binding around an Ethereum contract.
+type SsoStorage struct {
+	SsoStorageCaller     // Read-only binding to the contract
+	SsoStorageTransactor // Write-only binding to the contract
+	SsoStorageFilterer   // Log filterer for contract events
+}
+
+// SsoStorageCaller is an auto generated read-only Go binding around an Ethereum contract.
+type SsoStorageCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// SsoStorageTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type SsoStorageTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// SsoStorageFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type SsoStorageFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// SsoStorageSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type SsoStorageSession struct {
+	Contract     *SsoStorage       // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// SsoStorageCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type SsoStorageCallerSession struct {
+	Contract *SsoStorageCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts     // Call options to use throughout this session
+}
+
+// SsoStorageTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type SsoStorageTransactorSession struct {
+	Contract     *SsoStorageTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts     // Transaction auth options to use throughout this session
+}
+
+// SsoStorageRaw is an auto generated low-level Go binding around an Ethereum contract.
+type SsoStorageRaw struct {
+	Contract *SsoStorage // Generic contract binding to access the raw methods on
+}
+
+// SsoStorageCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type SsoStorageCallerRaw struct {
+	Contract *SsoStorageCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// SsoStorageTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type SsoStorageTransactorRaw struct {
+	Contract *SsoStorageTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewSsoStorage creates a new instance of SsoStorage, bound to a specific deployed contract.
+func NewSsoStorage(address common.Address, backend bind.ContractBackend) (*SsoStorage, error) {
+	contract, err := bindSsoStorage(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &SsoStorage{SsoStorageCaller: SsoStorageCaller{contract: contract}, SsoStorageTransactor: SsoStorageTransactor{contract: contract}, SsoStorageFilterer: SsoStorageFilterer{contract: contract}}, nil
+}
+
+// NewSsoStorageCaller creates a new read-only instance of SsoStorage, bound to a specific deployed contract.
+func NewSsoStorageCaller(address common.Address, caller bind.ContractCaller) (*SsoStorageCaller, error) {
+	contract, err := bindSsoStorage(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &SsoStorageCaller{contract: contract}, nil
+}
+
+// NewSsoStorageTransactor creates a new write-only instance of SsoStorage, bound to a specific deployed contract.
+func NewSsoStorageTransactor(address common.Address, transactor bind.ContractTransactor) (*SsoStorageTransactor, error) {
+	contract, err := bindSsoStorage(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &SsoStorageTransactor{contract: contract}, nil
+}
+
+// NewSsoStorageFilterer creates a new log filterer instance of SsoStorage, bound to a specific deployed contract.
+func NewSsoStorageFilterer(address common.Address, filterer bind.ContractFilterer) (*SsoStorageFilterer, error) {
+	contract, err := bindSsoStorage(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &SsoStorageFilterer{contract: contract}, nil
+}
+
+// bindSsoStorage binds a generic wrapper to an already deployed contract.
+func bindSsoStorage(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := SsoStorageMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_SsoStorage *SsoStorageRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _SsoStorage.Contract.SsoStorageCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_SsoStorage *SsoStorageRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _SsoStorage.Contract.SsoStorageTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_SsoStorage *SsoStorageRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _SsoStorage.Contract.SsoStorageTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_SsoStorage *SsoStorageCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _SsoStorage.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_SsoStorage *SsoStorageTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _SsoStorage.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_SsoStorage *SsoStorageTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _SsoStorage.Contract.contract.Transact(opts, method, params...)
+}

--- a/contracts/zksyncsso/managers/hookmanager/hookmanager.go
+++ b/contracts/zksyncsso/managers/hookmanager/hookmanager.go
@@ -1,0 +1,594 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package hookmanager
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// HookManagerMetaData contains all meta data concerning the HookManager contract.
+var HookManagerMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"}],\"name\":\"HOOK_ALREADY_EXISTS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"hookAddress\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"}],\"name\":\"HOOK_ERC165_FAIL\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"}],\"name\":\"HOOK_NOT_FOUND\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"notSelf\",\"type\":\"address\"}],\"name\":\"NOT_FROM_SELF\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"VALIDATOR_ALREADY_EXISTS\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"}],\"name\":\"HookAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"}],\"name\":\"HookRemoved\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"},{\"internalType\":\"bytes\",\"name\":\"initData\",\"type\":\"bytes\"}],\"name\":\"addHook\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"isHook\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"}],\"name\":\"listHooks\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"hookList\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"},{\"internalType\":\"bytes\",\"name\":\"deinitData\",\"type\":\"bytes\"}],\"name\":\"removeHook\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"},{\"internalType\":\"bytes\",\"name\":\"deinitData\",\"type\":\"bytes\"}],\"name\":\"unlinkHook\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+}
+
+// HookManagerABI is the input ABI used to generate the binding from.
+// Deprecated: Use HookManagerMetaData.ABI instead.
+var HookManagerABI = HookManagerMetaData.ABI
+
+// HookManager is an auto generated Go binding around an Ethereum contract.
+type HookManager struct {
+	HookManagerCaller     // Read-only binding to the contract
+	HookManagerTransactor // Write-only binding to the contract
+	HookManagerFilterer   // Log filterer for contract events
+}
+
+// HookManagerCaller is an auto generated read-only Go binding around an Ethereum contract.
+type HookManagerCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// HookManagerTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type HookManagerTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// HookManagerFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type HookManagerFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// HookManagerSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type HookManagerSession struct {
+	Contract     *HookManager      // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// HookManagerCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type HookManagerCallerSession struct {
+	Contract *HookManagerCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts      // Call options to use throughout this session
+}
+
+// HookManagerTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type HookManagerTransactorSession struct {
+	Contract     *HookManagerTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts      // Transaction auth options to use throughout this session
+}
+
+// HookManagerRaw is an auto generated low-level Go binding around an Ethereum contract.
+type HookManagerRaw struct {
+	Contract *HookManager // Generic contract binding to access the raw methods on
+}
+
+// HookManagerCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type HookManagerCallerRaw struct {
+	Contract *HookManagerCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// HookManagerTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type HookManagerTransactorRaw struct {
+	Contract *HookManagerTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewHookManager creates a new instance of HookManager, bound to a specific deployed contract.
+func NewHookManager(address common.Address, backend bind.ContractBackend) (*HookManager, error) {
+	contract, err := bindHookManager(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &HookManager{HookManagerCaller: HookManagerCaller{contract: contract}, HookManagerTransactor: HookManagerTransactor{contract: contract}, HookManagerFilterer: HookManagerFilterer{contract: contract}}, nil
+}
+
+// NewHookManagerCaller creates a new read-only instance of HookManager, bound to a specific deployed contract.
+func NewHookManagerCaller(address common.Address, caller bind.ContractCaller) (*HookManagerCaller, error) {
+	contract, err := bindHookManager(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &HookManagerCaller{contract: contract}, nil
+}
+
+// NewHookManagerTransactor creates a new write-only instance of HookManager, bound to a specific deployed contract.
+func NewHookManagerTransactor(address common.Address, transactor bind.ContractTransactor) (*HookManagerTransactor, error) {
+	contract, err := bindHookManager(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &HookManagerTransactor{contract: contract}, nil
+}
+
+// NewHookManagerFilterer creates a new log filterer instance of HookManager, bound to a specific deployed contract.
+func NewHookManagerFilterer(address common.Address, filterer bind.ContractFilterer) (*HookManagerFilterer, error) {
+	contract, err := bindHookManager(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &HookManagerFilterer{contract: contract}, nil
+}
+
+// bindHookManager binds a generic wrapper to an already deployed contract.
+func bindHookManager(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := HookManagerMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_HookManager *HookManagerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _HookManager.Contract.HookManagerCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_HookManager *HookManagerRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _HookManager.Contract.HookManagerTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_HookManager *HookManagerRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _HookManager.Contract.HookManagerTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_HookManager *HookManagerCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _HookManager.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_HookManager *HookManagerTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _HookManager.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_HookManager *HookManagerTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _HookManager.Contract.contract.Transact(opts, method, params...)
+}
+
+// IsHook is a free data retrieval call binding the contract method 0xd2676529.
+//
+// Solidity: function isHook(address addr) view returns(bool)
+func (_HookManager *HookManagerCaller) IsHook(opts *bind.CallOpts, addr common.Address) (bool, error) {
+	var out []interface{}
+	err := _HookManager.contract.Call(opts, &out, "isHook", addr)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsHook is a free data retrieval call binding the contract method 0xd2676529.
+//
+// Solidity: function isHook(address addr) view returns(bool)
+func (_HookManager *HookManagerSession) IsHook(addr common.Address) (bool, error) {
+	return _HookManager.Contract.IsHook(&_HookManager.CallOpts, addr)
+}
+
+// IsHook is a free data retrieval call binding the contract method 0xd2676529.
+//
+// Solidity: function isHook(address addr) view returns(bool)
+func (_HookManager *HookManagerCallerSession) IsHook(addr common.Address) (bool, error) {
+	return _HookManager.Contract.IsHook(&_HookManager.CallOpts, addr)
+}
+
+// ListHooks is a free data retrieval call binding the contract method 0xdb8a323f.
+//
+// Solidity: function listHooks(bool isValidation) view returns(address[] hookList)
+func (_HookManager *HookManagerCaller) ListHooks(opts *bind.CallOpts, isValidation bool) ([]common.Address, error) {
+	var out []interface{}
+	err := _HookManager.contract.Call(opts, &out, "listHooks", isValidation)
+
+	if err != nil {
+		return *new([]common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
+
+	return out0, err
+
+}
+
+// ListHooks is a free data retrieval call binding the contract method 0xdb8a323f.
+//
+// Solidity: function listHooks(bool isValidation) view returns(address[] hookList)
+func (_HookManager *HookManagerSession) ListHooks(isValidation bool) ([]common.Address, error) {
+	return _HookManager.Contract.ListHooks(&_HookManager.CallOpts, isValidation)
+}
+
+// ListHooks is a free data retrieval call binding the contract method 0xdb8a323f.
+//
+// Solidity: function listHooks(bool isValidation) view returns(address[] hookList)
+func (_HookManager *HookManagerCallerSession) ListHooks(isValidation bool) ([]common.Address, error) {
+	return _HookManager.Contract.ListHooks(&_HookManager.CallOpts, isValidation)
+}
+
+// AddHook is a paid mutator transaction binding the contract method 0x0775a94e.
+//
+// Solidity: function addHook(address hook, bool isValidation, bytes initData) returns()
+func (_HookManager *HookManagerTransactor) AddHook(opts *bind.TransactOpts, hook common.Address, isValidation bool, initData []byte) (*types.Transaction, error) {
+	return _HookManager.contract.Transact(opts, "addHook", hook, isValidation, initData)
+}
+
+// AddHook is a paid mutator transaction binding the contract method 0x0775a94e.
+//
+// Solidity: function addHook(address hook, bool isValidation, bytes initData) returns()
+func (_HookManager *HookManagerSession) AddHook(hook common.Address, isValidation bool, initData []byte) (*types.Transaction, error) {
+	return _HookManager.Contract.AddHook(&_HookManager.TransactOpts, hook, isValidation, initData)
+}
+
+// AddHook is a paid mutator transaction binding the contract method 0x0775a94e.
+//
+// Solidity: function addHook(address hook, bool isValidation, bytes initData) returns()
+func (_HookManager *HookManagerTransactorSession) AddHook(hook common.Address, isValidation bool, initData []byte) (*types.Transaction, error) {
+	return _HookManager.Contract.AddHook(&_HookManager.TransactOpts, hook, isValidation, initData)
+}
+
+// RemoveHook is a paid mutator transaction binding the contract method 0xe1551286.
+//
+// Solidity: function removeHook(address hook, bool isValidation, bytes deinitData) returns()
+func (_HookManager *HookManagerTransactor) RemoveHook(opts *bind.TransactOpts, hook common.Address, isValidation bool, deinitData []byte) (*types.Transaction, error) {
+	return _HookManager.contract.Transact(opts, "removeHook", hook, isValidation, deinitData)
+}
+
+// RemoveHook is a paid mutator transaction binding the contract method 0xe1551286.
+//
+// Solidity: function removeHook(address hook, bool isValidation, bytes deinitData) returns()
+func (_HookManager *HookManagerSession) RemoveHook(hook common.Address, isValidation bool, deinitData []byte) (*types.Transaction, error) {
+	return _HookManager.Contract.RemoveHook(&_HookManager.TransactOpts, hook, isValidation, deinitData)
+}
+
+// RemoveHook is a paid mutator transaction binding the contract method 0xe1551286.
+//
+// Solidity: function removeHook(address hook, bool isValidation, bytes deinitData) returns()
+func (_HookManager *HookManagerTransactorSession) RemoveHook(hook common.Address, isValidation bool, deinitData []byte) (*types.Transaction, error) {
+	return _HookManager.Contract.RemoveHook(&_HookManager.TransactOpts, hook, isValidation, deinitData)
+}
+
+// UnlinkHook is a paid mutator transaction binding the contract method 0x126c46c1.
+//
+// Solidity: function unlinkHook(address hook, bool isValidation, bytes deinitData) returns()
+func (_HookManager *HookManagerTransactor) UnlinkHook(opts *bind.TransactOpts, hook common.Address, isValidation bool, deinitData []byte) (*types.Transaction, error) {
+	return _HookManager.contract.Transact(opts, "unlinkHook", hook, isValidation, deinitData)
+}
+
+// UnlinkHook is a paid mutator transaction binding the contract method 0x126c46c1.
+//
+// Solidity: function unlinkHook(address hook, bool isValidation, bytes deinitData) returns()
+func (_HookManager *HookManagerSession) UnlinkHook(hook common.Address, isValidation bool, deinitData []byte) (*types.Transaction, error) {
+	return _HookManager.Contract.UnlinkHook(&_HookManager.TransactOpts, hook, isValidation, deinitData)
+}
+
+// UnlinkHook is a paid mutator transaction binding the contract method 0x126c46c1.
+//
+// Solidity: function unlinkHook(address hook, bool isValidation, bytes deinitData) returns()
+func (_HookManager *HookManagerTransactorSession) UnlinkHook(hook common.Address, isValidation bool, deinitData []byte) (*types.Transaction, error) {
+	return _HookManager.Contract.UnlinkHook(&_HookManager.TransactOpts, hook, isValidation, deinitData)
+}
+
+// HookManagerHookAddedIterator is returned from FilterHookAdded and is used to iterate over the raw logs and unpacked data for HookAdded events raised by the HookManager contract.
+type HookManagerHookAddedIterator struct {
+	Event *HookManagerHookAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *HookManagerHookAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(HookManagerHookAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(HookManagerHookAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *HookManagerHookAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *HookManagerHookAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// HookManagerHookAdded represents a HookAdded event raised by the HookManager contract.
+type HookManagerHookAdded struct {
+	Hook common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterHookAdded is a free log retrieval operation binding the contract event 0x28e00134722f84e69c391c81e4fe022ee3e61048222a8ea2f98c9f235f797508.
+//
+// Solidity: event HookAdded(address indexed hook)
+func (_HookManager *HookManagerFilterer) FilterHookAdded(opts *bind.FilterOpts, hook []common.Address) (*HookManagerHookAddedIterator, error) {
+
+	var hookRule []interface{}
+	for _, hookItem := range hook {
+		hookRule = append(hookRule, hookItem)
+	}
+
+	logs, sub, err := _HookManager.contract.FilterLogs(opts, "HookAdded", hookRule)
+	if err != nil {
+		return nil, err
+	}
+	return &HookManagerHookAddedIterator{contract: _HookManager.contract, event: "HookAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchHookAdded is a free log subscription operation binding the contract event 0x28e00134722f84e69c391c81e4fe022ee3e61048222a8ea2f98c9f235f797508.
+//
+// Solidity: event HookAdded(address indexed hook)
+func (_HookManager *HookManagerFilterer) WatchHookAdded(opts *bind.WatchOpts, sink chan<- *HookManagerHookAdded, hook []common.Address) (event.Subscription, error) {
+
+	var hookRule []interface{}
+	for _, hookItem := range hook {
+		hookRule = append(hookRule, hookItem)
+	}
+
+	logs, sub, err := _HookManager.contract.WatchLogs(opts, "HookAdded", hookRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(HookManagerHookAdded)
+				if err := _HookManager.contract.UnpackLog(event, "HookAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseHookAdded is a log parse operation binding the contract event 0x28e00134722f84e69c391c81e4fe022ee3e61048222a8ea2f98c9f235f797508.
+//
+// Solidity: event HookAdded(address indexed hook)
+func (_HookManager *HookManagerFilterer) ParseHookAdded(log types.Log) (*HookManagerHookAdded, error) {
+	event := new(HookManagerHookAdded)
+	if err := _HookManager.contract.UnpackLog(event, "HookAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// HookManagerHookRemovedIterator is returned from FilterHookRemoved and is used to iterate over the raw logs and unpacked data for HookRemoved events raised by the HookManager contract.
+type HookManagerHookRemovedIterator struct {
+	Event *HookManagerHookRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *HookManagerHookRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(HookManagerHookRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(HookManagerHookRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *HookManagerHookRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *HookManagerHookRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// HookManagerHookRemoved represents a HookRemoved event raised by the HookManager contract.
+type HookManagerHookRemoved struct {
+	Hook common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterHookRemoved is a free log retrieval operation binding the contract event 0x47d0871e905ac6550f54ba266e0d90d2dc8ed67a957c064ca3438eddf4e3fd89.
+//
+// Solidity: event HookRemoved(address indexed hook)
+func (_HookManager *HookManagerFilterer) FilterHookRemoved(opts *bind.FilterOpts, hook []common.Address) (*HookManagerHookRemovedIterator, error) {
+
+	var hookRule []interface{}
+	for _, hookItem := range hook {
+		hookRule = append(hookRule, hookItem)
+	}
+
+	logs, sub, err := _HookManager.contract.FilterLogs(opts, "HookRemoved", hookRule)
+	if err != nil {
+		return nil, err
+	}
+	return &HookManagerHookRemovedIterator{contract: _HookManager.contract, event: "HookRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchHookRemoved is a free log subscription operation binding the contract event 0x47d0871e905ac6550f54ba266e0d90d2dc8ed67a957c064ca3438eddf4e3fd89.
+//
+// Solidity: event HookRemoved(address indexed hook)
+func (_HookManager *HookManagerFilterer) WatchHookRemoved(opts *bind.WatchOpts, sink chan<- *HookManagerHookRemoved, hook []common.Address) (event.Subscription, error) {
+
+	var hookRule []interface{}
+	for _, hookItem := range hook {
+		hookRule = append(hookRule, hookItem)
+	}
+
+	logs, sub, err := _HookManager.contract.WatchLogs(opts, "HookRemoved", hookRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(HookManagerHookRemoved)
+				if err := _HookManager.contract.UnpackLog(event, "HookRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseHookRemoved is a log parse operation binding the contract event 0x47d0871e905ac6550f54ba266e0d90d2dc8ed67a957c064ca3438eddf4e3fd89.
+//
+// Solidity: event HookRemoved(address indexed hook)
+func (_HookManager *HookManagerFilterer) ParseHookRemoved(log types.Log) (*HookManagerHookRemoved, error) {
+	event := new(HookManagerHookRemoved)
+	if err := _HookManager.contract.UnpackLog(event, "HookRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts/zksyncsso/managers/ownermanager/ownermanager.go
+++ b/contracts/zksyncsso/managers/ownermanager/ownermanager.go
@@ -1,0 +1,573 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package ownermanager
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// OwnerManagerMetaData contains all meta data concerning the OwnerManager contract.
+var OwnerManagerMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"notSelf\",\"type\":\"address\"}],\"name\":\"NOT_FROM_SELF\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OWNER_ALREADY_EXISTS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OWNER_NOT_FOUND\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"K1OwnerAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"K1OwnerRemoved\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"addK1Owner\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"isK1Owner\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"listK1Owners\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"k1OwnerList\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"removeK1Owner\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+}
+
+// OwnerManagerABI is the input ABI used to generate the binding from.
+// Deprecated: Use OwnerManagerMetaData.ABI instead.
+var OwnerManagerABI = OwnerManagerMetaData.ABI
+
+// OwnerManager is an auto generated Go binding around an Ethereum contract.
+type OwnerManager struct {
+	OwnerManagerCaller     // Read-only binding to the contract
+	OwnerManagerTransactor // Write-only binding to the contract
+	OwnerManagerFilterer   // Log filterer for contract events
+}
+
+// OwnerManagerCaller is an auto generated read-only Go binding around an Ethereum contract.
+type OwnerManagerCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// OwnerManagerTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type OwnerManagerTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// OwnerManagerFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type OwnerManagerFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// OwnerManagerSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type OwnerManagerSession struct {
+	Contract     *OwnerManager     // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// OwnerManagerCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type OwnerManagerCallerSession struct {
+	Contract *OwnerManagerCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts       // Call options to use throughout this session
+}
+
+// OwnerManagerTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type OwnerManagerTransactorSession struct {
+	Contract     *OwnerManagerTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts       // Transaction auth options to use throughout this session
+}
+
+// OwnerManagerRaw is an auto generated low-level Go binding around an Ethereum contract.
+type OwnerManagerRaw struct {
+	Contract *OwnerManager // Generic contract binding to access the raw methods on
+}
+
+// OwnerManagerCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type OwnerManagerCallerRaw struct {
+	Contract *OwnerManagerCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// OwnerManagerTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type OwnerManagerTransactorRaw struct {
+	Contract *OwnerManagerTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewOwnerManager creates a new instance of OwnerManager, bound to a specific deployed contract.
+func NewOwnerManager(address common.Address, backend bind.ContractBackend) (*OwnerManager, error) {
+	contract, err := bindOwnerManager(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &OwnerManager{OwnerManagerCaller: OwnerManagerCaller{contract: contract}, OwnerManagerTransactor: OwnerManagerTransactor{contract: contract}, OwnerManagerFilterer: OwnerManagerFilterer{contract: contract}}, nil
+}
+
+// NewOwnerManagerCaller creates a new read-only instance of OwnerManager, bound to a specific deployed contract.
+func NewOwnerManagerCaller(address common.Address, caller bind.ContractCaller) (*OwnerManagerCaller, error) {
+	contract, err := bindOwnerManager(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &OwnerManagerCaller{contract: contract}, nil
+}
+
+// NewOwnerManagerTransactor creates a new write-only instance of OwnerManager, bound to a specific deployed contract.
+func NewOwnerManagerTransactor(address common.Address, transactor bind.ContractTransactor) (*OwnerManagerTransactor, error) {
+	contract, err := bindOwnerManager(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &OwnerManagerTransactor{contract: contract}, nil
+}
+
+// NewOwnerManagerFilterer creates a new log filterer instance of OwnerManager, bound to a specific deployed contract.
+func NewOwnerManagerFilterer(address common.Address, filterer bind.ContractFilterer) (*OwnerManagerFilterer, error) {
+	contract, err := bindOwnerManager(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &OwnerManagerFilterer{contract: contract}, nil
+}
+
+// bindOwnerManager binds a generic wrapper to an already deployed contract.
+func bindOwnerManager(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := OwnerManagerMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_OwnerManager *OwnerManagerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _OwnerManager.Contract.OwnerManagerCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_OwnerManager *OwnerManagerRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _OwnerManager.Contract.OwnerManagerTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_OwnerManager *OwnerManagerRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _OwnerManager.Contract.OwnerManagerTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_OwnerManager *OwnerManagerCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _OwnerManager.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_OwnerManager *OwnerManagerTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _OwnerManager.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_OwnerManager *OwnerManagerTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _OwnerManager.Contract.contract.Transact(opts, method, params...)
+}
+
+// IsK1Owner is a free data retrieval call binding the contract method 0x6e354cb8.
+//
+// Solidity: function isK1Owner(address addr) view returns(bool)
+func (_OwnerManager *OwnerManagerCaller) IsK1Owner(opts *bind.CallOpts, addr common.Address) (bool, error) {
+	var out []interface{}
+	err := _OwnerManager.contract.Call(opts, &out, "isK1Owner", addr)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsK1Owner is a free data retrieval call binding the contract method 0x6e354cb8.
+//
+// Solidity: function isK1Owner(address addr) view returns(bool)
+func (_OwnerManager *OwnerManagerSession) IsK1Owner(addr common.Address) (bool, error) {
+	return _OwnerManager.Contract.IsK1Owner(&_OwnerManager.CallOpts, addr)
+}
+
+// IsK1Owner is a free data retrieval call binding the contract method 0x6e354cb8.
+//
+// Solidity: function isK1Owner(address addr) view returns(bool)
+func (_OwnerManager *OwnerManagerCallerSession) IsK1Owner(addr common.Address) (bool, error) {
+	return _OwnerManager.Contract.IsK1Owner(&_OwnerManager.CallOpts, addr)
+}
+
+// ListK1Owners is a free data retrieval call binding the contract method 0x4f16eec8.
+//
+// Solidity: function listK1Owners() view returns(address[] k1OwnerList)
+func (_OwnerManager *OwnerManagerCaller) ListK1Owners(opts *bind.CallOpts) ([]common.Address, error) {
+	var out []interface{}
+	err := _OwnerManager.contract.Call(opts, &out, "listK1Owners")
+
+	if err != nil {
+		return *new([]common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
+
+	return out0, err
+
+}
+
+// ListK1Owners is a free data retrieval call binding the contract method 0x4f16eec8.
+//
+// Solidity: function listK1Owners() view returns(address[] k1OwnerList)
+func (_OwnerManager *OwnerManagerSession) ListK1Owners() ([]common.Address, error) {
+	return _OwnerManager.Contract.ListK1Owners(&_OwnerManager.CallOpts)
+}
+
+// ListK1Owners is a free data retrieval call binding the contract method 0x4f16eec8.
+//
+// Solidity: function listK1Owners() view returns(address[] k1OwnerList)
+func (_OwnerManager *OwnerManagerCallerSession) ListK1Owners() ([]common.Address, error) {
+	return _OwnerManager.Contract.ListK1Owners(&_OwnerManager.CallOpts)
+}
+
+// AddK1Owner is a paid mutator transaction binding the contract method 0x23cef13e.
+//
+// Solidity: function addK1Owner(address addr) returns()
+func (_OwnerManager *OwnerManagerTransactor) AddK1Owner(opts *bind.TransactOpts, addr common.Address) (*types.Transaction, error) {
+	return _OwnerManager.contract.Transact(opts, "addK1Owner", addr)
+}
+
+// AddK1Owner is a paid mutator transaction binding the contract method 0x23cef13e.
+//
+// Solidity: function addK1Owner(address addr) returns()
+func (_OwnerManager *OwnerManagerSession) AddK1Owner(addr common.Address) (*types.Transaction, error) {
+	return _OwnerManager.Contract.AddK1Owner(&_OwnerManager.TransactOpts, addr)
+}
+
+// AddK1Owner is a paid mutator transaction binding the contract method 0x23cef13e.
+//
+// Solidity: function addK1Owner(address addr) returns()
+func (_OwnerManager *OwnerManagerTransactorSession) AddK1Owner(addr common.Address) (*types.Transaction, error) {
+	return _OwnerManager.Contract.AddK1Owner(&_OwnerManager.TransactOpts, addr)
+}
+
+// RemoveK1Owner is a paid mutator transaction binding the contract method 0x714da018.
+//
+// Solidity: function removeK1Owner(address addr) returns()
+func (_OwnerManager *OwnerManagerTransactor) RemoveK1Owner(opts *bind.TransactOpts, addr common.Address) (*types.Transaction, error) {
+	return _OwnerManager.contract.Transact(opts, "removeK1Owner", addr)
+}
+
+// RemoveK1Owner is a paid mutator transaction binding the contract method 0x714da018.
+//
+// Solidity: function removeK1Owner(address addr) returns()
+func (_OwnerManager *OwnerManagerSession) RemoveK1Owner(addr common.Address) (*types.Transaction, error) {
+	return _OwnerManager.Contract.RemoveK1Owner(&_OwnerManager.TransactOpts, addr)
+}
+
+// RemoveK1Owner is a paid mutator transaction binding the contract method 0x714da018.
+//
+// Solidity: function removeK1Owner(address addr) returns()
+func (_OwnerManager *OwnerManagerTransactorSession) RemoveK1Owner(addr common.Address) (*types.Transaction, error) {
+	return _OwnerManager.Contract.RemoveK1Owner(&_OwnerManager.TransactOpts, addr)
+}
+
+// OwnerManagerK1OwnerAddedIterator is returned from FilterK1OwnerAdded and is used to iterate over the raw logs and unpacked data for K1OwnerAdded events raised by the OwnerManager contract.
+type OwnerManagerK1OwnerAddedIterator struct {
+	Event *OwnerManagerK1OwnerAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *OwnerManagerK1OwnerAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(OwnerManagerK1OwnerAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(OwnerManagerK1OwnerAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *OwnerManagerK1OwnerAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *OwnerManagerK1OwnerAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// OwnerManagerK1OwnerAdded represents a K1OwnerAdded event raised by the OwnerManager contract.
+type OwnerManagerK1OwnerAdded struct {
+	Addr common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterK1OwnerAdded is a free log retrieval operation binding the contract event 0x40097f116787d282c09163d089084b2d950545433dad84146baf8da81064e84c.
+//
+// Solidity: event K1OwnerAdded(address indexed addr)
+func (_OwnerManager *OwnerManagerFilterer) FilterK1OwnerAdded(opts *bind.FilterOpts, addr []common.Address) (*OwnerManagerK1OwnerAddedIterator, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+
+	logs, sub, err := _OwnerManager.contract.FilterLogs(opts, "K1OwnerAdded", addrRule)
+	if err != nil {
+		return nil, err
+	}
+	return &OwnerManagerK1OwnerAddedIterator{contract: _OwnerManager.contract, event: "K1OwnerAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchK1OwnerAdded is a free log subscription operation binding the contract event 0x40097f116787d282c09163d089084b2d950545433dad84146baf8da81064e84c.
+//
+// Solidity: event K1OwnerAdded(address indexed addr)
+func (_OwnerManager *OwnerManagerFilterer) WatchK1OwnerAdded(opts *bind.WatchOpts, sink chan<- *OwnerManagerK1OwnerAdded, addr []common.Address) (event.Subscription, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+
+	logs, sub, err := _OwnerManager.contract.WatchLogs(opts, "K1OwnerAdded", addrRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(OwnerManagerK1OwnerAdded)
+				if err := _OwnerManager.contract.UnpackLog(event, "K1OwnerAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseK1OwnerAdded is a log parse operation binding the contract event 0x40097f116787d282c09163d089084b2d950545433dad84146baf8da81064e84c.
+//
+// Solidity: event K1OwnerAdded(address indexed addr)
+func (_OwnerManager *OwnerManagerFilterer) ParseK1OwnerAdded(log types.Log) (*OwnerManagerK1OwnerAdded, error) {
+	event := new(OwnerManagerK1OwnerAdded)
+	if err := _OwnerManager.contract.UnpackLog(event, "K1OwnerAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// OwnerManagerK1OwnerRemovedIterator is returned from FilterK1OwnerRemoved and is used to iterate over the raw logs and unpacked data for K1OwnerRemoved events raised by the OwnerManager contract.
+type OwnerManagerK1OwnerRemovedIterator struct {
+	Event *OwnerManagerK1OwnerRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *OwnerManagerK1OwnerRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(OwnerManagerK1OwnerRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(OwnerManagerK1OwnerRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *OwnerManagerK1OwnerRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *OwnerManagerK1OwnerRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// OwnerManagerK1OwnerRemoved represents a K1OwnerRemoved event raised by the OwnerManager contract.
+type OwnerManagerK1OwnerRemoved struct {
+	Addr common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterK1OwnerRemoved is a free log retrieval operation binding the contract event 0xe09f0b842a072d50a0b373f3255e2a4216aeb61908e35a93a499f0ff2aa4c8fa.
+//
+// Solidity: event K1OwnerRemoved(address indexed addr)
+func (_OwnerManager *OwnerManagerFilterer) FilterK1OwnerRemoved(opts *bind.FilterOpts, addr []common.Address) (*OwnerManagerK1OwnerRemovedIterator, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+
+	logs, sub, err := _OwnerManager.contract.FilterLogs(opts, "K1OwnerRemoved", addrRule)
+	if err != nil {
+		return nil, err
+	}
+	return &OwnerManagerK1OwnerRemovedIterator{contract: _OwnerManager.contract, event: "K1OwnerRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchK1OwnerRemoved is a free log subscription operation binding the contract event 0xe09f0b842a072d50a0b373f3255e2a4216aeb61908e35a93a499f0ff2aa4c8fa.
+//
+// Solidity: event K1OwnerRemoved(address indexed addr)
+func (_OwnerManager *OwnerManagerFilterer) WatchK1OwnerRemoved(opts *bind.WatchOpts, sink chan<- *OwnerManagerK1OwnerRemoved, addr []common.Address) (event.Subscription, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+
+	logs, sub, err := _OwnerManager.contract.WatchLogs(opts, "K1OwnerRemoved", addrRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(OwnerManagerK1OwnerRemoved)
+				if err := _OwnerManager.contract.UnpackLog(event, "K1OwnerRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseK1OwnerRemoved is a log parse operation binding the contract event 0xe09f0b842a072d50a0b373f3255e2a4216aeb61908e35a93a499f0ff2aa4c8fa.
+//
+// Solidity: event K1OwnerRemoved(address indexed addr)
+func (_OwnerManager *OwnerManagerFilterer) ParseK1OwnerRemoved(log types.Log) (*OwnerManagerK1OwnerRemoved, error) {
+	event := new(OwnerManagerK1OwnerRemoved)
+	if err := _OwnerManager.contract.UnpackLog(event, "K1OwnerRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts/zksyncsso/managers/validatormanager/validatormanager.go
+++ b/contracts/zksyncsso/managers/validatormanager/validatormanager.go
@@ -1,0 +1,594 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package validatormanager
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// ValidatorManagerMetaData contains all meta data concerning the ValidatorManager contract.
+var ValidatorManagerMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"}],\"name\":\"HOOK_ALREADY_EXISTS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"notSelf\",\"type\":\"address\"}],\"name\":\"NOT_FROM_SELF\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"VALIDATOR_ALREADY_EXISTS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"VALIDATOR_ERC165_FAIL\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"VALIDATOR_NOT_FOUND\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"ValidatorAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"ValidatorRemoved\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"initData\",\"type\":\"bytes\"}],\"name\":\"addModuleValidator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"isModuleValidator\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"listModuleValidators\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"validatorList\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"deinitData\",\"type\":\"bytes\"}],\"name\":\"removeModuleValidator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"deinitData\",\"type\":\"bytes\"}],\"name\":\"unlinkModuleValidator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+}
+
+// ValidatorManagerABI is the input ABI used to generate the binding from.
+// Deprecated: Use ValidatorManagerMetaData.ABI instead.
+var ValidatorManagerABI = ValidatorManagerMetaData.ABI
+
+// ValidatorManager is an auto generated Go binding around an Ethereum contract.
+type ValidatorManager struct {
+	ValidatorManagerCaller     // Read-only binding to the contract
+	ValidatorManagerTransactor // Write-only binding to the contract
+	ValidatorManagerFilterer   // Log filterer for contract events
+}
+
+// ValidatorManagerCaller is an auto generated read-only Go binding around an Ethereum contract.
+type ValidatorManagerCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ValidatorManagerTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type ValidatorManagerTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ValidatorManagerFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type ValidatorManagerFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ValidatorManagerSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type ValidatorManagerSession struct {
+	Contract     *ValidatorManager // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// ValidatorManagerCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type ValidatorManagerCallerSession struct {
+	Contract *ValidatorManagerCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts           // Call options to use throughout this session
+}
+
+// ValidatorManagerTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type ValidatorManagerTransactorSession struct {
+	Contract     *ValidatorManagerTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts           // Transaction auth options to use throughout this session
+}
+
+// ValidatorManagerRaw is an auto generated low-level Go binding around an Ethereum contract.
+type ValidatorManagerRaw struct {
+	Contract *ValidatorManager // Generic contract binding to access the raw methods on
+}
+
+// ValidatorManagerCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type ValidatorManagerCallerRaw struct {
+	Contract *ValidatorManagerCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// ValidatorManagerTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type ValidatorManagerTransactorRaw struct {
+	Contract *ValidatorManagerTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewValidatorManager creates a new instance of ValidatorManager, bound to a specific deployed contract.
+func NewValidatorManager(address common.Address, backend bind.ContractBackend) (*ValidatorManager, error) {
+	contract, err := bindValidatorManager(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &ValidatorManager{ValidatorManagerCaller: ValidatorManagerCaller{contract: contract}, ValidatorManagerTransactor: ValidatorManagerTransactor{contract: contract}, ValidatorManagerFilterer: ValidatorManagerFilterer{contract: contract}}, nil
+}
+
+// NewValidatorManagerCaller creates a new read-only instance of ValidatorManager, bound to a specific deployed contract.
+func NewValidatorManagerCaller(address common.Address, caller bind.ContractCaller) (*ValidatorManagerCaller, error) {
+	contract, err := bindValidatorManager(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ValidatorManagerCaller{contract: contract}, nil
+}
+
+// NewValidatorManagerTransactor creates a new write-only instance of ValidatorManager, bound to a specific deployed contract.
+func NewValidatorManagerTransactor(address common.Address, transactor bind.ContractTransactor) (*ValidatorManagerTransactor, error) {
+	contract, err := bindValidatorManager(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ValidatorManagerTransactor{contract: contract}, nil
+}
+
+// NewValidatorManagerFilterer creates a new log filterer instance of ValidatorManager, bound to a specific deployed contract.
+func NewValidatorManagerFilterer(address common.Address, filterer bind.ContractFilterer) (*ValidatorManagerFilterer, error) {
+	contract, err := bindValidatorManager(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &ValidatorManagerFilterer{contract: contract}, nil
+}
+
+// bindValidatorManager binds a generic wrapper to an already deployed contract.
+func bindValidatorManager(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := ValidatorManagerMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_ValidatorManager *ValidatorManagerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _ValidatorManager.Contract.ValidatorManagerCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_ValidatorManager *ValidatorManagerRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ValidatorManager.Contract.ValidatorManagerTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_ValidatorManager *ValidatorManagerRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _ValidatorManager.Contract.ValidatorManagerTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_ValidatorManager *ValidatorManagerCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _ValidatorManager.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_ValidatorManager *ValidatorManagerTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ValidatorManager.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_ValidatorManager *ValidatorManagerTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _ValidatorManager.Contract.contract.Transact(opts, method, params...)
+}
+
+// IsModuleValidator is a free data retrieval call binding the contract method 0x9b7be156.
+//
+// Solidity: function isModuleValidator(address validator) view returns(bool)
+func (_ValidatorManager *ValidatorManagerCaller) IsModuleValidator(opts *bind.CallOpts, validator common.Address) (bool, error) {
+	var out []interface{}
+	err := _ValidatorManager.contract.Call(opts, &out, "isModuleValidator", validator)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsModuleValidator is a free data retrieval call binding the contract method 0x9b7be156.
+//
+// Solidity: function isModuleValidator(address validator) view returns(bool)
+func (_ValidatorManager *ValidatorManagerSession) IsModuleValidator(validator common.Address) (bool, error) {
+	return _ValidatorManager.Contract.IsModuleValidator(&_ValidatorManager.CallOpts, validator)
+}
+
+// IsModuleValidator is a free data retrieval call binding the contract method 0x9b7be156.
+//
+// Solidity: function isModuleValidator(address validator) view returns(bool)
+func (_ValidatorManager *ValidatorManagerCallerSession) IsModuleValidator(validator common.Address) (bool, error) {
+	return _ValidatorManager.Contract.IsModuleValidator(&_ValidatorManager.CallOpts, validator)
+}
+
+// ListModuleValidators is a free data retrieval call binding the contract method 0x3d3a69bf.
+//
+// Solidity: function listModuleValidators() view returns(address[] validatorList)
+func (_ValidatorManager *ValidatorManagerCaller) ListModuleValidators(opts *bind.CallOpts) ([]common.Address, error) {
+	var out []interface{}
+	err := _ValidatorManager.contract.Call(opts, &out, "listModuleValidators")
+
+	if err != nil {
+		return *new([]common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
+
+	return out0, err
+
+}
+
+// ListModuleValidators is a free data retrieval call binding the contract method 0x3d3a69bf.
+//
+// Solidity: function listModuleValidators() view returns(address[] validatorList)
+func (_ValidatorManager *ValidatorManagerSession) ListModuleValidators() ([]common.Address, error) {
+	return _ValidatorManager.Contract.ListModuleValidators(&_ValidatorManager.CallOpts)
+}
+
+// ListModuleValidators is a free data retrieval call binding the contract method 0x3d3a69bf.
+//
+// Solidity: function listModuleValidators() view returns(address[] validatorList)
+func (_ValidatorManager *ValidatorManagerCallerSession) ListModuleValidators() ([]common.Address, error) {
+	return _ValidatorManager.Contract.ListModuleValidators(&_ValidatorManager.CallOpts)
+}
+
+// AddModuleValidator is a paid mutator transaction binding the contract method 0x2e0b437d.
+//
+// Solidity: function addModuleValidator(address validator, bytes initData) returns()
+func (_ValidatorManager *ValidatorManagerTransactor) AddModuleValidator(opts *bind.TransactOpts, validator common.Address, initData []byte) (*types.Transaction, error) {
+	return _ValidatorManager.contract.Transact(opts, "addModuleValidator", validator, initData)
+}
+
+// AddModuleValidator is a paid mutator transaction binding the contract method 0x2e0b437d.
+//
+// Solidity: function addModuleValidator(address validator, bytes initData) returns()
+func (_ValidatorManager *ValidatorManagerSession) AddModuleValidator(validator common.Address, initData []byte) (*types.Transaction, error) {
+	return _ValidatorManager.Contract.AddModuleValidator(&_ValidatorManager.TransactOpts, validator, initData)
+}
+
+// AddModuleValidator is a paid mutator transaction binding the contract method 0x2e0b437d.
+//
+// Solidity: function addModuleValidator(address validator, bytes initData) returns()
+func (_ValidatorManager *ValidatorManagerTransactorSession) AddModuleValidator(validator common.Address, initData []byte) (*types.Transaction, error) {
+	return _ValidatorManager.Contract.AddModuleValidator(&_ValidatorManager.TransactOpts, validator, initData)
+}
+
+// RemoveModuleValidator is a paid mutator transaction binding the contract method 0xb027e50a.
+//
+// Solidity: function removeModuleValidator(address validator, bytes deinitData) returns()
+func (_ValidatorManager *ValidatorManagerTransactor) RemoveModuleValidator(opts *bind.TransactOpts, validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _ValidatorManager.contract.Transact(opts, "removeModuleValidator", validator, deinitData)
+}
+
+// RemoveModuleValidator is a paid mutator transaction binding the contract method 0xb027e50a.
+//
+// Solidity: function removeModuleValidator(address validator, bytes deinitData) returns()
+func (_ValidatorManager *ValidatorManagerSession) RemoveModuleValidator(validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _ValidatorManager.Contract.RemoveModuleValidator(&_ValidatorManager.TransactOpts, validator, deinitData)
+}
+
+// RemoveModuleValidator is a paid mutator transaction binding the contract method 0xb027e50a.
+//
+// Solidity: function removeModuleValidator(address validator, bytes deinitData) returns()
+func (_ValidatorManager *ValidatorManagerTransactorSession) RemoveModuleValidator(validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _ValidatorManager.Contract.RemoveModuleValidator(&_ValidatorManager.TransactOpts, validator, deinitData)
+}
+
+// UnlinkModuleValidator is a paid mutator transaction binding the contract method 0xa7d525e8.
+//
+// Solidity: function unlinkModuleValidator(address validator, bytes deinitData) returns()
+func (_ValidatorManager *ValidatorManagerTransactor) UnlinkModuleValidator(opts *bind.TransactOpts, validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _ValidatorManager.contract.Transact(opts, "unlinkModuleValidator", validator, deinitData)
+}
+
+// UnlinkModuleValidator is a paid mutator transaction binding the contract method 0xa7d525e8.
+//
+// Solidity: function unlinkModuleValidator(address validator, bytes deinitData) returns()
+func (_ValidatorManager *ValidatorManagerSession) UnlinkModuleValidator(validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _ValidatorManager.Contract.UnlinkModuleValidator(&_ValidatorManager.TransactOpts, validator, deinitData)
+}
+
+// UnlinkModuleValidator is a paid mutator transaction binding the contract method 0xa7d525e8.
+//
+// Solidity: function unlinkModuleValidator(address validator, bytes deinitData) returns()
+func (_ValidatorManager *ValidatorManagerTransactorSession) UnlinkModuleValidator(validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _ValidatorManager.Contract.UnlinkModuleValidator(&_ValidatorManager.TransactOpts, validator, deinitData)
+}
+
+// ValidatorManagerValidatorAddedIterator is returned from FilterValidatorAdded and is used to iterate over the raw logs and unpacked data for ValidatorAdded events raised by the ValidatorManager contract.
+type ValidatorManagerValidatorAddedIterator struct {
+	Event *ValidatorManagerValidatorAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ValidatorManagerValidatorAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ValidatorManagerValidatorAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ValidatorManagerValidatorAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ValidatorManagerValidatorAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ValidatorManagerValidatorAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ValidatorManagerValidatorAdded represents a ValidatorAdded event raised by the ValidatorManager contract.
+type ValidatorManagerValidatorAdded struct {
+	Validator common.Address
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterValidatorAdded is a free log retrieval operation binding the contract event 0xe366c1c0452ed8eec96861e9e54141ebff23c9ec89fe27b996b45f5ec3884987.
+//
+// Solidity: event ValidatorAdded(address indexed validator)
+func (_ValidatorManager *ValidatorManagerFilterer) FilterValidatorAdded(opts *bind.FilterOpts, validator []common.Address) (*ValidatorManagerValidatorAddedIterator, error) {
+
+	var validatorRule []interface{}
+	for _, validatorItem := range validator {
+		validatorRule = append(validatorRule, validatorItem)
+	}
+
+	logs, sub, err := _ValidatorManager.contract.FilterLogs(opts, "ValidatorAdded", validatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ValidatorManagerValidatorAddedIterator{contract: _ValidatorManager.contract, event: "ValidatorAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchValidatorAdded is a free log subscription operation binding the contract event 0xe366c1c0452ed8eec96861e9e54141ebff23c9ec89fe27b996b45f5ec3884987.
+//
+// Solidity: event ValidatorAdded(address indexed validator)
+func (_ValidatorManager *ValidatorManagerFilterer) WatchValidatorAdded(opts *bind.WatchOpts, sink chan<- *ValidatorManagerValidatorAdded, validator []common.Address) (event.Subscription, error) {
+
+	var validatorRule []interface{}
+	for _, validatorItem := range validator {
+		validatorRule = append(validatorRule, validatorItem)
+	}
+
+	logs, sub, err := _ValidatorManager.contract.WatchLogs(opts, "ValidatorAdded", validatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ValidatorManagerValidatorAdded)
+				if err := _ValidatorManager.contract.UnpackLog(event, "ValidatorAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseValidatorAdded is a log parse operation binding the contract event 0xe366c1c0452ed8eec96861e9e54141ebff23c9ec89fe27b996b45f5ec3884987.
+//
+// Solidity: event ValidatorAdded(address indexed validator)
+func (_ValidatorManager *ValidatorManagerFilterer) ParseValidatorAdded(log types.Log) (*ValidatorManagerValidatorAdded, error) {
+	event := new(ValidatorManagerValidatorAdded)
+	if err := _ValidatorManager.contract.UnpackLog(event, "ValidatorAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ValidatorManagerValidatorRemovedIterator is returned from FilterValidatorRemoved and is used to iterate over the raw logs and unpacked data for ValidatorRemoved events raised by the ValidatorManager contract.
+type ValidatorManagerValidatorRemovedIterator struct {
+	Event *ValidatorManagerValidatorRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ValidatorManagerValidatorRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ValidatorManagerValidatorRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ValidatorManagerValidatorRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ValidatorManagerValidatorRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ValidatorManagerValidatorRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ValidatorManagerValidatorRemoved represents a ValidatorRemoved event raised by the ValidatorManager contract.
+type ValidatorManagerValidatorRemoved struct {
+	Validator common.Address
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterValidatorRemoved is a free log retrieval operation binding the contract event 0xe1434e25d6611e0db941968fdc97811c982ac1602e951637d206f5fdda9dd8f1.
+//
+// Solidity: event ValidatorRemoved(address indexed validator)
+func (_ValidatorManager *ValidatorManagerFilterer) FilterValidatorRemoved(opts *bind.FilterOpts, validator []common.Address) (*ValidatorManagerValidatorRemovedIterator, error) {
+
+	var validatorRule []interface{}
+	for _, validatorItem := range validator {
+		validatorRule = append(validatorRule, validatorItem)
+	}
+
+	logs, sub, err := _ValidatorManager.contract.FilterLogs(opts, "ValidatorRemoved", validatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ValidatorManagerValidatorRemovedIterator{contract: _ValidatorManager.contract, event: "ValidatorRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchValidatorRemoved is a free log subscription operation binding the contract event 0xe1434e25d6611e0db941968fdc97811c982ac1602e951637d206f5fdda9dd8f1.
+//
+// Solidity: event ValidatorRemoved(address indexed validator)
+func (_ValidatorManager *ValidatorManagerFilterer) WatchValidatorRemoved(opts *bind.WatchOpts, sink chan<- *ValidatorManagerValidatorRemoved, validator []common.Address) (event.Subscription, error) {
+
+	var validatorRule []interface{}
+	for _, validatorItem := range validator {
+		validatorRule = append(validatorRule, validatorItem)
+	}
+
+	logs, sub, err := _ValidatorManager.contract.WatchLogs(opts, "ValidatorRemoved", validatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ValidatorManagerValidatorRemoved)
+				if err := _ValidatorManager.contract.UnpackLog(event, "ValidatorRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseValidatorRemoved is a log parse operation binding the contract event 0xe1434e25d6611e0db941968fdc97811c982ac1602e951637d206f5fdda9dd8f1.
+//
+// Solidity: event ValidatorRemoved(address indexed validator)
+func (_ValidatorManager *ValidatorManagerFilterer) ParseValidatorRemoved(log types.Log) (*ValidatorManagerValidatorRemoved, error) {
+	event := new(ValidatorManagerValidatorRemoved)
+	if err := _ValidatorManager.contract.UnpackLog(event, "ValidatorRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts/zksyncsso/ssoaccount/ssoaccount.go
+++ b/contracts/zksyncsso/ssoaccount/ssoaccount.go
@@ -1,0 +1,2029 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package ssoaccount
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// Call is an auto generated low-level Go binding around an user-defined struct.
+type Call struct {
+	Target       common.Address
+	AllowFailure bool
+	Value        *big.Int
+	CallData     []byte
+}
+
+// Transaction is an auto generated low-level Go binding around an user-defined struct.
+type Transaction struct {
+	TxType                 *big.Int
+	From                   *big.Int
+	To                     *big.Int
+	GasLimit               *big.Int
+	GasPerPubdataByteLimit *big.Int
+	MaxFeePerGas           *big.Int
+	MaxPriorityFeePerGas   *big.Int
+	Paymaster              *big.Int
+	Nonce                  *big.Int
+	Value                  *big.Int
+	Reserved               [4]*big.Int
+	Data                   []byte
+	Signature              []byte
+	FactoryDeps            [][32]byte
+	PaymasterInput         []byte
+	ReservedDynamic        []byte
+}
+
+// SsoAccountMetaData contains all meta data concerning the SsoAccount contract.
+var SsoAccountMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"ADDRESS_CAST_OVERFLOW\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"actualValue\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expectedValue\",\"type\":\"uint256\"}],\"name\":\"BATCH_MSG_VALUE_MISMATCH\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"FEE_PAYMENT_FAILED\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"}],\"name\":\"HOOK_ALREADY_EXISTS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"hookAddress\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"}],\"name\":\"HOOK_ERC165_FAIL\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"}],\"name\":\"HOOK_NOT_FOUND\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"required\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"available\",\"type\":\"uint256\"}],\"name\":\"INSUFFICIENT_FUNDS\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"INVALID_ACCOUNT_KEYS\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"METHOD_NOT_IMPLEMENTED\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"notBootloader\",\"type\":\"address\"}],\"name\":\"NOT_FROM_BOOTLOADER\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"notSelf\",\"type\":\"address\"}],\"name\":\"NOT_FROM_SELF\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OWNER_ALREADY_EXISTS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"OWNER_NOT_FOUND\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"VALIDATOR_ALREADY_EXISTS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"VALIDATOR_ERC165_FAIL\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"VALIDATOR_NOT_FOUND\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"index\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"revertData\",\"type\":\"bytes\"}],\"name\":\"BatchCallFailure\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"}],\"name\":\"HookAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"}],\"name\":\"HookRemoved\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"version\",\"type\":\"uint8\"}],\"name\":\"Initialized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"K1OwnerAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"K1OwnerRemoved\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"ValidatorAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"ValidatorRemoved\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"},{\"internalType\":\"bytes\",\"name\":\"initData\",\"type\":\"bytes\"}],\"name\":\"addHook\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"addK1Owner\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"initData\",\"type\":\"bytes\"}],\"name\":\"addModuleValidator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"allowFailure\",\"type\":\"bool\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"callData\",\"type\":\"bytes\"}],\"internalType\":\"structCall[]\",\"name\":\"_calls\",\"type\":\"tuple[]\"}],\"name\":\"batchCall\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[]\",\"name\":\"factoryDeps\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"reservedDynamic\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"_transaction\",\"type\":\"tuple\"}],\"name\":\"executeTransaction\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[]\",\"name\":\"factoryDeps\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"reservedDynamic\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"\",\"type\":\"tuple\"}],\"name\":\"executeTransactionFromOutside\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes[]\",\"name\":\"initialValidators\",\"type\":\"bytes[]\"},{\"internalType\":\"address[]\",\"name\":\"initialK1Owners\",\"type\":\"address[]\"}],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"isHook\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"isK1Owner\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"}],\"name\":\"isModuleValidator\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"hash\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"}],\"name\":\"isValidSignature\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"magicValue\",\"type\":\"bytes4\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"}],\"name\":\"listHooks\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"hookList\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"listK1Owners\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"k1OwnerList\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"listModuleValidators\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"validatorList\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"uint256[]\",\"name\":\"\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256[]\",\"name\":\"\",\"type\":\"uint256[]\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"name\":\"onERC1155BatchReceived\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"\",\"type\":\"bytes4\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"name\":\"onERC1155Received\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"\",\"type\":\"bytes4\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"name\":\"onERC721Received\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"\",\"type\":\"bytes4\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[]\",\"name\":\"factoryDeps\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"reservedDynamic\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"_transaction\",\"type\":\"tuple\"}],\"name\":\"payForTransaction\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[]\",\"name\":\"factoryDeps\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"reservedDynamic\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"_transaction\",\"type\":\"tuple\"}],\"name\":\"prepareForPaymaster\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"},{\"internalType\":\"bytes\",\"name\":\"deinitData\",\"type\":\"bytes\"}],\"name\":\"removeHook\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"removeK1Owner\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"deinitData\",\"type\":\"bytes\"}],\"name\":\"removeModuleValidator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"}],\"name\":\"supportsInterface\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"hook\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isValidation\",\"type\":\"bool\"},{\"internalType\":\"bytes\",\"name\":\"deinitData\",\"type\":\"bytes\"}],\"name\":\"unlinkHook\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"deinitData\",\"type\":\"bytes\"}],\"name\":\"unlinkModuleValidator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"_suggestedSignedHash\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[]\",\"name\":\"factoryDeps\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"reservedDynamic\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"_transaction\",\"type\":\"tuple\"}],\"name\":\"validateTransaction\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"magic\",\"type\":\"bytes4\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"stateMutability\":\"payable\",\"type\":\"receive\"}]",
+}
+
+// SsoAccountABI is the input ABI used to generate the binding from.
+// Deprecated: Use SsoAccountMetaData.ABI instead.
+var SsoAccountABI = SsoAccountMetaData.ABI
+
+// SsoAccount is an auto generated Go binding around an Ethereum contract.
+type SsoAccount struct {
+	SsoAccountCaller     // Read-only binding to the contract
+	SsoAccountTransactor // Write-only binding to the contract
+	SsoAccountFilterer   // Log filterer for contract events
+}
+
+// SsoAccountCaller is an auto generated read-only Go binding around an Ethereum contract.
+type SsoAccountCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// SsoAccountTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type SsoAccountTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// SsoAccountFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type SsoAccountFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// SsoAccountSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type SsoAccountSession struct {
+	Contract     *SsoAccount       // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// SsoAccountCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type SsoAccountCallerSession struct {
+	Contract *SsoAccountCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts     // Call options to use throughout this session
+}
+
+// SsoAccountTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type SsoAccountTransactorSession struct {
+	Contract     *SsoAccountTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts     // Transaction auth options to use throughout this session
+}
+
+// SsoAccountRaw is an auto generated low-level Go binding around an Ethereum contract.
+type SsoAccountRaw struct {
+	Contract *SsoAccount // Generic contract binding to access the raw methods on
+}
+
+// SsoAccountCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type SsoAccountCallerRaw struct {
+	Contract *SsoAccountCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// SsoAccountTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type SsoAccountTransactorRaw struct {
+	Contract *SsoAccountTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewSsoAccount creates a new instance of SsoAccount, bound to a specific deployed contract.
+func NewSsoAccount(address common.Address, backend bind.ContractBackend) (*SsoAccount, error) {
+	contract, err := bindSsoAccount(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &SsoAccount{SsoAccountCaller: SsoAccountCaller{contract: contract}, SsoAccountTransactor: SsoAccountTransactor{contract: contract}, SsoAccountFilterer: SsoAccountFilterer{contract: contract}}, nil
+}
+
+// NewSsoAccountCaller creates a new read-only instance of SsoAccount, bound to a specific deployed contract.
+func NewSsoAccountCaller(address common.Address, caller bind.ContractCaller) (*SsoAccountCaller, error) {
+	contract, err := bindSsoAccount(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &SsoAccountCaller{contract: contract}, nil
+}
+
+// NewSsoAccountTransactor creates a new write-only instance of SsoAccount, bound to a specific deployed contract.
+func NewSsoAccountTransactor(address common.Address, transactor bind.ContractTransactor) (*SsoAccountTransactor, error) {
+	contract, err := bindSsoAccount(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &SsoAccountTransactor{contract: contract}, nil
+}
+
+// NewSsoAccountFilterer creates a new log filterer instance of SsoAccount, bound to a specific deployed contract.
+func NewSsoAccountFilterer(address common.Address, filterer bind.ContractFilterer) (*SsoAccountFilterer, error) {
+	contract, err := bindSsoAccount(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &SsoAccountFilterer{contract: contract}, nil
+}
+
+// bindSsoAccount binds a generic wrapper to an already deployed contract.
+func bindSsoAccount(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := SsoAccountMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_SsoAccount *SsoAccountRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _SsoAccount.Contract.SsoAccountCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_SsoAccount *SsoAccountRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _SsoAccount.Contract.SsoAccountTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_SsoAccount *SsoAccountRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _SsoAccount.Contract.SsoAccountTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_SsoAccount *SsoAccountCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _SsoAccount.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_SsoAccount *SsoAccountTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _SsoAccount.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_SsoAccount *SsoAccountTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _SsoAccount.Contract.contract.Transact(opts, method, params...)
+}
+
+// IsHook is a free data retrieval call binding the contract method 0xd2676529.
+//
+// Solidity: function isHook(address addr) view returns(bool)
+func (_SsoAccount *SsoAccountCaller) IsHook(opts *bind.CallOpts, addr common.Address) (bool, error) {
+	var out []interface{}
+	err := _SsoAccount.contract.Call(opts, &out, "isHook", addr)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsHook is a free data retrieval call binding the contract method 0xd2676529.
+//
+// Solidity: function isHook(address addr) view returns(bool)
+func (_SsoAccount *SsoAccountSession) IsHook(addr common.Address) (bool, error) {
+	return _SsoAccount.Contract.IsHook(&_SsoAccount.CallOpts, addr)
+}
+
+// IsHook is a free data retrieval call binding the contract method 0xd2676529.
+//
+// Solidity: function isHook(address addr) view returns(bool)
+func (_SsoAccount *SsoAccountCallerSession) IsHook(addr common.Address) (bool, error) {
+	return _SsoAccount.Contract.IsHook(&_SsoAccount.CallOpts, addr)
+}
+
+// IsK1Owner is a free data retrieval call binding the contract method 0x6e354cb8.
+//
+// Solidity: function isK1Owner(address addr) view returns(bool)
+func (_SsoAccount *SsoAccountCaller) IsK1Owner(opts *bind.CallOpts, addr common.Address) (bool, error) {
+	var out []interface{}
+	err := _SsoAccount.contract.Call(opts, &out, "isK1Owner", addr)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsK1Owner is a free data retrieval call binding the contract method 0x6e354cb8.
+//
+// Solidity: function isK1Owner(address addr) view returns(bool)
+func (_SsoAccount *SsoAccountSession) IsK1Owner(addr common.Address) (bool, error) {
+	return _SsoAccount.Contract.IsK1Owner(&_SsoAccount.CallOpts, addr)
+}
+
+// IsK1Owner is a free data retrieval call binding the contract method 0x6e354cb8.
+//
+// Solidity: function isK1Owner(address addr) view returns(bool)
+func (_SsoAccount *SsoAccountCallerSession) IsK1Owner(addr common.Address) (bool, error) {
+	return _SsoAccount.Contract.IsK1Owner(&_SsoAccount.CallOpts, addr)
+}
+
+// IsModuleValidator is a free data retrieval call binding the contract method 0x9b7be156.
+//
+// Solidity: function isModuleValidator(address validator) view returns(bool)
+func (_SsoAccount *SsoAccountCaller) IsModuleValidator(opts *bind.CallOpts, validator common.Address) (bool, error) {
+	var out []interface{}
+	err := _SsoAccount.contract.Call(opts, &out, "isModuleValidator", validator)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsModuleValidator is a free data retrieval call binding the contract method 0x9b7be156.
+//
+// Solidity: function isModuleValidator(address validator) view returns(bool)
+func (_SsoAccount *SsoAccountSession) IsModuleValidator(validator common.Address) (bool, error) {
+	return _SsoAccount.Contract.IsModuleValidator(&_SsoAccount.CallOpts, validator)
+}
+
+// IsModuleValidator is a free data retrieval call binding the contract method 0x9b7be156.
+//
+// Solidity: function isModuleValidator(address validator) view returns(bool)
+func (_SsoAccount *SsoAccountCallerSession) IsModuleValidator(validator common.Address) (bool, error) {
+	return _SsoAccount.Contract.IsModuleValidator(&_SsoAccount.CallOpts, validator)
+}
+
+// IsValidSignature is a free data retrieval call binding the contract method 0x1626ba7e.
+//
+// Solidity: function isValidSignature(bytes32 hash, bytes signature) view returns(bytes4 magicValue)
+func (_SsoAccount *SsoAccountCaller) IsValidSignature(opts *bind.CallOpts, hash [32]byte, signature []byte) ([4]byte, error) {
+	var out []interface{}
+	err := _SsoAccount.contract.Call(opts, &out, "isValidSignature", hash, signature)
+
+	if err != nil {
+		return *new([4]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([4]byte)).(*[4]byte)
+
+	return out0, err
+
+}
+
+// IsValidSignature is a free data retrieval call binding the contract method 0x1626ba7e.
+//
+// Solidity: function isValidSignature(bytes32 hash, bytes signature) view returns(bytes4 magicValue)
+func (_SsoAccount *SsoAccountSession) IsValidSignature(hash [32]byte, signature []byte) ([4]byte, error) {
+	return _SsoAccount.Contract.IsValidSignature(&_SsoAccount.CallOpts, hash, signature)
+}
+
+// IsValidSignature is a free data retrieval call binding the contract method 0x1626ba7e.
+//
+// Solidity: function isValidSignature(bytes32 hash, bytes signature) view returns(bytes4 magicValue)
+func (_SsoAccount *SsoAccountCallerSession) IsValidSignature(hash [32]byte, signature []byte) ([4]byte, error) {
+	return _SsoAccount.Contract.IsValidSignature(&_SsoAccount.CallOpts, hash, signature)
+}
+
+// ListHooks is a free data retrieval call binding the contract method 0xdb8a323f.
+//
+// Solidity: function listHooks(bool isValidation) view returns(address[] hookList)
+func (_SsoAccount *SsoAccountCaller) ListHooks(opts *bind.CallOpts, isValidation bool) ([]common.Address, error) {
+	var out []interface{}
+	err := _SsoAccount.contract.Call(opts, &out, "listHooks", isValidation)
+
+	if err != nil {
+		return *new([]common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
+
+	return out0, err
+
+}
+
+// ListHooks is a free data retrieval call binding the contract method 0xdb8a323f.
+//
+// Solidity: function listHooks(bool isValidation) view returns(address[] hookList)
+func (_SsoAccount *SsoAccountSession) ListHooks(isValidation bool) ([]common.Address, error) {
+	return _SsoAccount.Contract.ListHooks(&_SsoAccount.CallOpts, isValidation)
+}
+
+// ListHooks is a free data retrieval call binding the contract method 0xdb8a323f.
+//
+// Solidity: function listHooks(bool isValidation) view returns(address[] hookList)
+func (_SsoAccount *SsoAccountCallerSession) ListHooks(isValidation bool) ([]common.Address, error) {
+	return _SsoAccount.Contract.ListHooks(&_SsoAccount.CallOpts, isValidation)
+}
+
+// ListK1Owners is a free data retrieval call binding the contract method 0x4f16eec8.
+//
+// Solidity: function listK1Owners() view returns(address[] k1OwnerList)
+func (_SsoAccount *SsoAccountCaller) ListK1Owners(opts *bind.CallOpts) ([]common.Address, error) {
+	var out []interface{}
+	err := _SsoAccount.contract.Call(opts, &out, "listK1Owners")
+
+	if err != nil {
+		return *new([]common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
+
+	return out0, err
+
+}
+
+// ListK1Owners is a free data retrieval call binding the contract method 0x4f16eec8.
+//
+// Solidity: function listK1Owners() view returns(address[] k1OwnerList)
+func (_SsoAccount *SsoAccountSession) ListK1Owners() ([]common.Address, error) {
+	return _SsoAccount.Contract.ListK1Owners(&_SsoAccount.CallOpts)
+}
+
+// ListK1Owners is a free data retrieval call binding the contract method 0x4f16eec8.
+//
+// Solidity: function listK1Owners() view returns(address[] k1OwnerList)
+func (_SsoAccount *SsoAccountCallerSession) ListK1Owners() ([]common.Address, error) {
+	return _SsoAccount.Contract.ListK1Owners(&_SsoAccount.CallOpts)
+}
+
+// ListModuleValidators is a free data retrieval call binding the contract method 0x3d3a69bf.
+//
+// Solidity: function listModuleValidators() view returns(address[] validatorList)
+func (_SsoAccount *SsoAccountCaller) ListModuleValidators(opts *bind.CallOpts) ([]common.Address, error) {
+	var out []interface{}
+	err := _SsoAccount.contract.Call(opts, &out, "listModuleValidators")
+
+	if err != nil {
+		return *new([]common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
+
+	return out0, err
+
+}
+
+// ListModuleValidators is a free data retrieval call binding the contract method 0x3d3a69bf.
+//
+// Solidity: function listModuleValidators() view returns(address[] validatorList)
+func (_SsoAccount *SsoAccountSession) ListModuleValidators() ([]common.Address, error) {
+	return _SsoAccount.Contract.ListModuleValidators(&_SsoAccount.CallOpts)
+}
+
+// ListModuleValidators is a free data retrieval call binding the contract method 0x3d3a69bf.
+//
+// Solidity: function listModuleValidators() view returns(address[] validatorList)
+func (_SsoAccount *SsoAccountCallerSession) ListModuleValidators() ([]common.Address, error) {
+	return _SsoAccount.Contract.ListModuleValidators(&_SsoAccount.CallOpts)
+}
+
+// OnERC1155BatchReceived is a free data retrieval call binding the contract method 0xbc197c81.
+//
+// Solidity: function onERC1155BatchReceived(address , address , uint256[] , uint256[] , bytes ) pure returns(bytes4)
+func (_SsoAccount *SsoAccountCaller) OnERC1155BatchReceived(opts *bind.CallOpts, arg0 common.Address, arg1 common.Address, arg2 []*big.Int, arg3 []*big.Int, arg4 []byte) ([4]byte, error) {
+	var out []interface{}
+	err := _SsoAccount.contract.Call(opts, &out, "onERC1155BatchReceived", arg0, arg1, arg2, arg3, arg4)
+
+	if err != nil {
+		return *new([4]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([4]byte)).(*[4]byte)
+
+	return out0, err
+
+}
+
+// OnERC1155BatchReceived is a free data retrieval call binding the contract method 0xbc197c81.
+//
+// Solidity: function onERC1155BatchReceived(address , address , uint256[] , uint256[] , bytes ) pure returns(bytes4)
+func (_SsoAccount *SsoAccountSession) OnERC1155BatchReceived(arg0 common.Address, arg1 common.Address, arg2 []*big.Int, arg3 []*big.Int, arg4 []byte) ([4]byte, error) {
+	return _SsoAccount.Contract.OnERC1155BatchReceived(&_SsoAccount.CallOpts, arg0, arg1, arg2, arg3, arg4)
+}
+
+// OnERC1155BatchReceived is a free data retrieval call binding the contract method 0xbc197c81.
+//
+// Solidity: function onERC1155BatchReceived(address , address , uint256[] , uint256[] , bytes ) pure returns(bytes4)
+func (_SsoAccount *SsoAccountCallerSession) OnERC1155BatchReceived(arg0 common.Address, arg1 common.Address, arg2 []*big.Int, arg3 []*big.Int, arg4 []byte) ([4]byte, error) {
+	return _SsoAccount.Contract.OnERC1155BatchReceived(&_SsoAccount.CallOpts, arg0, arg1, arg2, arg3, arg4)
+}
+
+// OnERC1155Received is a free data retrieval call binding the contract method 0xf23a6e61.
+//
+// Solidity: function onERC1155Received(address , address , uint256 , uint256 , bytes ) pure returns(bytes4)
+func (_SsoAccount *SsoAccountCaller) OnERC1155Received(opts *bind.CallOpts, arg0 common.Address, arg1 common.Address, arg2 *big.Int, arg3 *big.Int, arg4 []byte) ([4]byte, error) {
+	var out []interface{}
+	err := _SsoAccount.contract.Call(opts, &out, "onERC1155Received", arg0, arg1, arg2, arg3, arg4)
+
+	if err != nil {
+		return *new([4]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([4]byte)).(*[4]byte)
+
+	return out0, err
+
+}
+
+// OnERC1155Received is a free data retrieval call binding the contract method 0xf23a6e61.
+//
+// Solidity: function onERC1155Received(address , address , uint256 , uint256 , bytes ) pure returns(bytes4)
+func (_SsoAccount *SsoAccountSession) OnERC1155Received(arg0 common.Address, arg1 common.Address, arg2 *big.Int, arg3 *big.Int, arg4 []byte) ([4]byte, error) {
+	return _SsoAccount.Contract.OnERC1155Received(&_SsoAccount.CallOpts, arg0, arg1, arg2, arg3, arg4)
+}
+
+// OnERC1155Received is a free data retrieval call binding the contract method 0xf23a6e61.
+//
+// Solidity: function onERC1155Received(address , address , uint256 , uint256 , bytes ) pure returns(bytes4)
+func (_SsoAccount *SsoAccountCallerSession) OnERC1155Received(arg0 common.Address, arg1 common.Address, arg2 *big.Int, arg3 *big.Int, arg4 []byte) ([4]byte, error) {
+	return _SsoAccount.Contract.OnERC1155Received(&_SsoAccount.CallOpts, arg0, arg1, arg2, arg3, arg4)
+}
+
+// OnERC721Received is a free data retrieval call binding the contract method 0x150b7a02.
+//
+// Solidity: function onERC721Received(address , address , uint256 , bytes ) pure returns(bytes4)
+func (_SsoAccount *SsoAccountCaller) OnERC721Received(opts *bind.CallOpts, arg0 common.Address, arg1 common.Address, arg2 *big.Int, arg3 []byte) ([4]byte, error) {
+	var out []interface{}
+	err := _SsoAccount.contract.Call(opts, &out, "onERC721Received", arg0, arg1, arg2, arg3)
+
+	if err != nil {
+		return *new([4]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([4]byte)).(*[4]byte)
+
+	return out0, err
+
+}
+
+// OnERC721Received is a free data retrieval call binding the contract method 0x150b7a02.
+//
+// Solidity: function onERC721Received(address , address , uint256 , bytes ) pure returns(bytes4)
+func (_SsoAccount *SsoAccountSession) OnERC721Received(arg0 common.Address, arg1 common.Address, arg2 *big.Int, arg3 []byte) ([4]byte, error) {
+	return _SsoAccount.Contract.OnERC721Received(&_SsoAccount.CallOpts, arg0, arg1, arg2, arg3)
+}
+
+// OnERC721Received is a free data retrieval call binding the contract method 0x150b7a02.
+//
+// Solidity: function onERC721Received(address , address , uint256 , bytes ) pure returns(bytes4)
+func (_SsoAccount *SsoAccountCallerSession) OnERC721Received(arg0 common.Address, arg1 common.Address, arg2 *big.Int, arg3 []byte) ([4]byte, error) {
+	return _SsoAccount.Contract.OnERC721Received(&_SsoAccount.CallOpts, arg0, arg1, arg2, arg3)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_SsoAccount *SsoAccountCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _SsoAccount.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_SsoAccount *SsoAccountSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _SsoAccount.Contract.SupportsInterface(&_SsoAccount.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_SsoAccount *SsoAccountCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _SsoAccount.Contract.SupportsInterface(&_SsoAccount.CallOpts, interfaceId)
+}
+
+// AddHook is a paid mutator transaction binding the contract method 0x0775a94e.
+//
+// Solidity: function addHook(address hook, bool isValidation, bytes initData) returns()
+func (_SsoAccount *SsoAccountTransactor) AddHook(opts *bind.TransactOpts, hook common.Address, isValidation bool, initData []byte) (*types.Transaction, error) {
+	return _SsoAccount.contract.Transact(opts, "addHook", hook, isValidation, initData)
+}
+
+// AddHook is a paid mutator transaction binding the contract method 0x0775a94e.
+//
+// Solidity: function addHook(address hook, bool isValidation, bytes initData) returns()
+func (_SsoAccount *SsoAccountSession) AddHook(hook common.Address, isValidation bool, initData []byte) (*types.Transaction, error) {
+	return _SsoAccount.Contract.AddHook(&_SsoAccount.TransactOpts, hook, isValidation, initData)
+}
+
+// AddHook is a paid mutator transaction binding the contract method 0x0775a94e.
+//
+// Solidity: function addHook(address hook, bool isValidation, bytes initData) returns()
+func (_SsoAccount *SsoAccountTransactorSession) AddHook(hook common.Address, isValidation bool, initData []byte) (*types.Transaction, error) {
+	return _SsoAccount.Contract.AddHook(&_SsoAccount.TransactOpts, hook, isValidation, initData)
+}
+
+// AddK1Owner is a paid mutator transaction binding the contract method 0x23cef13e.
+//
+// Solidity: function addK1Owner(address addr) returns()
+func (_SsoAccount *SsoAccountTransactor) AddK1Owner(opts *bind.TransactOpts, addr common.Address) (*types.Transaction, error) {
+	return _SsoAccount.contract.Transact(opts, "addK1Owner", addr)
+}
+
+// AddK1Owner is a paid mutator transaction binding the contract method 0x23cef13e.
+//
+// Solidity: function addK1Owner(address addr) returns()
+func (_SsoAccount *SsoAccountSession) AddK1Owner(addr common.Address) (*types.Transaction, error) {
+	return _SsoAccount.Contract.AddK1Owner(&_SsoAccount.TransactOpts, addr)
+}
+
+// AddK1Owner is a paid mutator transaction binding the contract method 0x23cef13e.
+//
+// Solidity: function addK1Owner(address addr) returns()
+func (_SsoAccount *SsoAccountTransactorSession) AddK1Owner(addr common.Address) (*types.Transaction, error) {
+	return _SsoAccount.Contract.AddK1Owner(&_SsoAccount.TransactOpts, addr)
+}
+
+// AddModuleValidator is a paid mutator transaction binding the contract method 0x2e0b437d.
+//
+// Solidity: function addModuleValidator(address validator, bytes initData) returns()
+func (_SsoAccount *SsoAccountTransactor) AddModuleValidator(opts *bind.TransactOpts, validator common.Address, initData []byte) (*types.Transaction, error) {
+	return _SsoAccount.contract.Transact(opts, "addModuleValidator", validator, initData)
+}
+
+// AddModuleValidator is a paid mutator transaction binding the contract method 0x2e0b437d.
+//
+// Solidity: function addModuleValidator(address validator, bytes initData) returns()
+func (_SsoAccount *SsoAccountSession) AddModuleValidator(validator common.Address, initData []byte) (*types.Transaction, error) {
+	return _SsoAccount.Contract.AddModuleValidator(&_SsoAccount.TransactOpts, validator, initData)
+}
+
+// AddModuleValidator is a paid mutator transaction binding the contract method 0x2e0b437d.
+//
+// Solidity: function addModuleValidator(address validator, bytes initData) returns()
+func (_SsoAccount *SsoAccountTransactorSession) AddModuleValidator(validator common.Address, initData []byte) (*types.Transaction, error) {
+	return _SsoAccount.Contract.AddModuleValidator(&_SsoAccount.TransactOpts, validator, initData)
+}
+
+// BatchCall is a paid mutator transaction binding the contract method 0x8f0273a9.
+//
+// Solidity: function batchCall((address,bool,uint256,bytes)[] _calls) payable returns()
+func (_SsoAccount *SsoAccountTransactor) BatchCall(opts *bind.TransactOpts, _calls []Call) (*types.Transaction, error) {
+	return _SsoAccount.contract.Transact(opts, "batchCall", _calls)
+}
+
+// BatchCall is a paid mutator transaction binding the contract method 0x8f0273a9.
+//
+// Solidity: function batchCall((address,bool,uint256,bytes)[] _calls) payable returns()
+func (_SsoAccount *SsoAccountSession) BatchCall(_calls []Call) (*types.Transaction, error) {
+	return _SsoAccount.Contract.BatchCall(&_SsoAccount.TransactOpts, _calls)
+}
+
+// BatchCall is a paid mutator transaction binding the contract method 0x8f0273a9.
+//
+// Solidity: function batchCall((address,bool,uint256,bytes)[] _calls) payable returns()
+func (_SsoAccount *SsoAccountTransactorSession) BatchCall(_calls []Call) (*types.Transaction, error) {
+	return _SsoAccount.Contract.BatchCall(&_SsoAccount.TransactOpts, _calls)
+}
+
+// ExecuteTransaction is a paid mutator transaction binding the contract method 0xdf9c1589.
+//
+// Solidity: function executeTransaction(bytes32 , bytes32 , (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns()
+func (_SsoAccount *SsoAccountTransactor) ExecuteTransaction(opts *bind.TransactOpts, arg0 [32]byte, arg1 [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _SsoAccount.contract.Transact(opts, "executeTransaction", arg0, arg1, _transaction)
+}
+
+// ExecuteTransaction is a paid mutator transaction binding the contract method 0xdf9c1589.
+//
+// Solidity: function executeTransaction(bytes32 , bytes32 , (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns()
+func (_SsoAccount *SsoAccountSession) ExecuteTransaction(arg0 [32]byte, arg1 [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _SsoAccount.Contract.ExecuteTransaction(&_SsoAccount.TransactOpts, arg0, arg1, _transaction)
+}
+
+// ExecuteTransaction is a paid mutator transaction binding the contract method 0xdf9c1589.
+//
+// Solidity: function executeTransaction(bytes32 , bytes32 , (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns()
+func (_SsoAccount *SsoAccountTransactorSession) ExecuteTransaction(arg0 [32]byte, arg1 [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _SsoAccount.Contract.ExecuteTransaction(&_SsoAccount.TransactOpts, arg0, arg1, _transaction)
+}
+
+// ExecuteTransactionFromOutside is a paid mutator transaction binding the contract method 0xeeb8cb09.
+//
+// Solidity: function executeTransactionFromOutside((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) ) payable returns()
+func (_SsoAccount *SsoAccountTransactor) ExecuteTransactionFromOutside(opts *bind.TransactOpts, arg0 Transaction) (*types.Transaction, error) {
+	return _SsoAccount.contract.Transact(opts, "executeTransactionFromOutside", arg0)
+}
+
+// ExecuteTransactionFromOutside is a paid mutator transaction binding the contract method 0xeeb8cb09.
+//
+// Solidity: function executeTransactionFromOutside((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) ) payable returns()
+func (_SsoAccount *SsoAccountSession) ExecuteTransactionFromOutside(arg0 Transaction) (*types.Transaction, error) {
+	return _SsoAccount.Contract.ExecuteTransactionFromOutside(&_SsoAccount.TransactOpts, arg0)
+}
+
+// ExecuteTransactionFromOutside is a paid mutator transaction binding the contract method 0xeeb8cb09.
+//
+// Solidity: function executeTransactionFromOutside((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) ) payable returns()
+func (_SsoAccount *SsoAccountTransactorSession) ExecuteTransactionFromOutside(arg0 Transaction) (*types.Transaction, error) {
+	return _SsoAccount.Contract.ExecuteTransactionFromOutside(&_SsoAccount.TransactOpts, arg0)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xb9094997.
+//
+// Solidity: function initialize(bytes[] initialValidators, address[] initialK1Owners) returns()
+func (_SsoAccount *SsoAccountTransactor) Initialize(opts *bind.TransactOpts, initialValidators [][]byte, initialK1Owners []common.Address) (*types.Transaction, error) {
+	return _SsoAccount.contract.Transact(opts, "initialize", initialValidators, initialK1Owners)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xb9094997.
+//
+// Solidity: function initialize(bytes[] initialValidators, address[] initialK1Owners) returns()
+func (_SsoAccount *SsoAccountSession) Initialize(initialValidators [][]byte, initialK1Owners []common.Address) (*types.Transaction, error) {
+	return _SsoAccount.Contract.Initialize(&_SsoAccount.TransactOpts, initialValidators, initialK1Owners)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xb9094997.
+//
+// Solidity: function initialize(bytes[] initialValidators, address[] initialK1Owners) returns()
+func (_SsoAccount *SsoAccountTransactorSession) Initialize(initialValidators [][]byte, initialK1Owners []common.Address) (*types.Transaction, error) {
+	return _SsoAccount.Contract.Initialize(&_SsoAccount.TransactOpts, initialValidators, initialK1Owners)
+}
+
+// PayForTransaction is a paid mutator transaction binding the contract method 0xe2f318e3.
+//
+// Solidity: function payForTransaction(bytes32 , bytes32 , (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns()
+func (_SsoAccount *SsoAccountTransactor) PayForTransaction(opts *bind.TransactOpts, arg0 [32]byte, arg1 [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _SsoAccount.contract.Transact(opts, "payForTransaction", arg0, arg1, _transaction)
+}
+
+// PayForTransaction is a paid mutator transaction binding the contract method 0xe2f318e3.
+//
+// Solidity: function payForTransaction(bytes32 , bytes32 , (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns()
+func (_SsoAccount *SsoAccountSession) PayForTransaction(arg0 [32]byte, arg1 [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _SsoAccount.Contract.PayForTransaction(&_SsoAccount.TransactOpts, arg0, arg1, _transaction)
+}
+
+// PayForTransaction is a paid mutator transaction binding the contract method 0xe2f318e3.
+//
+// Solidity: function payForTransaction(bytes32 , bytes32 , (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns()
+func (_SsoAccount *SsoAccountTransactorSession) PayForTransaction(arg0 [32]byte, arg1 [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _SsoAccount.Contract.PayForTransaction(&_SsoAccount.TransactOpts, arg0, arg1, _transaction)
+}
+
+// PrepareForPaymaster is a paid mutator transaction binding the contract method 0xa28c1aee.
+//
+// Solidity: function prepareForPaymaster(bytes32 , bytes32 , (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns()
+func (_SsoAccount *SsoAccountTransactor) PrepareForPaymaster(opts *bind.TransactOpts, arg0 [32]byte, arg1 [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _SsoAccount.contract.Transact(opts, "prepareForPaymaster", arg0, arg1, _transaction)
+}
+
+// PrepareForPaymaster is a paid mutator transaction binding the contract method 0xa28c1aee.
+//
+// Solidity: function prepareForPaymaster(bytes32 , bytes32 , (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns()
+func (_SsoAccount *SsoAccountSession) PrepareForPaymaster(arg0 [32]byte, arg1 [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _SsoAccount.Contract.PrepareForPaymaster(&_SsoAccount.TransactOpts, arg0, arg1, _transaction)
+}
+
+// PrepareForPaymaster is a paid mutator transaction binding the contract method 0xa28c1aee.
+//
+// Solidity: function prepareForPaymaster(bytes32 , bytes32 , (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns()
+func (_SsoAccount *SsoAccountTransactorSession) PrepareForPaymaster(arg0 [32]byte, arg1 [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _SsoAccount.Contract.PrepareForPaymaster(&_SsoAccount.TransactOpts, arg0, arg1, _transaction)
+}
+
+// RemoveHook is a paid mutator transaction binding the contract method 0xe1551286.
+//
+// Solidity: function removeHook(address hook, bool isValidation, bytes deinitData) returns()
+func (_SsoAccount *SsoAccountTransactor) RemoveHook(opts *bind.TransactOpts, hook common.Address, isValidation bool, deinitData []byte) (*types.Transaction, error) {
+	return _SsoAccount.contract.Transact(opts, "removeHook", hook, isValidation, deinitData)
+}
+
+// RemoveHook is a paid mutator transaction binding the contract method 0xe1551286.
+//
+// Solidity: function removeHook(address hook, bool isValidation, bytes deinitData) returns()
+func (_SsoAccount *SsoAccountSession) RemoveHook(hook common.Address, isValidation bool, deinitData []byte) (*types.Transaction, error) {
+	return _SsoAccount.Contract.RemoveHook(&_SsoAccount.TransactOpts, hook, isValidation, deinitData)
+}
+
+// RemoveHook is a paid mutator transaction binding the contract method 0xe1551286.
+//
+// Solidity: function removeHook(address hook, bool isValidation, bytes deinitData) returns()
+func (_SsoAccount *SsoAccountTransactorSession) RemoveHook(hook common.Address, isValidation bool, deinitData []byte) (*types.Transaction, error) {
+	return _SsoAccount.Contract.RemoveHook(&_SsoAccount.TransactOpts, hook, isValidation, deinitData)
+}
+
+// RemoveK1Owner is a paid mutator transaction binding the contract method 0x714da018.
+//
+// Solidity: function removeK1Owner(address addr) returns()
+func (_SsoAccount *SsoAccountTransactor) RemoveK1Owner(opts *bind.TransactOpts, addr common.Address) (*types.Transaction, error) {
+	return _SsoAccount.contract.Transact(opts, "removeK1Owner", addr)
+}
+
+// RemoveK1Owner is a paid mutator transaction binding the contract method 0x714da018.
+//
+// Solidity: function removeK1Owner(address addr) returns()
+func (_SsoAccount *SsoAccountSession) RemoveK1Owner(addr common.Address) (*types.Transaction, error) {
+	return _SsoAccount.Contract.RemoveK1Owner(&_SsoAccount.TransactOpts, addr)
+}
+
+// RemoveK1Owner is a paid mutator transaction binding the contract method 0x714da018.
+//
+// Solidity: function removeK1Owner(address addr) returns()
+func (_SsoAccount *SsoAccountTransactorSession) RemoveK1Owner(addr common.Address) (*types.Transaction, error) {
+	return _SsoAccount.Contract.RemoveK1Owner(&_SsoAccount.TransactOpts, addr)
+}
+
+// RemoveModuleValidator is a paid mutator transaction binding the contract method 0xb027e50a.
+//
+// Solidity: function removeModuleValidator(address validator, bytes deinitData) returns()
+func (_SsoAccount *SsoAccountTransactor) RemoveModuleValidator(opts *bind.TransactOpts, validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _SsoAccount.contract.Transact(opts, "removeModuleValidator", validator, deinitData)
+}
+
+// RemoveModuleValidator is a paid mutator transaction binding the contract method 0xb027e50a.
+//
+// Solidity: function removeModuleValidator(address validator, bytes deinitData) returns()
+func (_SsoAccount *SsoAccountSession) RemoveModuleValidator(validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _SsoAccount.Contract.RemoveModuleValidator(&_SsoAccount.TransactOpts, validator, deinitData)
+}
+
+// RemoveModuleValidator is a paid mutator transaction binding the contract method 0xb027e50a.
+//
+// Solidity: function removeModuleValidator(address validator, bytes deinitData) returns()
+func (_SsoAccount *SsoAccountTransactorSession) RemoveModuleValidator(validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _SsoAccount.Contract.RemoveModuleValidator(&_SsoAccount.TransactOpts, validator, deinitData)
+}
+
+// UnlinkHook is a paid mutator transaction binding the contract method 0x126c46c1.
+//
+// Solidity: function unlinkHook(address hook, bool isValidation, bytes deinitData) returns()
+func (_SsoAccount *SsoAccountTransactor) UnlinkHook(opts *bind.TransactOpts, hook common.Address, isValidation bool, deinitData []byte) (*types.Transaction, error) {
+	return _SsoAccount.contract.Transact(opts, "unlinkHook", hook, isValidation, deinitData)
+}
+
+// UnlinkHook is a paid mutator transaction binding the contract method 0x126c46c1.
+//
+// Solidity: function unlinkHook(address hook, bool isValidation, bytes deinitData) returns()
+func (_SsoAccount *SsoAccountSession) UnlinkHook(hook common.Address, isValidation bool, deinitData []byte) (*types.Transaction, error) {
+	return _SsoAccount.Contract.UnlinkHook(&_SsoAccount.TransactOpts, hook, isValidation, deinitData)
+}
+
+// UnlinkHook is a paid mutator transaction binding the contract method 0x126c46c1.
+//
+// Solidity: function unlinkHook(address hook, bool isValidation, bytes deinitData) returns()
+func (_SsoAccount *SsoAccountTransactorSession) UnlinkHook(hook common.Address, isValidation bool, deinitData []byte) (*types.Transaction, error) {
+	return _SsoAccount.Contract.UnlinkHook(&_SsoAccount.TransactOpts, hook, isValidation, deinitData)
+}
+
+// UnlinkModuleValidator is a paid mutator transaction binding the contract method 0xa7d525e8.
+//
+// Solidity: function unlinkModuleValidator(address validator, bytes deinitData) returns()
+func (_SsoAccount *SsoAccountTransactor) UnlinkModuleValidator(opts *bind.TransactOpts, validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _SsoAccount.contract.Transact(opts, "unlinkModuleValidator", validator, deinitData)
+}
+
+// UnlinkModuleValidator is a paid mutator transaction binding the contract method 0xa7d525e8.
+//
+// Solidity: function unlinkModuleValidator(address validator, bytes deinitData) returns()
+func (_SsoAccount *SsoAccountSession) UnlinkModuleValidator(validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _SsoAccount.Contract.UnlinkModuleValidator(&_SsoAccount.TransactOpts, validator, deinitData)
+}
+
+// UnlinkModuleValidator is a paid mutator transaction binding the contract method 0xa7d525e8.
+//
+// Solidity: function unlinkModuleValidator(address validator, bytes deinitData) returns()
+func (_SsoAccount *SsoAccountTransactorSession) UnlinkModuleValidator(validator common.Address, deinitData []byte) (*types.Transaction, error) {
+	return _SsoAccount.Contract.UnlinkModuleValidator(&_SsoAccount.TransactOpts, validator, deinitData)
+}
+
+// ValidateTransaction is a paid mutator transaction binding the contract method 0x202bcce7.
+//
+// Solidity: function validateTransaction(bytes32 , bytes32 _suggestedSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns(bytes4 magic)
+func (_SsoAccount *SsoAccountTransactor) ValidateTransaction(opts *bind.TransactOpts, arg0 [32]byte, _suggestedSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _SsoAccount.contract.Transact(opts, "validateTransaction", arg0, _suggestedSignedHash, _transaction)
+}
+
+// ValidateTransaction is a paid mutator transaction binding the contract method 0x202bcce7.
+//
+// Solidity: function validateTransaction(bytes32 , bytes32 _suggestedSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns(bytes4 magic)
+func (_SsoAccount *SsoAccountSession) ValidateTransaction(arg0 [32]byte, _suggestedSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _SsoAccount.Contract.ValidateTransaction(&_SsoAccount.TransactOpts, arg0, _suggestedSignedHash, _transaction)
+}
+
+// ValidateTransaction is a paid mutator transaction binding the contract method 0x202bcce7.
+//
+// Solidity: function validateTransaction(bytes32 , bytes32 _suggestedSignedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns(bytes4 magic)
+func (_SsoAccount *SsoAccountTransactorSession) ValidateTransaction(arg0 [32]byte, _suggestedSignedHash [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _SsoAccount.Contract.ValidateTransaction(&_SsoAccount.TransactOpts, arg0, _suggestedSignedHash, _transaction)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_SsoAccount *SsoAccountTransactor) Receive(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _SsoAccount.contract.RawTransact(opts, nil) // calldata is disallowed for receive function
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_SsoAccount *SsoAccountSession) Receive() (*types.Transaction, error) {
+	return _SsoAccount.Contract.Receive(&_SsoAccount.TransactOpts)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_SsoAccount *SsoAccountTransactorSession) Receive() (*types.Transaction, error) {
+	return _SsoAccount.Contract.Receive(&_SsoAccount.TransactOpts)
+}
+
+// SsoAccountBatchCallFailureIterator is returned from FilterBatchCallFailure and is used to iterate over the raw logs and unpacked data for BatchCallFailure events raised by the SsoAccount contract.
+type SsoAccountBatchCallFailureIterator struct {
+	Event *SsoAccountBatchCallFailure // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *SsoAccountBatchCallFailureIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(SsoAccountBatchCallFailure)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(SsoAccountBatchCallFailure)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *SsoAccountBatchCallFailureIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *SsoAccountBatchCallFailureIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// SsoAccountBatchCallFailure represents a BatchCallFailure event raised by the SsoAccount contract.
+type SsoAccountBatchCallFailure struct {
+	Index      *big.Int
+	RevertData []byte
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterBatchCallFailure is a free log retrieval operation binding the contract event 0x860d60a3c3ed451a144846eba67081eb134233fed0aff20997e5110b942b3d0e.
+//
+// Solidity: event BatchCallFailure(uint256 indexed index, bytes revertData)
+func (_SsoAccount *SsoAccountFilterer) FilterBatchCallFailure(opts *bind.FilterOpts, index []*big.Int) (*SsoAccountBatchCallFailureIterator, error) {
+
+	var indexRule []interface{}
+	for _, indexItem := range index {
+		indexRule = append(indexRule, indexItem)
+	}
+
+	logs, sub, err := _SsoAccount.contract.FilterLogs(opts, "BatchCallFailure", indexRule)
+	if err != nil {
+		return nil, err
+	}
+	return &SsoAccountBatchCallFailureIterator{contract: _SsoAccount.contract, event: "BatchCallFailure", logs: logs, sub: sub}, nil
+}
+
+// WatchBatchCallFailure is a free log subscription operation binding the contract event 0x860d60a3c3ed451a144846eba67081eb134233fed0aff20997e5110b942b3d0e.
+//
+// Solidity: event BatchCallFailure(uint256 indexed index, bytes revertData)
+func (_SsoAccount *SsoAccountFilterer) WatchBatchCallFailure(opts *bind.WatchOpts, sink chan<- *SsoAccountBatchCallFailure, index []*big.Int) (event.Subscription, error) {
+
+	var indexRule []interface{}
+	for _, indexItem := range index {
+		indexRule = append(indexRule, indexItem)
+	}
+
+	logs, sub, err := _SsoAccount.contract.WatchLogs(opts, "BatchCallFailure", indexRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(SsoAccountBatchCallFailure)
+				if err := _SsoAccount.contract.UnpackLog(event, "BatchCallFailure", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBatchCallFailure is a log parse operation binding the contract event 0x860d60a3c3ed451a144846eba67081eb134233fed0aff20997e5110b942b3d0e.
+//
+// Solidity: event BatchCallFailure(uint256 indexed index, bytes revertData)
+func (_SsoAccount *SsoAccountFilterer) ParseBatchCallFailure(log types.Log) (*SsoAccountBatchCallFailure, error) {
+	event := new(SsoAccountBatchCallFailure)
+	if err := _SsoAccount.contract.UnpackLog(event, "BatchCallFailure", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// SsoAccountHookAddedIterator is returned from FilterHookAdded and is used to iterate over the raw logs and unpacked data for HookAdded events raised by the SsoAccount contract.
+type SsoAccountHookAddedIterator struct {
+	Event *SsoAccountHookAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *SsoAccountHookAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(SsoAccountHookAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(SsoAccountHookAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *SsoAccountHookAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *SsoAccountHookAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// SsoAccountHookAdded represents a HookAdded event raised by the SsoAccount contract.
+type SsoAccountHookAdded struct {
+	Hook common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterHookAdded is a free log retrieval operation binding the contract event 0x28e00134722f84e69c391c81e4fe022ee3e61048222a8ea2f98c9f235f797508.
+//
+// Solidity: event HookAdded(address indexed hook)
+func (_SsoAccount *SsoAccountFilterer) FilterHookAdded(opts *bind.FilterOpts, hook []common.Address) (*SsoAccountHookAddedIterator, error) {
+
+	var hookRule []interface{}
+	for _, hookItem := range hook {
+		hookRule = append(hookRule, hookItem)
+	}
+
+	logs, sub, err := _SsoAccount.contract.FilterLogs(opts, "HookAdded", hookRule)
+	if err != nil {
+		return nil, err
+	}
+	return &SsoAccountHookAddedIterator{contract: _SsoAccount.contract, event: "HookAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchHookAdded is a free log subscription operation binding the contract event 0x28e00134722f84e69c391c81e4fe022ee3e61048222a8ea2f98c9f235f797508.
+//
+// Solidity: event HookAdded(address indexed hook)
+func (_SsoAccount *SsoAccountFilterer) WatchHookAdded(opts *bind.WatchOpts, sink chan<- *SsoAccountHookAdded, hook []common.Address) (event.Subscription, error) {
+
+	var hookRule []interface{}
+	for _, hookItem := range hook {
+		hookRule = append(hookRule, hookItem)
+	}
+
+	logs, sub, err := _SsoAccount.contract.WatchLogs(opts, "HookAdded", hookRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(SsoAccountHookAdded)
+				if err := _SsoAccount.contract.UnpackLog(event, "HookAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseHookAdded is a log parse operation binding the contract event 0x28e00134722f84e69c391c81e4fe022ee3e61048222a8ea2f98c9f235f797508.
+//
+// Solidity: event HookAdded(address indexed hook)
+func (_SsoAccount *SsoAccountFilterer) ParseHookAdded(log types.Log) (*SsoAccountHookAdded, error) {
+	event := new(SsoAccountHookAdded)
+	if err := _SsoAccount.contract.UnpackLog(event, "HookAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// SsoAccountHookRemovedIterator is returned from FilterHookRemoved and is used to iterate over the raw logs and unpacked data for HookRemoved events raised by the SsoAccount contract.
+type SsoAccountHookRemovedIterator struct {
+	Event *SsoAccountHookRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *SsoAccountHookRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(SsoAccountHookRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(SsoAccountHookRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *SsoAccountHookRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *SsoAccountHookRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// SsoAccountHookRemoved represents a HookRemoved event raised by the SsoAccount contract.
+type SsoAccountHookRemoved struct {
+	Hook common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterHookRemoved is a free log retrieval operation binding the contract event 0x47d0871e905ac6550f54ba266e0d90d2dc8ed67a957c064ca3438eddf4e3fd89.
+//
+// Solidity: event HookRemoved(address indexed hook)
+func (_SsoAccount *SsoAccountFilterer) FilterHookRemoved(opts *bind.FilterOpts, hook []common.Address) (*SsoAccountHookRemovedIterator, error) {
+
+	var hookRule []interface{}
+	for _, hookItem := range hook {
+		hookRule = append(hookRule, hookItem)
+	}
+
+	logs, sub, err := _SsoAccount.contract.FilterLogs(opts, "HookRemoved", hookRule)
+	if err != nil {
+		return nil, err
+	}
+	return &SsoAccountHookRemovedIterator{contract: _SsoAccount.contract, event: "HookRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchHookRemoved is a free log subscription operation binding the contract event 0x47d0871e905ac6550f54ba266e0d90d2dc8ed67a957c064ca3438eddf4e3fd89.
+//
+// Solidity: event HookRemoved(address indexed hook)
+func (_SsoAccount *SsoAccountFilterer) WatchHookRemoved(opts *bind.WatchOpts, sink chan<- *SsoAccountHookRemoved, hook []common.Address) (event.Subscription, error) {
+
+	var hookRule []interface{}
+	for _, hookItem := range hook {
+		hookRule = append(hookRule, hookItem)
+	}
+
+	logs, sub, err := _SsoAccount.contract.WatchLogs(opts, "HookRemoved", hookRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(SsoAccountHookRemoved)
+				if err := _SsoAccount.contract.UnpackLog(event, "HookRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseHookRemoved is a log parse operation binding the contract event 0x47d0871e905ac6550f54ba266e0d90d2dc8ed67a957c064ca3438eddf4e3fd89.
+//
+// Solidity: event HookRemoved(address indexed hook)
+func (_SsoAccount *SsoAccountFilterer) ParseHookRemoved(log types.Log) (*SsoAccountHookRemoved, error) {
+	event := new(SsoAccountHookRemoved)
+	if err := _SsoAccount.contract.UnpackLog(event, "HookRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// SsoAccountInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the SsoAccount contract.
+type SsoAccountInitializedIterator struct {
+	Event *SsoAccountInitialized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *SsoAccountInitializedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(SsoAccountInitialized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(SsoAccountInitialized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *SsoAccountInitializedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *SsoAccountInitializedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// SsoAccountInitialized represents a Initialized event raised by the SsoAccount contract.
+type SsoAccountInitialized struct {
+	Version uint8
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterInitialized is a free log retrieval operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_SsoAccount *SsoAccountFilterer) FilterInitialized(opts *bind.FilterOpts) (*SsoAccountInitializedIterator, error) {
+
+	logs, sub, err := _SsoAccount.contract.FilterLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return &SsoAccountInitializedIterator{contract: _SsoAccount.contract, event: "Initialized", logs: logs, sub: sub}, nil
+}
+
+// WatchInitialized is a free log subscription operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_SsoAccount *SsoAccountFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *SsoAccountInitialized) (event.Subscription, error) {
+
+	logs, sub, err := _SsoAccount.contract.WatchLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(SsoAccountInitialized)
+				if err := _SsoAccount.contract.UnpackLog(event, "Initialized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseInitialized is a log parse operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_SsoAccount *SsoAccountFilterer) ParseInitialized(log types.Log) (*SsoAccountInitialized, error) {
+	event := new(SsoAccountInitialized)
+	if err := _SsoAccount.contract.UnpackLog(event, "Initialized", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// SsoAccountK1OwnerAddedIterator is returned from FilterK1OwnerAdded and is used to iterate over the raw logs and unpacked data for K1OwnerAdded events raised by the SsoAccount contract.
+type SsoAccountK1OwnerAddedIterator struct {
+	Event *SsoAccountK1OwnerAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *SsoAccountK1OwnerAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(SsoAccountK1OwnerAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(SsoAccountK1OwnerAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *SsoAccountK1OwnerAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *SsoAccountK1OwnerAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// SsoAccountK1OwnerAdded represents a K1OwnerAdded event raised by the SsoAccount contract.
+type SsoAccountK1OwnerAdded struct {
+	Addr common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterK1OwnerAdded is a free log retrieval operation binding the contract event 0x40097f116787d282c09163d089084b2d950545433dad84146baf8da81064e84c.
+//
+// Solidity: event K1OwnerAdded(address indexed addr)
+func (_SsoAccount *SsoAccountFilterer) FilterK1OwnerAdded(opts *bind.FilterOpts, addr []common.Address) (*SsoAccountK1OwnerAddedIterator, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+
+	logs, sub, err := _SsoAccount.contract.FilterLogs(opts, "K1OwnerAdded", addrRule)
+	if err != nil {
+		return nil, err
+	}
+	return &SsoAccountK1OwnerAddedIterator{contract: _SsoAccount.contract, event: "K1OwnerAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchK1OwnerAdded is a free log subscription operation binding the contract event 0x40097f116787d282c09163d089084b2d950545433dad84146baf8da81064e84c.
+//
+// Solidity: event K1OwnerAdded(address indexed addr)
+func (_SsoAccount *SsoAccountFilterer) WatchK1OwnerAdded(opts *bind.WatchOpts, sink chan<- *SsoAccountK1OwnerAdded, addr []common.Address) (event.Subscription, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+
+	logs, sub, err := _SsoAccount.contract.WatchLogs(opts, "K1OwnerAdded", addrRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(SsoAccountK1OwnerAdded)
+				if err := _SsoAccount.contract.UnpackLog(event, "K1OwnerAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseK1OwnerAdded is a log parse operation binding the contract event 0x40097f116787d282c09163d089084b2d950545433dad84146baf8da81064e84c.
+//
+// Solidity: event K1OwnerAdded(address indexed addr)
+func (_SsoAccount *SsoAccountFilterer) ParseK1OwnerAdded(log types.Log) (*SsoAccountK1OwnerAdded, error) {
+	event := new(SsoAccountK1OwnerAdded)
+	if err := _SsoAccount.contract.UnpackLog(event, "K1OwnerAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// SsoAccountK1OwnerRemovedIterator is returned from FilterK1OwnerRemoved and is used to iterate over the raw logs and unpacked data for K1OwnerRemoved events raised by the SsoAccount contract.
+type SsoAccountK1OwnerRemovedIterator struct {
+	Event *SsoAccountK1OwnerRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *SsoAccountK1OwnerRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(SsoAccountK1OwnerRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(SsoAccountK1OwnerRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *SsoAccountK1OwnerRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *SsoAccountK1OwnerRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// SsoAccountK1OwnerRemoved represents a K1OwnerRemoved event raised by the SsoAccount contract.
+type SsoAccountK1OwnerRemoved struct {
+	Addr common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterK1OwnerRemoved is a free log retrieval operation binding the contract event 0xe09f0b842a072d50a0b373f3255e2a4216aeb61908e35a93a499f0ff2aa4c8fa.
+//
+// Solidity: event K1OwnerRemoved(address indexed addr)
+func (_SsoAccount *SsoAccountFilterer) FilterK1OwnerRemoved(opts *bind.FilterOpts, addr []common.Address) (*SsoAccountK1OwnerRemovedIterator, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+
+	logs, sub, err := _SsoAccount.contract.FilterLogs(opts, "K1OwnerRemoved", addrRule)
+	if err != nil {
+		return nil, err
+	}
+	return &SsoAccountK1OwnerRemovedIterator{contract: _SsoAccount.contract, event: "K1OwnerRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchK1OwnerRemoved is a free log subscription operation binding the contract event 0xe09f0b842a072d50a0b373f3255e2a4216aeb61908e35a93a499f0ff2aa4c8fa.
+//
+// Solidity: event K1OwnerRemoved(address indexed addr)
+func (_SsoAccount *SsoAccountFilterer) WatchK1OwnerRemoved(opts *bind.WatchOpts, sink chan<- *SsoAccountK1OwnerRemoved, addr []common.Address) (event.Subscription, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+
+	logs, sub, err := _SsoAccount.contract.WatchLogs(opts, "K1OwnerRemoved", addrRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(SsoAccountK1OwnerRemoved)
+				if err := _SsoAccount.contract.UnpackLog(event, "K1OwnerRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseK1OwnerRemoved is a log parse operation binding the contract event 0xe09f0b842a072d50a0b373f3255e2a4216aeb61908e35a93a499f0ff2aa4c8fa.
+//
+// Solidity: event K1OwnerRemoved(address indexed addr)
+func (_SsoAccount *SsoAccountFilterer) ParseK1OwnerRemoved(log types.Log) (*SsoAccountK1OwnerRemoved, error) {
+	event := new(SsoAccountK1OwnerRemoved)
+	if err := _SsoAccount.contract.UnpackLog(event, "K1OwnerRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// SsoAccountValidatorAddedIterator is returned from FilterValidatorAdded and is used to iterate over the raw logs and unpacked data for ValidatorAdded events raised by the SsoAccount contract.
+type SsoAccountValidatorAddedIterator struct {
+	Event *SsoAccountValidatorAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *SsoAccountValidatorAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(SsoAccountValidatorAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(SsoAccountValidatorAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *SsoAccountValidatorAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *SsoAccountValidatorAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// SsoAccountValidatorAdded represents a ValidatorAdded event raised by the SsoAccount contract.
+type SsoAccountValidatorAdded struct {
+	Validator common.Address
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterValidatorAdded is a free log retrieval operation binding the contract event 0xe366c1c0452ed8eec96861e9e54141ebff23c9ec89fe27b996b45f5ec3884987.
+//
+// Solidity: event ValidatorAdded(address indexed validator)
+func (_SsoAccount *SsoAccountFilterer) FilterValidatorAdded(opts *bind.FilterOpts, validator []common.Address) (*SsoAccountValidatorAddedIterator, error) {
+
+	var validatorRule []interface{}
+	for _, validatorItem := range validator {
+		validatorRule = append(validatorRule, validatorItem)
+	}
+
+	logs, sub, err := _SsoAccount.contract.FilterLogs(opts, "ValidatorAdded", validatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &SsoAccountValidatorAddedIterator{contract: _SsoAccount.contract, event: "ValidatorAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchValidatorAdded is a free log subscription operation binding the contract event 0xe366c1c0452ed8eec96861e9e54141ebff23c9ec89fe27b996b45f5ec3884987.
+//
+// Solidity: event ValidatorAdded(address indexed validator)
+func (_SsoAccount *SsoAccountFilterer) WatchValidatorAdded(opts *bind.WatchOpts, sink chan<- *SsoAccountValidatorAdded, validator []common.Address) (event.Subscription, error) {
+
+	var validatorRule []interface{}
+	for _, validatorItem := range validator {
+		validatorRule = append(validatorRule, validatorItem)
+	}
+
+	logs, sub, err := _SsoAccount.contract.WatchLogs(opts, "ValidatorAdded", validatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(SsoAccountValidatorAdded)
+				if err := _SsoAccount.contract.UnpackLog(event, "ValidatorAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseValidatorAdded is a log parse operation binding the contract event 0xe366c1c0452ed8eec96861e9e54141ebff23c9ec89fe27b996b45f5ec3884987.
+//
+// Solidity: event ValidatorAdded(address indexed validator)
+func (_SsoAccount *SsoAccountFilterer) ParseValidatorAdded(log types.Log) (*SsoAccountValidatorAdded, error) {
+	event := new(SsoAccountValidatorAdded)
+	if err := _SsoAccount.contract.UnpackLog(event, "ValidatorAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// SsoAccountValidatorRemovedIterator is returned from FilterValidatorRemoved and is used to iterate over the raw logs and unpacked data for ValidatorRemoved events raised by the SsoAccount contract.
+type SsoAccountValidatorRemovedIterator struct {
+	Event *SsoAccountValidatorRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *SsoAccountValidatorRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(SsoAccountValidatorRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(SsoAccountValidatorRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *SsoAccountValidatorRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *SsoAccountValidatorRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// SsoAccountValidatorRemoved represents a ValidatorRemoved event raised by the SsoAccount contract.
+type SsoAccountValidatorRemoved struct {
+	Validator common.Address
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterValidatorRemoved is a free log retrieval operation binding the contract event 0xe1434e25d6611e0db941968fdc97811c982ac1602e951637d206f5fdda9dd8f1.
+//
+// Solidity: event ValidatorRemoved(address indexed validator)
+func (_SsoAccount *SsoAccountFilterer) FilterValidatorRemoved(opts *bind.FilterOpts, validator []common.Address) (*SsoAccountValidatorRemovedIterator, error) {
+
+	var validatorRule []interface{}
+	for _, validatorItem := range validator {
+		validatorRule = append(validatorRule, validatorItem)
+	}
+
+	logs, sub, err := _SsoAccount.contract.FilterLogs(opts, "ValidatorRemoved", validatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &SsoAccountValidatorRemovedIterator{contract: _SsoAccount.contract, event: "ValidatorRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchValidatorRemoved is a free log subscription operation binding the contract event 0xe1434e25d6611e0db941968fdc97811c982ac1602e951637d206f5fdda9dd8f1.
+//
+// Solidity: event ValidatorRemoved(address indexed validator)
+func (_SsoAccount *SsoAccountFilterer) WatchValidatorRemoved(opts *bind.WatchOpts, sink chan<- *SsoAccountValidatorRemoved, validator []common.Address) (event.Subscription, error) {
+
+	var validatorRule []interface{}
+	for _, validatorItem := range validator {
+		validatorRule = append(validatorRule, validatorItem)
+	}
+
+	logs, sub, err := _SsoAccount.contract.WatchLogs(opts, "ValidatorRemoved", validatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(SsoAccountValidatorRemoved)
+				if err := _SsoAccount.contract.UnpackLog(event, "ValidatorRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseValidatorRemoved is a log parse operation binding the contract event 0xe1434e25d6611e0db941968fdc97811c982ac1602e951637d206f5fdda9dd8f1.
+//
+// Solidity: event ValidatorRemoved(address indexed validator)
+func (_SsoAccount *SsoAccountFilterer) ParseValidatorRemoved(log types.Log) (*SsoAccountValidatorRemoved, error) {
+	event := new(SsoAccountValidatorRemoved)
+	if err := _SsoAccount.contract.UnpackLog(event, "ValidatorRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts/zksyncsso/ssobeacon/ssobeacon.go
+++ b/contracts/zksyncsso/ssobeacon/ssobeacon.go
@@ -1,0 +1,603 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package ssobeacon
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// SsoBeaconMetaData contains all meta data concerning the SsoBeacon contract.
+var SsoBeaconMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_implementation\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"implementation\",\"type\":\"address\"}],\"name\":\"Upgraded\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"implementation\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newImplementation\",\"type\":\"address\"}],\"name\":\"upgradeTo\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+}
+
+// SsoBeaconABI is the input ABI used to generate the binding from.
+// Deprecated: Use SsoBeaconMetaData.ABI instead.
+var SsoBeaconABI = SsoBeaconMetaData.ABI
+
+// SsoBeacon is an auto generated Go binding around an Ethereum contract.
+type SsoBeacon struct {
+	SsoBeaconCaller     // Read-only binding to the contract
+	SsoBeaconTransactor // Write-only binding to the contract
+	SsoBeaconFilterer   // Log filterer for contract events
+}
+
+// SsoBeaconCaller is an auto generated read-only Go binding around an Ethereum contract.
+type SsoBeaconCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// SsoBeaconTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type SsoBeaconTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// SsoBeaconFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type SsoBeaconFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// SsoBeaconSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type SsoBeaconSession struct {
+	Contract     *SsoBeacon        // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// SsoBeaconCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type SsoBeaconCallerSession struct {
+	Contract *SsoBeaconCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts    // Call options to use throughout this session
+}
+
+// SsoBeaconTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type SsoBeaconTransactorSession struct {
+	Contract     *SsoBeaconTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts    // Transaction auth options to use throughout this session
+}
+
+// SsoBeaconRaw is an auto generated low-level Go binding around an Ethereum contract.
+type SsoBeaconRaw struct {
+	Contract *SsoBeacon // Generic contract binding to access the raw methods on
+}
+
+// SsoBeaconCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type SsoBeaconCallerRaw struct {
+	Contract *SsoBeaconCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// SsoBeaconTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type SsoBeaconTransactorRaw struct {
+	Contract *SsoBeaconTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewSsoBeacon creates a new instance of SsoBeacon, bound to a specific deployed contract.
+func NewSsoBeacon(address common.Address, backend bind.ContractBackend) (*SsoBeacon, error) {
+	contract, err := bindSsoBeacon(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &SsoBeacon{SsoBeaconCaller: SsoBeaconCaller{contract: contract}, SsoBeaconTransactor: SsoBeaconTransactor{contract: contract}, SsoBeaconFilterer: SsoBeaconFilterer{contract: contract}}, nil
+}
+
+// NewSsoBeaconCaller creates a new read-only instance of SsoBeacon, bound to a specific deployed contract.
+func NewSsoBeaconCaller(address common.Address, caller bind.ContractCaller) (*SsoBeaconCaller, error) {
+	contract, err := bindSsoBeacon(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &SsoBeaconCaller{contract: contract}, nil
+}
+
+// NewSsoBeaconTransactor creates a new write-only instance of SsoBeacon, bound to a specific deployed contract.
+func NewSsoBeaconTransactor(address common.Address, transactor bind.ContractTransactor) (*SsoBeaconTransactor, error) {
+	contract, err := bindSsoBeacon(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &SsoBeaconTransactor{contract: contract}, nil
+}
+
+// NewSsoBeaconFilterer creates a new log filterer instance of SsoBeacon, bound to a specific deployed contract.
+func NewSsoBeaconFilterer(address common.Address, filterer bind.ContractFilterer) (*SsoBeaconFilterer, error) {
+	contract, err := bindSsoBeacon(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &SsoBeaconFilterer{contract: contract}, nil
+}
+
+// bindSsoBeacon binds a generic wrapper to an already deployed contract.
+func bindSsoBeacon(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := SsoBeaconMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_SsoBeacon *SsoBeaconRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _SsoBeacon.Contract.SsoBeaconCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_SsoBeacon *SsoBeaconRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _SsoBeacon.Contract.SsoBeaconTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_SsoBeacon *SsoBeaconRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _SsoBeacon.Contract.SsoBeaconTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_SsoBeacon *SsoBeaconCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _SsoBeacon.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_SsoBeacon *SsoBeaconTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _SsoBeacon.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_SsoBeacon *SsoBeaconTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _SsoBeacon.Contract.contract.Transact(opts, method, params...)
+}
+
+// Implementation is a free data retrieval call binding the contract method 0x5c60da1b.
+//
+// Solidity: function implementation() view returns(address)
+func (_SsoBeacon *SsoBeaconCaller) Implementation(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _SsoBeacon.contract.Call(opts, &out, "implementation")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Implementation is a free data retrieval call binding the contract method 0x5c60da1b.
+//
+// Solidity: function implementation() view returns(address)
+func (_SsoBeacon *SsoBeaconSession) Implementation() (common.Address, error) {
+	return _SsoBeacon.Contract.Implementation(&_SsoBeacon.CallOpts)
+}
+
+// Implementation is a free data retrieval call binding the contract method 0x5c60da1b.
+//
+// Solidity: function implementation() view returns(address)
+func (_SsoBeacon *SsoBeaconCallerSession) Implementation() (common.Address, error) {
+	return _SsoBeacon.Contract.Implementation(&_SsoBeacon.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_SsoBeacon *SsoBeaconCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _SsoBeacon.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_SsoBeacon *SsoBeaconSession) Owner() (common.Address, error) {
+	return _SsoBeacon.Contract.Owner(&_SsoBeacon.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_SsoBeacon *SsoBeaconCallerSession) Owner() (common.Address, error) {
+	return _SsoBeacon.Contract.Owner(&_SsoBeacon.CallOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_SsoBeacon *SsoBeaconTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _SsoBeacon.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_SsoBeacon *SsoBeaconSession) RenounceOwnership() (*types.Transaction, error) {
+	return _SsoBeacon.Contract.RenounceOwnership(&_SsoBeacon.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_SsoBeacon *SsoBeaconTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _SsoBeacon.Contract.RenounceOwnership(&_SsoBeacon.TransactOpts)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_SsoBeacon *SsoBeaconTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _SsoBeacon.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_SsoBeacon *SsoBeaconSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _SsoBeacon.Contract.TransferOwnership(&_SsoBeacon.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_SsoBeacon *SsoBeaconTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _SsoBeacon.Contract.TransferOwnership(&_SsoBeacon.TransactOpts, newOwner)
+}
+
+// UpgradeTo is a paid mutator transaction binding the contract method 0x3659cfe6.
+//
+// Solidity: function upgradeTo(address newImplementation) returns()
+func (_SsoBeacon *SsoBeaconTransactor) UpgradeTo(opts *bind.TransactOpts, newImplementation common.Address) (*types.Transaction, error) {
+	return _SsoBeacon.contract.Transact(opts, "upgradeTo", newImplementation)
+}
+
+// UpgradeTo is a paid mutator transaction binding the contract method 0x3659cfe6.
+//
+// Solidity: function upgradeTo(address newImplementation) returns()
+func (_SsoBeacon *SsoBeaconSession) UpgradeTo(newImplementation common.Address) (*types.Transaction, error) {
+	return _SsoBeacon.Contract.UpgradeTo(&_SsoBeacon.TransactOpts, newImplementation)
+}
+
+// UpgradeTo is a paid mutator transaction binding the contract method 0x3659cfe6.
+//
+// Solidity: function upgradeTo(address newImplementation) returns()
+func (_SsoBeacon *SsoBeaconTransactorSession) UpgradeTo(newImplementation common.Address) (*types.Transaction, error) {
+	return _SsoBeacon.Contract.UpgradeTo(&_SsoBeacon.TransactOpts, newImplementation)
+}
+
+// SsoBeaconOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the SsoBeacon contract.
+type SsoBeaconOwnershipTransferredIterator struct {
+	Event *SsoBeaconOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *SsoBeaconOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(SsoBeaconOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(SsoBeaconOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *SsoBeaconOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *SsoBeaconOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// SsoBeaconOwnershipTransferred represents a OwnershipTransferred event raised by the SsoBeacon contract.
+type SsoBeaconOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_SsoBeacon *SsoBeaconFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*SsoBeaconOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _SsoBeacon.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &SsoBeaconOwnershipTransferredIterator{contract: _SsoBeacon.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_SsoBeacon *SsoBeaconFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *SsoBeaconOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _SsoBeacon.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(SsoBeaconOwnershipTransferred)
+				if err := _SsoBeacon.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_SsoBeacon *SsoBeaconFilterer) ParseOwnershipTransferred(log types.Log) (*SsoBeaconOwnershipTransferred, error) {
+	event := new(SsoBeaconOwnershipTransferred)
+	if err := _SsoBeacon.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// SsoBeaconUpgradedIterator is returned from FilterUpgraded and is used to iterate over the raw logs and unpacked data for Upgraded events raised by the SsoBeacon contract.
+type SsoBeaconUpgradedIterator struct {
+	Event *SsoBeaconUpgraded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *SsoBeaconUpgradedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(SsoBeaconUpgraded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(SsoBeaconUpgraded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *SsoBeaconUpgradedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *SsoBeaconUpgradedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// SsoBeaconUpgraded represents a Upgraded event raised by the SsoBeacon contract.
+type SsoBeaconUpgraded struct {
+	Implementation common.Address
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterUpgraded is a free log retrieval operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_SsoBeacon *SsoBeaconFilterer) FilterUpgraded(opts *bind.FilterOpts, implementation []common.Address) (*SsoBeaconUpgradedIterator, error) {
+
+	var implementationRule []interface{}
+	for _, implementationItem := range implementation {
+		implementationRule = append(implementationRule, implementationItem)
+	}
+
+	logs, sub, err := _SsoBeacon.contract.FilterLogs(opts, "Upgraded", implementationRule)
+	if err != nil {
+		return nil, err
+	}
+	return &SsoBeaconUpgradedIterator{contract: _SsoBeacon.contract, event: "Upgraded", logs: logs, sub: sub}, nil
+}
+
+// WatchUpgraded is a free log subscription operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_SsoBeacon *SsoBeaconFilterer) WatchUpgraded(opts *bind.WatchOpts, sink chan<- *SsoBeaconUpgraded, implementation []common.Address) (event.Subscription, error) {
+
+	var implementationRule []interface{}
+	for _, implementationItem := range implementation {
+		implementationRule = append(implementationRule, implementationItem)
+	}
+
+	logs, sub, err := _SsoBeacon.contract.WatchLogs(opts, "Upgraded", implementationRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(SsoBeaconUpgraded)
+				if err := _SsoBeacon.contract.UnpackLog(event, "Upgraded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUpgraded is a log parse operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_SsoBeacon *SsoBeaconFilterer) ParseUpgraded(log types.Log) (*SsoBeaconUpgraded, error) {
+	event := new(SsoBeaconUpgraded)
+	if err := _SsoBeacon.contract.UnpackLog(event, "Upgraded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts/zksyncsso/test/dummy/dummy.go
+++ b/contracts/zksyncsso/test/dummy/dummy.go
@@ -1,0 +1,212 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package dummy
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// DummyMetaData contains all meta data concerning the Dummy contract.
+var DummyMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[],\"name\":\"dummy\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+}
+
+// DummyABI is the input ABI used to generate the binding from.
+// Deprecated: Use DummyMetaData.ABI instead.
+var DummyABI = DummyMetaData.ABI
+
+// Dummy is an auto generated Go binding around an Ethereum contract.
+type Dummy struct {
+	DummyCaller     // Read-only binding to the contract
+	DummyTransactor // Write-only binding to the contract
+	DummyFilterer   // Log filterer for contract events
+}
+
+// DummyCaller is an auto generated read-only Go binding around an Ethereum contract.
+type DummyCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// DummyTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type DummyTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// DummyFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type DummyFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// DummySession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type DummySession struct {
+	Contract     *Dummy            // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// DummyCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type DummyCallerSession struct {
+	Contract *DummyCaller  // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts // Call options to use throughout this session
+}
+
+// DummyTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type DummyTransactorSession struct {
+	Contract     *DummyTransactor  // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// DummyRaw is an auto generated low-level Go binding around an Ethereum contract.
+type DummyRaw struct {
+	Contract *Dummy // Generic contract binding to access the raw methods on
+}
+
+// DummyCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type DummyCallerRaw struct {
+	Contract *DummyCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// DummyTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type DummyTransactorRaw struct {
+	Contract *DummyTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewDummy creates a new instance of Dummy, bound to a specific deployed contract.
+func NewDummy(address common.Address, backend bind.ContractBackend) (*Dummy, error) {
+	contract, err := bindDummy(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Dummy{DummyCaller: DummyCaller{contract: contract}, DummyTransactor: DummyTransactor{contract: contract}, DummyFilterer: DummyFilterer{contract: contract}}, nil
+}
+
+// NewDummyCaller creates a new read-only instance of Dummy, bound to a specific deployed contract.
+func NewDummyCaller(address common.Address, caller bind.ContractCaller) (*DummyCaller, error) {
+	contract, err := bindDummy(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &DummyCaller{contract: contract}, nil
+}
+
+// NewDummyTransactor creates a new write-only instance of Dummy, bound to a specific deployed contract.
+func NewDummyTransactor(address common.Address, transactor bind.ContractTransactor) (*DummyTransactor, error) {
+	contract, err := bindDummy(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &DummyTransactor{contract: contract}, nil
+}
+
+// NewDummyFilterer creates a new log filterer instance of Dummy, bound to a specific deployed contract.
+func NewDummyFilterer(address common.Address, filterer bind.ContractFilterer) (*DummyFilterer, error) {
+	contract, err := bindDummy(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &DummyFilterer{contract: contract}, nil
+}
+
+// bindDummy binds a generic wrapper to an already deployed contract.
+func bindDummy(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := DummyMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Dummy *DummyRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Dummy.Contract.DummyCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Dummy *DummyRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Dummy.Contract.DummyTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Dummy *DummyRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Dummy.Contract.DummyTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Dummy *DummyCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Dummy.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Dummy *DummyTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Dummy.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Dummy *DummyTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Dummy.Contract.contract.Transact(opts, method, params...)
+}
+
+// Dummy is a free data retrieval call binding the contract method 0x32e43a11.
+//
+// Solidity: function dummy() view returns(string)
+func (_Dummy *DummyCaller) Dummy(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _Dummy.contract.Call(opts, &out, "dummy")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// Dummy is a free data retrieval call binding the contract method 0x32e43a11.
+//
+// Solidity: function dummy() view returns(string)
+func (_Dummy *DummySession) Dummy() (string, error) {
+	return _Dummy.Contract.Dummy(&_Dummy.CallOpts)
+}
+
+// Dummy is a free data retrieval call binding the contract method 0x32e43a11.
+//
+// Solidity: function dummy() view returns(string)
+func (_Dummy *DummyCallerSession) Dummy() (string, error) {
+	return _Dummy.Contract.Dummy(&_Dummy.CallOpts)
+}

--- a/contracts/zksyncsso/test/exampleauthserverpaymaster/exampleauthserverpaymaster.go
+++ b/contracts/zksyncsso/test/exampleauthserverpaymaster/exampleauthserverpaymaster.go
@@ -1,0 +1,635 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package exampleauthserverpaymaster
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// Transaction is an auto generated low-level Go binding around an user-defined struct.
+type Transaction struct {
+	TxType                 *big.Int
+	From                   *big.Int
+	To                     *big.Int
+	GasLimit               *big.Int
+	GasPerPubdataByteLimit *big.Int
+	MaxFeePerGas           *big.Int
+	MaxPriorityFeePerGas   *big.Int
+	Paymaster              *big.Int
+	Nonce                  *big.Int
+	Value                  *big.Int
+	Reserved               [4]*big.Int
+	Data                   []byte
+	Signature              []byte
+	FactoryDeps            [][32]byte
+	PaymasterInput         []byte
+	ReservedDynamic        []byte
+}
+
+// ExampleAuthServerPaymasterMetaData contains all meta data concerning the ExampleAuthServerPaymaster contract.
+var ExampleAuthServerPaymasterMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"aaFactoryAddress\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"sessionKeyValidatorAddress\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"accountRecoveryValidatorAddress\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"webAuthValidatorAddress\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"AA_FACTORY_CONTRACT_ADDRESS\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"ACCOUNT_RECOVERY_VALIDATOR_CONTRACT_ADDRESS\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SESSION_KEY_VALIDATOR_CONTRACT_ADDRESS\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"WEB_AUTH_VALIDATOR_CONTRACT_ADDRESS\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"_context\",\"type\":\"bytes\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[]\",\"name\":\"factoryDeps\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"reservedDynamic\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"_transaction\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"internalType\":\"enumExecutionResult\",\"name\":\"_txResult\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"_maxRefundedGas\",\"type\":\"uint256\"}],\"name\":\"postTransaction\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[]\",\"name\":\"factoryDeps\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"reservedDynamic\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"_transaction\",\"type\":\"tuple\"}],\"name\":\"validateAndPayForPaymasterTransaction\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"magic\",\"type\":\"bytes4\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"addresspayable\",\"name\":\"_to\",\"type\":\"address\"}],\"name\":\"withdraw\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"stateMutability\":\"payable\",\"type\":\"receive\"}]",
+}
+
+// ExampleAuthServerPaymasterABI is the input ABI used to generate the binding from.
+// Deprecated: Use ExampleAuthServerPaymasterMetaData.ABI instead.
+var ExampleAuthServerPaymasterABI = ExampleAuthServerPaymasterMetaData.ABI
+
+// ExampleAuthServerPaymaster is an auto generated Go binding around an Ethereum contract.
+type ExampleAuthServerPaymaster struct {
+	ExampleAuthServerPaymasterCaller     // Read-only binding to the contract
+	ExampleAuthServerPaymasterTransactor // Write-only binding to the contract
+	ExampleAuthServerPaymasterFilterer   // Log filterer for contract events
+}
+
+// ExampleAuthServerPaymasterCaller is an auto generated read-only Go binding around an Ethereum contract.
+type ExampleAuthServerPaymasterCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ExampleAuthServerPaymasterTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type ExampleAuthServerPaymasterTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ExampleAuthServerPaymasterFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type ExampleAuthServerPaymasterFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ExampleAuthServerPaymasterSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type ExampleAuthServerPaymasterSession struct {
+	Contract     *ExampleAuthServerPaymaster // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts               // Call options to use throughout this session
+	TransactOpts bind.TransactOpts           // Transaction auth options to use throughout this session
+}
+
+// ExampleAuthServerPaymasterCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type ExampleAuthServerPaymasterCallerSession struct {
+	Contract *ExampleAuthServerPaymasterCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts                     // Call options to use throughout this session
+}
+
+// ExampleAuthServerPaymasterTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type ExampleAuthServerPaymasterTransactorSession struct {
+	Contract     *ExampleAuthServerPaymasterTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts                     // Transaction auth options to use throughout this session
+}
+
+// ExampleAuthServerPaymasterRaw is an auto generated low-level Go binding around an Ethereum contract.
+type ExampleAuthServerPaymasterRaw struct {
+	Contract *ExampleAuthServerPaymaster // Generic contract binding to access the raw methods on
+}
+
+// ExampleAuthServerPaymasterCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type ExampleAuthServerPaymasterCallerRaw struct {
+	Contract *ExampleAuthServerPaymasterCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// ExampleAuthServerPaymasterTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type ExampleAuthServerPaymasterTransactorRaw struct {
+	Contract *ExampleAuthServerPaymasterTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewExampleAuthServerPaymaster creates a new instance of ExampleAuthServerPaymaster, bound to a specific deployed contract.
+func NewExampleAuthServerPaymaster(address common.Address, backend bind.ContractBackend) (*ExampleAuthServerPaymaster, error) {
+	contract, err := bindExampleAuthServerPaymaster(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &ExampleAuthServerPaymaster{ExampleAuthServerPaymasterCaller: ExampleAuthServerPaymasterCaller{contract: contract}, ExampleAuthServerPaymasterTransactor: ExampleAuthServerPaymasterTransactor{contract: contract}, ExampleAuthServerPaymasterFilterer: ExampleAuthServerPaymasterFilterer{contract: contract}}, nil
+}
+
+// NewExampleAuthServerPaymasterCaller creates a new read-only instance of ExampleAuthServerPaymaster, bound to a specific deployed contract.
+func NewExampleAuthServerPaymasterCaller(address common.Address, caller bind.ContractCaller) (*ExampleAuthServerPaymasterCaller, error) {
+	contract, err := bindExampleAuthServerPaymaster(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ExampleAuthServerPaymasterCaller{contract: contract}, nil
+}
+
+// NewExampleAuthServerPaymasterTransactor creates a new write-only instance of ExampleAuthServerPaymaster, bound to a specific deployed contract.
+func NewExampleAuthServerPaymasterTransactor(address common.Address, transactor bind.ContractTransactor) (*ExampleAuthServerPaymasterTransactor, error) {
+	contract, err := bindExampleAuthServerPaymaster(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ExampleAuthServerPaymasterTransactor{contract: contract}, nil
+}
+
+// NewExampleAuthServerPaymasterFilterer creates a new log filterer instance of ExampleAuthServerPaymaster, bound to a specific deployed contract.
+func NewExampleAuthServerPaymasterFilterer(address common.Address, filterer bind.ContractFilterer) (*ExampleAuthServerPaymasterFilterer, error) {
+	contract, err := bindExampleAuthServerPaymaster(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &ExampleAuthServerPaymasterFilterer{contract: contract}, nil
+}
+
+// bindExampleAuthServerPaymaster binds a generic wrapper to an already deployed contract.
+func bindExampleAuthServerPaymaster(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := ExampleAuthServerPaymasterMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _ExampleAuthServerPaymaster.Contract.ExampleAuthServerPaymasterCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ExampleAuthServerPaymaster.Contract.ExampleAuthServerPaymasterTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _ExampleAuthServerPaymaster.Contract.ExampleAuthServerPaymasterTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _ExampleAuthServerPaymaster.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ExampleAuthServerPaymaster.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _ExampleAuthServerPaymaster.Contract.contract.Transact(opts, method, params...)
+}
+
+// AAFACTORYCONTRACTADDRESS is a free data retrieval call binding the contract method 0x6ab2d73f.
+//
+// Solidity: function AA_FACTORY_CONTRACT_ADDRESS() view returns(address)
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterCaller) AAFACTORYCONTRACTADDRESS(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _ExampleAuthServerPaymaster.contract.Call(opts, &out, "AA_FACTORY_CONTRACT_ADDRESS")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// AAFACTORYCONTRACTADDRESS is a free data retrieval call binding the contract method 0x6ab2d73f.
+//
+// Solidity: function AA_FACTORY_CONTRACT_ADDRESS() view returns(address)
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterSession) AAFACTORYCONTRACTADDRESS() (common.Address, error) {
+	return _ExampleAuthServerPaymaster.Contract.AAFACTORYCONTRACTADDRESS(&_ExampleAuthServerPaymaster.CallOpts)
+}
+
+// AAFACTORYCONTRACTADDRESS is a free data retrieval call binding the contract method 0x6ab2d73f.
+//
+// Solidity: function AA_FACTORY_CONTRACT_ADDRESS() view returns(address)
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterCallerSession) AAFACTORYCONTRACTADDRESS() (common.Address, error) {
+	return _ExampleAuthServerPaymaster.Contract.AAFACTORYCONTRACTADDRESS(&_ExampleAuthServerPaymaster.CallOpts)
+}
+
+// ACCOUNTRECOVERYVALIDATORCONTRACTADDRESS is a free data retrieval call binding the contract method 0xb45c72e4.
+//
+// Solidity: function ACCOUNT_RECOVERY_VALIDATOR_CONTRACT_ADDRESS() view returns(address)
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterCaller) ACCOUNTRECOVERYVALIDATORCONTRACTADDRESS(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _ExampleAuthServerPaymaster.contract.Call(opts, &out, "ACCOUNT_RECOVERY_VALIDATOR_CONTRACT_ADDRESS")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// ACCOUNTRECOVERYVALIDATORCONTRACTADDRESS is a free data retrieval call binding the contract method 0xb45c72e4.
+//
+// Solidity: function ACCOUNT_RECOVERY_VALIDATOR_CONTRACT_ADDRESS() view returns(address)
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterSession) ACCOUNTRECOVERYVALIDATORCONTRACTADDRESS() (common.Address, error) {
+	return _ExampleAuthServerPaymaster.Contract.ACCOUNTRECOVERYVALIDATORCONTRACTADDRESS(&_ExampleAuthServerPaymaster.CallOpts)
+}
+
+// ACCOUNTRECOVERYVALIDATORCONTRACTADDRESS is a free data retrieval call binding the contract method 0xb45c72e4.
+//
+// Solidity: function ACCOUNT_RECOVERY_VALIDATOR_CONTRACT_ADDRESS() view returns(address)
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterCallerSession) ACCOUNTRECOVERYVALIDATORCONTRACTADDRESS() (common.Address, error) {
+	return _ExampleAuthServerPaymaster.Contract.ACCOUNTRECOVERYVALIDATORCONTRACTADDRESS(&_ExampleAuthServerPaymaster.CallOpts)
+}
+
+// SESSIONKEYVALIDATORCONTRACTADDRESS is a free data retrieval call binding the contract method 0x10677c76.
+//
+// Solidity: function SESSION_KEY_VALIDATOR_CONTRACT_ADDRESS() view returns(address)
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterCaller) SESSIONKEYVALIDATORCONTRACTADDRESS(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _ExampleAuthServerPaymaster.contract.Call(opts, &out, "SESSION_KEY_VALIDATOR_CONTRACT_ADDRESS")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// SESSIONKEYVALIDATORCONTRACTADDRESS is a free data retrieval call binding the contract method 0x10677c76.
+//
+// Solidity: function SESSION_KEY_VALIDATOR_CONTRACT_ADDRESS() view returns(address)
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterSession) SESSIONKEYVALIDATORCONTRACTADDRESS() (common.Address, error) {
+	return _ExampleAuthServerPaymaster.Contract.SESSIONKEYVALIDATORCONTRACTADDRESS(&_ExampleAuthServerPaymaster.CallOpts)
+}
+
+// SESSIONKEYVALIDATORCONTRACTADDRESS is a free data retrieval call binding the contract method 0x10677c76.
+//
+// Solidity: function SESSION_KEY_VALIDATOR_CONTRACT_ADDRESS() view returns(address)
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterCallerSession) SESSIONKEYVALIDATORCONTRACTADDRESS() (common.Address, error) {
+	return _ExampleAuthServerPaymaster.Contract.SESSIONKEYVALIDATORCONTRACTADDRESS(&_ExampleAuthServerPaymaster.CallOpts)
+}
+
+// WEBAUTHVALIDATORCONTRACTADDRESS is a free data retrieval call binding the contract method 0x8875a5da.
+//
+// Solidity: function WEB_AUTH_VALIDATOR_CONTRACT_ADDRESS() view returns(address)
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterCaller) WEBAUTHVALIDATORCONTRACTADDRESS(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _ExampleAuthServerPaymaster.contract.Call(opts, &out, "WEB_AUTH_VALIDATOR_CONTRACT_ADDRESS")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// WEBAUTHVALIDATORCONTRACTADDRESS is a free data retrieval call binding the contract method 0x8875a5da.
+//
+// Solidity: function WEB_AUTH_VALIDATOR_CONTRACT_ADDRESS() view returns(address)
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterSession) WEBAUTHVALIDATORCONTRACTADDRESS() (common.Address, error) {
+	return _ExampleAuthServerPaymaster.Contract.WEBAUTHVALIDATORCONTRACTADDRESS(&_ExampleAuthServerPaymaster.CallOpts)
+}
+
+// WEBAUTHVALIDATORCONTRACTADDRESS is a free data retrieval call binding the contract method 0x8875a5da.
+//
+// Solidity: function WEB_AUTH_VALIDATOR_CONTRACT_ADDRESS() view returns(address)
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterCallerSession) WEBAUTHVALIDATORCONTRACTADDRESS() (common.Address, error) {
+	return _ExampleAuthServerPaymaster.Contract.WEBAUTHVALIDATORCONTRACTADDRESS(&_ExampleAuthServerPaymaster.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _ExampleAuthServerPaymaster.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterSession) Owner() (common.Address, error) {
+	return _ExampleAuthServerPaymaster.Contract.Owner(&_ExampleAuthServerPaymaster.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterCallerSession) Owner() (common.Address, error) {
+	return _ExampleAuthServerPaymaster.Contract.Owner(&_ExampleAuthServerPaymaster.CallOpts)
+}
+
+// PostTransaction is a paid mutator transaction binding the contract method 0x817b17f0.
+//
+// Solidity: function postTransaction(bytes _context, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction, bytes32 , bytes32 , uint8 _txResult, uint256 _maxRefundedGas) payable returns()
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterTransactor) PostTransaction(opts *bind.TransactOpts, _context []byte, _transaction Transaction, arg2 [32]byte, arg3 [32]byte, _txResult uint8, _maxRefundedGas *big.Int) (*types.Transaction, error) {
+	return _ExampleAuthServerPaymaster.contract.Transact(opts, "postTransaction", _context, _transaction, arg2, arg3, _txResult, _maxRefundedGas)
+}
+
+// PostTransaction is a paid mutator transaction binding the contract method 0x817b17f0.
+//
+// Solidity: function postTransaction(bytes _context, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction, bytes32 , bytes32 , uint8 _txResult, uint256 _maxRefundedGas) payable returns()
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterSession) PostTransaction(_context []byte, _transaction Transaction, arg2 [32]byte, arg3 [32]byte, _txResult uint8, _maxRefundedGas *big.Int) (*types.Transaction, error) {
+	return _ExampleAuthServerPaymaster.Contract.PostTransaction(&_ExampleAuthServerPaymaster.TransactOpts, _context, _transaction, arg2, arg3, _txResult, _maxRefundedGas)
+}
+
+// PostTransaction is a paid mutator transaction binding the contract method 0x817b17f0.
+//
+// Solidity: function postTransaction(bytes _context, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction, bytes32 , bytes32 , uint8 _txResult, uint256 _maxRefundedGas) payable returns()
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterTransactorSession) PostTransaction(_context []byte, _transaction Transaction, arg2 [32]byte, arg3 [32]byte, _txResult uint8, _maxRefundedGas *big.Int) (*types.Transaction, error) {
+	return _ExampleAuthServerPaymaster.Contract.PostTransaction(&_ExampleAuthServerPaymaster.TransactOpts, _context, _transaction, arg2, arg3, _txResult, _maxRefundedGas)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ExampleAuthServerPaymaster.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterSession) RenounceOwnership() (*types.Transaction, error) {
+	return _ExampleAuthServerPaymaster.Contract.RenounceOwnership(&_ExampleAuthServerPaymaster.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _ExampleAuthServerPaymaster.Contract.RenounceOwnership(&_ExampleAuthServerPaymaster.TransactOpts)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _ExampleAuthServerPaymaster.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _ExampleAuthServerPaymaster.Contract.TransferOwnership(&_ExampleAuthServerPaymaster.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _ExampleAuthServerPaymaster.Contract.TransferOwnership(&_ExampleAuthServerPaymaster.TransactOpts, newOwner)
+}
+
+// ValidateAndPayForPaymasterTransaction is a paid mutator transaction binding the contract method 0x038a24bc.
+//
+// Solidity: function validateAndPayForPaymasterTransaction(bytes32 , bytes32 , (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns(bytes4 magic, bytes)
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterTransactor) ValidateAndPayForPaymasterTransaction(opts *bind.TransactOpts, arg0 [32]byte, arg1 [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _ExampleAuthServerPaymaster.contract.Transact(opts, "validateAndPayForPaymasterTransaction", arg0, arg1, _transaction)
+}
+
+// ValidateAndPayForPaymasterTransaction is a paid mutator transaction binding the contract method 0x038a24bc.
+//
+// Solidity: function validateAndPayForPaymasterTransaction(bytes32 , bytes32 , (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns(bytes4 magic, bytes)
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterSession) ValidateAndPayForPaymasterTransaction(arg0 [32]byte, arg1 [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _ExampleAuthServerPaymaster.Contract.ValidateAndPayForPaymasterTransaction(&_ExampleAuthServerPaymaster.TransactOpts, arg0, arg1, _transaction)
+}
+
+// ValidateAndPayForPaymasterTransaction is a paid mutator transaction binding the contract method 0x038a24bc.
+//
+// Solidity: function validateAndPayForPaymasterTransaction(bytes32 , bytes32 , (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) _transaction) payable returns(bytes4 magic, bytes)
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterTransactorSession) ValidateAndPayForPaymasterTransaction(arg0 [32]byte, arg1 [32]byte, _transaction Transaction) (*types.Transaction, error) {
+	return _ExampleAuthServerPaymaster.Contract.ValidateAndPayForPaymasterTransaction(&_ExampleAuthServerPaymaster.TransactOpts, arg0, arg1, _transaction)
+}
+
+// Withdraw is a paid mutator transaction binding the contract method 0x51cff8d9.
+//
+// Solidity: function withdraw(address _to) returns()
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterTransactor) Withdraw(opts *bind.TransactOpts, _to common.Address) (*types.Transaction, error) {
+	return _ExampleAuthServerPaymaster.contract.Transact(opts, "withdraw", _to)
+}
+
+// Withdraw is a paid mutator transaction binding the contract method 0x51cff8d9.
+//
+// Solidity: function withdraw(address _to) returns()
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterSession) Withdraw(_to common.Address) (*types.Transaction, error) {
+	return _ExampleAuthServerPaymaster.Contract.Withdraw(&_ExampleAuthServerPaymaster.TransactOpts, _to)
+}
+
+// Withdraw is a paid mutator transaction binding the contract method 0x51cff8d9.
+//
+// Solidity: function withdraw(address _to) returns()
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterTransactorSession) Withdraw(_to common.Address) (*types.Transaction, error) {
+	return _ExampleAuthServerPaymaster.Contract.Withdraw(&_ExampleAuthServerPaymaster.TransactOpts, _to)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterTransactor) Receive(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ExampleAuthServerPaymaster.contract.RawTransact(opts, nil) // calldata is disallowed for receive function
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterSession) Receive() (*types.Transaction, error) {
+	return _ExampleAuthServerPaymaster.Contract.Receive(&_ExampleAuthServerPaymaster.TransactOpts)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterTransactorSession) Receive() (*types.Transaction, error) {
+	return _ExampleAuthServerPaymaster.Contract.Receive(&_ExampleAuthServerPaymaster.TransactOpts)
+}
+
+// ExampleAuthServerPaymasterOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the ExampleAuthServerPaymaster contract.
+type ExampleAuthServerPaymasterOwnershipTransferredIterator struct {
+	Event *ExampleAuthServerPaymasterOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ExampleAuthServerPaymasterOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ExampleAuthServerPaymasterOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ExampleAuthServerPaymasterOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ExampleAuthServerPaymasterOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ExampleAuthServerPaymasterOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ExampleAuthServerPaymasterOwnershipTransferred represents a OwnershipTransferred event raised by the ExampleAuthServerPaymaster contract.
+type ExampleAuthServerPaymasterOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*ExampleAuthServerPaymasterOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _ExampleAuthServerPaymaster.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ExampleAuthServerPaymasterOwnershipTransferredIterator{contract: _ExampleAuthServerPaymaster.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *ExampleAuthServerPaymasterOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _ExampleAuthServerPaymaster.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ExampleAuthServerPaymasterOwnershipTransferred)
+				if err := _ExampleAuthServerPaymaster.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_ExampleAuthServerPaymaster *ExampleAuthServerPaymasterFilterer) ParseOwnershipTransferred(log types.Log) (*ExampleAuthServerPaymasterOwnershipTransferred, error) {
+	event := new(ExampleAuthServerPaymasterOwnershipTransferred)
+	if err := _ExampleAuthServerPaymaster.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts/zksyncsso/test/jsonparserlibtest/jsonparserlibtest.go
+++ b/contracts/zksyncsso/test/jsonparserlibtest/jsonparserlibtest.go
@@ -1,0 +1,217 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package jsonparserlibtest
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// JSONParserLibItem is an auto generated low-level Go binding around an user-defined struct.
+type JSONParserLibItem struct {
+	Data *big.Int
+}
+
+// JSONParserLibTestMetaData contains all meta data concerning the JSONParserLibTest contract.
+var JSONParserLibTestMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"json\",\"type\":\"string\"}],\"name\":\"parse\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"_data\",\"type\":\"uint256\"}],\"internalType\":\"structJSONParserLib.Item\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"pure\",\"type\":\"function\"}]",
+}
+
+// JSONParserLibTestABI is the input ABI used to generate the binding from.
+// Deprecated: Use JSONParserLibTestMetaData.ABI instead.
+var JSONParserLibTestABI = JSONParserLibTestMetaData.ABI
+
+// JSONParserLibTest is an auto generated Go binding around an Ethereum contract.
+type JSONParserLibTest struct {
+	JSONParserLibTestCaller     // Read-only binding to the contract
+	JSONParserLibTestTransactor // Write-only binding to the contract
+	JSONParserLibTestFilterer   // Log filterer for contract events
+}
+
+// JSONParserLibTestCaller is an auto generated read-only Go binding around an Ethereum contract.
+type JSONParserLibTestCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// JSONParserLibTestTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type JSONParserLibTestTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// JSONParserLibTestFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type JSONParserLibTestFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// JSONParserLibTestSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type JSONParserLibTestSession struct {
+	Contract     *JSONParserLibTest // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts      // Call options to use throughout this session
+	TransactOpts bind.TransactOpts  // Transaction auth options to use throughout this session
+}
+
+// JSONParserLibTestCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type JSONParserLibTestCallerSession struct {
+	Contract *JSONParserLibTestCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts            // Call options to use throughout this session
+}
+
+// JSONParserLibTestTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type JSONParserLibTestTransactorSession struct {
+	Contract     *JSONParserLibTestTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts            // Transaction auth options to use throughout this session
+}
+
+// JSONParserLibTestRaw is an auto generated low-level Go binding around an Ethereum contract.
+type JSONParserLibTestRaw struct {
+	Contract *JSONParserLibTest // Generic contract binding to access the raw methods on
+}
+
+// JSONParserLibTestCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type JSONParserLibTestCallerRaw struct {
+	Contract *JSONParserLibTestCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// JSONParserLibTestTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type JSONParserLibTestTransactorRaw struct {
+	Contract *JSONParserLibTestTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewJSONParserLibTest creates a new instance of JSONParserLibTest, bound to a specific deployed contract.
+func NewJSONParserLibTest(address common.Address, backend bind.ContractBackend) (*JSONParserLibTest, error) {
+	contract, err := bindJSONParserLibTest(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &JSONParserLibTest{JSONParserLibTestCaller: JSONParserLibTestCaller{contract: contract}, JSONParserLibTestTransactor: JSONParserLibTestTransactor{contract: contract}, JSONParserLibTestFilterer: JSONParserLibTestFilterer{contract: contract}}, nil
+}
+
+// NewJSONParserLibTestCaller creates a new read-only instance of JSONParserLibTest, bound to a specific deployed contract.
+func NewJSONParserLibTestCaller(address common.Address, caller bind.ContractCaller) (*JSONParserLibTestCaller, error) {
+	contract, err := bindJSONParserLibTest(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &JSONParserLibTestCaller{contract: contract}, nil
+}
+
+// NewJSONParserLibTestTransactor creates a new write-only instance of JSONParserLibTest, bound to a specific deployed contract.
+func NewJSONParserLibTestTransactor(address common.Address, transactor bind.ContractTransactor) (*JSONParserLibTestTransactor, error) {
+	contract, err := bindJSONParserLibTest(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &JSONParserLibTestTransactor{contract: contract}, nil
+}
+
+// NewJSONParserLibTestFilterer creates a new log filterer instance of JSONParserLibTest, bound to a specific deployed contract.
+func NewJSONParserLibTestFilterer(address common.Address, filterer bind.ContractFilterer) (*JSONParserLibTestFilterer, error) {
+	contract, err := bindJSONParserLibTest(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &JSONParserLibTestFilterer{contract: contract}, nil
+}
+
+// bindJSONParserLibTest binds a generic wrapper to an already deployed contract.
+func bindJSONParserLibTest(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := JSONParserLibTestMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_JSONParserLibTest *JSONParserLibTestRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _JSONParserLibTest.Contract.JSONParserLibTestCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_JSONParserLibTest *JSONParserLibTestRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _JSONParserLibTest.Contract.JSONParserLibTestTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_JSONParserLibTest *JSONParserLibTestRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _JSONParserLibTest.Contract.JSONParserLibTestTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_JSONParserLibTest *JSONParserLibTestCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _JSONParserLibTest.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_JSONParserLibTest *JSONParserLibTestTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _JSONParserLibTest.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_JSONParserLibTest *JSONParserLibTestTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _JSONParserLibTest.Contract.contract.Transact(opts, method, params...)
+}
+
+// Parse is a free data retrieval call binding the contract method 0xbc62d8d8.
+//
+// Solidity: function parse(string json) pure returns((uint256))
+func (_JSONParserLibTest *JSONParserLibTestCaller) Parse(opts *bind.CallOpts, json string) (JSONParserLibItem, error) {
+	var out []interface{}
+	err := _JSONParserLibTest.contract.Call(opts, &out, "parse", json)
+
+	if err != nil {
+		return *new(JSONParserLibItem), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(JSONParserLibItem)).(*JSONParserLibItem)
+
+	return out0, err
+
+}
+
+// Parse is a free data retrieval call binding the contract method 0xbc62d8d8.
+//
+// Solidity: function parse(string json) pure returns((uint256))
+func (_JSONParserLibTest *JSONParserLibTestSession) Parse(json string) (JSONParserLibItem, error) {
+	return _JSONParserLibTest.Contract.Parse(&_JSONParserLibTest.CallOpts, json)
+}
+
+// Parse is a free data retrieval call binding the contract method 0xbc62d8d8.
+//
+// Solidity: function parse(string json) pure returns((uint256))
+func (_JSONParserLibTest *JSONParserLibTestCallerSession) Parse(json string) (JSONParserLibItem, error) {
+	return _JSONParserLibTest.Contract.Parse(&_JSONParserLibTest.CallOpts, json)
+}

--- a/contracts/zksyncsso/test/testerc20/testerc20.go
+++ b/contracts/zksyncsso/test/testerc20/testerc20.go
@@ -1,0 +1,780 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package testerc20
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// TestERC20MetaData contains all meta data concerning the TestERC20 contract.
+var TestERC20MetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"mintTo\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Approval\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Transfer\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"allowance\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"approve\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"balanceOf\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"subtractedValue\",\"type\":\"uint256\"}],\"name\":\"decreaseAllowance\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"addedValue\",\"type\":\"uint256\"}],\"name\":\"increaseAllowance\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"name\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"symbol\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"totalSupply\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"transfer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"transferFrom\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+}
+
+// TestERC20ABI is the input ABI used to generate the binding from.
+// Deprecated: Use TestERC20MetaData.ABI instead.
+var TestERC20ABI = TestERC20MetaData.ABI
+
+// TestERC20 is an auto generated Go binding around an Ethereum contract.
+type TestERC20 struct {
+	TestERC20Caller     // Read-only binding to the contract
+	TestERC20Transactor // Write-only binding to the contract
+	TestERC20Filterer   // Log filterer for contract events
+}
+
+// TestERC20Caller is an auto generated read-only Go binding around an Ethereum contract.
+type TestERC20Caller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TestERC20Transactor is an auto generated write-only Go binding around an Ethereum contract.
+type TestERC20Transactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TestERC20Filterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type TestERC20Filterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TestERC20Session is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type TestERC20Session struct {
+	Contract     *TestERC20        // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// TestERC20CallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type TestERC20CallerSession struct {
+	Contract *TestERC20Caller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts    // Call options to use throughout this session
+}
+
+// TestERC20TransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type TestERC20TransactorSession struct {
+	Contract     *TestERC20Transactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts    // Transaction auth options to use throughout this session
+}
+
+// TestERC20Raw is an auto generated low-level Go binding around an Ethereum contract.
+type TestERC20Raw struct {
+	Contract *TestERC20 // Generic contract binding to access the raw methods on
+}
+
+// TestERC20CallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type TestERC20CallerRaw struct {
+	Contract *TestERC20Caller // Generic read-only contract binding to access the raw methods on
+}
+
+// TestERC20TransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type TestERC20TransactorRaw struct {
+	Contract *TestERC20Transactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewTestERC20 creates a new instance of TestERC20, bound to a specific deployed contract.
+func NewTestERC20(address common.Address, backend bind.ContractBackend) (*TestERC20, error) {
+	contract, err := bindTestERC20(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &TestERC20{TestERC20Caller: TestERC20Caller{contract: contract}, TestERC20Transactor: TestERC20Transactor{contract: contract}, TestERC20Filterer: TestERC20Filterer{contract: contract}}, nil
+}
+
+// NewTestERC20Caller creates a new read-only instance of TestERC20, bound to a specific deployed contract.
+func NewTestERC20Caller(address common.Address, caller bind.ContractCaller) (*TestERC20Caller, error) {
+	contract, err := bindTestERC20(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &TestERC20Caller{contract: contract}, nil
+}
+
+// NewTestERC20Transactor creates a new write-only instance of TestERC20, bound to a specific deployed contract.
+func NewTestERC20Transactor(address common.Address, transactor bind.ContractTransactor) (*TestERC20Transactor, error) {
+	contract, err := bindTestERC20(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &TestERC20Transactor{contract: contract}, nil
+}
+
+// NewTestERC20Filterer creates a new log filterer instance of TestERC20, bound to a specific deployed contract.
+func NewTestERC20Filterer(address common.Address, filterer bind.ContractFilterer) (*TestERC20Filterer, error) {
+	contract, err := bindTestERC20(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &TestERC20Filterer{contract: contract}, nil
+}
+
+// bindTestERC20 binds a generic wrapper to an already deployed contract.
+func bindTestERC20(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := TestERC20MetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_TestERC20 *TestERC20Raw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _TestERC20.Contract.TestERC20Caller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_TestERC20 *TestERC20Raw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _TestERC20.Contract.TestERC20Transactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_TestERC20 *TestERC20Raw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _TestERC20.Contract.TestERC20Transactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_TestERC20 *TestERC20CallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _TestERC20.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_TestERC20 *TestERC20TransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _TestERC20.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_TestERC20 *TestERC20TransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _TestERC20.Contract.contract.Transact(opts, method, params...)
+}
+
+// Allowance is a free data retrieval call binding the contract method 0xdd62ed3e.
+//
+// Solidity: function allowance(address owner, address spender) view returns(uint256)
+func (_TestERC20 *TestERC20Caller) Allowance(opts *bind.CallOpts, owner common.Address, spender common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _TestERC20.contract.Call(opts, &out, "allowance", owner, spender)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Allowance is a free data retrieval call binding the contract method 0xdd62ed3e.
+//
+// Solidity: function allowance(address owner, address spender) view returns(uint256)
+func (_TestERC20 *TestERC20Session) Allowance(owner common.Address, spender common.Address) (*big.Int, error) {
+	return _TestERC20.Contract.Allowance(&_TestERC20.CallOpts, owner, spender)
+}
+
+// Allowance is a free data retrieval call binding the contract method 0xdd62ed3e.
+//
+// Solidity: function allowance(address owner, address spender) view returns(uint256)
+func (_TestERC20 *TestERC20CallerSession) Allowance(owner common.Address, spender common.Address) (*big.Int, error) {
+	return _TestERC20.Contract.Allowance(&_TestERC20.CallOpts, owner, spender)
+}
+
+// BalanceOf is a free data retrieval call binding the contract method 0x70a08231.
+//
+// Solidity: function balanceOf(address account) view returns(uint256)
+func (_TestERC20 *TestERC20Caller) BalanceOf(opts *bind.CallOpts, account common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _TestERC20.contract.Call(opts, &out, "balanceOf", account)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// BalanceOf is a free data retrieval call binding the contract method 0x70a08231.
+//
+// Solidity: function balanceOf(address account) view returns(uint256)
+func (_TestERC20 *TestERC20Session) BalanceOf(account common.Address) (*big.Int, error) {
+	return _TestERC20.Contract.BalanceOf(&_TestERC20.CallOpts, account)
+}
+
+// BalanceOf is a free data retrieval call binding the contract method 0x70a08231.
+//
+// Solidity: function balanceOf(address account) view returns(uint256)
+func (_TestERC20 *TestERC20CallerSession) BalanceOf(account common.Address) (*big.Int, error) {
+	return _TestERC20.Contract.BalanceOf(&_TestERC20.CallOpts, account)
+}
+
+// Decimals is a free data retrieval call binding the contract method 0x313ce567.
+//
+// Solidity: function decimals() view returns(uint8)
+func (_TestERC20 *TestERC20Caller) Decimals(opts *bind.CallOpts) (uint8, error) {
+	var out []interface{}
+	err := _TestERC20.contract.Call(opts, &out, "decimals")
+
+	if err != nil {
+		return *new(uint8), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint8)).(*uint8)
+
+	return out0, err
+
+}
+
+// Decimals is a free data retrieval call binding the contract method 0x313ce567.
+//
+// Solidity: function decimals() view returns(uint8)
+func (_TestERC20 *TestERC20Session) Decimals() (uint8, error) {
+	return _TestERC20.Contract.Decimals(&_TestERC20.CallOpts)
+}
+
+// Decimals is a free data retrieval call binding the contract method 0x313ce567.
+//
+// Solidity: function decimals() view returns(uint8)
+func (_TestERC20 *TestERC20CallerSession) Decimals() (uint8, error) {
+	return _TestERC20.Contract.Decimals(&_TestERC20.CallOpts)
+}
+
+// Name is a free data retrieval call binding the contract method 0x06fdde03.
+//
+// Solidity: function name() view returns(string)
+func (_TestERC20 *TestERC20Caller) Name(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _TestERC20.contract.Call(opts, &out, "name")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// Name is a free data retrieval call binding the contract method 0x06fdde03.
+//
+// Solidity: function name() view returns(string)
+func (_TestERC20 *TestERC20Session) Name() (string, error) {
+	return _TestERC20.Contract.Name(&_TestERC20.CallOpts)
+}
+
+// Name is a free data retrieval call binding the contract method 0x06fdde03.
+//
+// Solidity: function name() view returns(string)
+func (_TestERC20 *TestERC20CallerSession) Name() (string, error) {
+	return _TestERC20.Contract.Name(&_TestERC20.CallOpts)
+}
+
+// Symbol is a free data retrieval call binding the contract method 0x95d89b41.
+//
+// Solidity: function symbol() view returns(string)
+func (_TestERC20 *TestERC20Caller) Symbol(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _TestERC20.contract.Call(opts, &out, "symbol")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// Symbol is a free data retrieval call binding the contract method 0x95d89b41.
+//
+// Solidity: function symbol() view returns(string)
+func (_TestERC20 *TestERC20Session) Symbol() (string, error) {
+	return _TestERC20.Contract.Symbol(&_TestERC20.CallOpts)
+}
+
+// Symbol is a free data retrieval call binding the contract method 0x95d89b41.
+//
+// Solidity: function symbol() view returns(string)
+func (_TestERC20 *TestERC20CallerSession) Symbol() (string, error) {
+	return _TestERC20.Contract.Symbol(&_TestERC20.CallOpts)
+}
+
+// TotalSupply is a free data retrieval call binding the contract method 0x18160ddd.
+//
+// Solidity: function totalSupply() view returns(uint256)
+func (_TestERC20 *TestERC20Caller) TotalSupply(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _TestERC20.contract.Call(opts, &out, "totalSupply")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// TotalSupply is a free data retrieval call binding the contract method 0x18160ddd.
+//
+// Solidity: function totalSupply() view returns(uint256)
+func (_TestERC20 *TestERC20Session) TotalSupply() (*big.Int, error) {
+	return _TestERC20.Contract.TotalSupply(&_TestERC20.CallOpts)
+}
+
+// TotalSupply is a free data retrieval call binding the contract method 0x18160ddd.
+//
+// Solidity: function totalSupply() view returns(uint256)
+func (_TestERC20 *TestERC20CallerSession) TotalSupply() (*big.Int, error) {
+	return _TestERC20.Contract.TotalSupply(&_TestERC20.CallOpts)
+}
+
+// Approve is a paid mutator transaction binding the contract method 0x095ea7b3.
+//
+// Solidity: function approve(address spender, uint256 amount) returns(bool)
+func (_TestERC20 *TestERC20Transactor) Approve(opts *bind.TransactOpts, spender common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _TestERC20.contract.Transact(opts, "approve", spender, amount)
+}
+
+// Approve is a paid mutator transaction binding the contract method 0x095ea7b3.
+//
+// Solidity: function approve(address spender, uint256 amount) returns(bool)
+func (_TestERC20 *TestERC20Session) Approve(spender common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _TestERC20.Contract.Approve(&_TestERC20.TransactOpts, spender, amount)
+}
+
+// Approve is a paid mutator transaction binding the contract method 0x095ea7b3.
+//
+// Solidity: function approve(address spender, uint256 amount) returns(bool)
+func (_TestERC20 *TestERC20TransactorSession) Approve(spender common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _TestERC20.Contract.Approve(&_TestERC20.TransactOpts, spender, amount)
+}
+
+// DecreaseAllowance is a paid mutator transaction binding the contract method 0xa457c2d7.
+//
+// Solidity: function decreaseAllowance(address spender, uint256 subtractedValue) returns(bool)
+func (_TestERC20 *TestERC20Transactor) DecreaseAllowance(opts *bind.TransactOpts, spender common.Address, subtractedValue *big.Int) (*types.Transaction, error) {
+	return _TestERC20.contract.Transact(opts, "decreaseAllowance", spender, subtractedValue)
+}
+
+// DecreaseAllowance is a paid mutator transaction binding the contract method 0xa457c2d7.
+//
+// Solidity: function decreaseAllowance(address spender, uint256 subtractedValue) returns(bool)
+func (_TestERC20 *TestERC20Session) DecreaseAllowance(spender common.Address, subtractedValue *big.Int) (*types.Transaction, error) {
+	return _TestERC20.Contract.DecreaseAllowance(&_TestERC20.TransactOpts, spender, subtractedValue)
+}
+
+// DecreaseAllowance is a paid mutator transaction binding the contract method 0xa457c2d7.
+//
+// Solidity: function decreaseAllowance(address spender, uint256 subtractedValue) returns(bool)
+func (_TestERC20 *TestERC20TransactorSession) DecreaseAllowance(spender common.Address, subtractedValue *big.Int) (*types.Transaction, error) {
+	return _TestERC20.Contract.DecreaseAllowance(&_TestERC20.TransactOpts, spender, subtractedValue)
+}
+
+// IncreaseAllowance is a paid mutator transaction binding the contract method 0x39509351.
+//
+// Solidity: function increaseAllowance(address spender, uint256 addedValue) returns(bool)
+func (_TestERC20 *TestERC20Transactor) IncreaseAllowance(opts *bind.TransactOpts, spender common.Address, addedValue *big.Int) (*types.Transaction, error) {
+	return _TestERC20.contract.Transact(opts, "increaseAllowance", spender, addedValue)
+}
+
+// IncreaseAllowance is a paid mutator transaction binding the contract method 0x39509351.
+//
+// Solidity: function increaseAllowance(address spender, uint256 addedValue) returns(bool)
+func (_TestERC20 *TestERC20Session) IncreaseAllowance(spender common.Address, addedValue *big.Int) (*types.Transaction, error) {
+	return _TestERC20.Contract.IncreaseAllowance(&_TestERC20.TransactOpts, spender, addedValue)
+}
+
+// IncreaseAllowance is a paid mutator transaction binding the contract method 0x39509351.
+//
+// Solidity: function increaseAllowance(address spender, uint256 addedValue) returns(bool)
+func (_TestERC20 *TestERC20TransactorSession) IncreaseAllowance(spender common.Address, addedValue *big.Int) (*types.Transaction, error) {
+	return _TestERC20.Contract.IncreaseAllowance(&_TestERC20.TransactOpts, spender, addedValue)
+}
+
+// Transfer is a paid mutator transaction binding the contract method 0xa9059cbb.
+//
+// Solidity: function transfer(address to, uint256 amount) returns(bool)
+func (_TestERC20 *TestERC20Transactor) Transfer(opts *bind.TransactOpts, to common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _TestERC20.contract.Transact(opts, "transfer", to, amount)
+}
+
+// Transfer is a paid mutator transaction binding the contract method 0xa9059cbb.
+//
+// Solidity: function transfer(address to, uint256 amount) returns(bool)
+func (_TestERC20 *TestERC20Session) Transfer(to common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _TestERC20.Contract.Transfer(&_TestERC20.TransactOpts, to, amount)
+}
+
+// Transfer is a paid mutator transaction binding the contract method 0xa9059cbb.
+//
+// Solidity: function transfer(address to, uint256 amount) returns(bool)
+func (_TestERC20 *TestERC20TransactorSession) Transfer(to common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _TestERC20.Contract.Transfer(&_TestERC20.TransactOpts, to, amount)
+}
+
+// TransferFrom is a paid mutator transaction binding the contract method 0x23b872dd.
+//
+// Solidity: function transferFrom(address from, address to, uint256 amount) returns(bool)
+func (_TestERC20 *TestERC20Transactor) TransferFrom(opts *bind.TransactOpts, from common.Address, to common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _TestERC20.contract.Transact(opts, "transferFrom", from, to, amount)
+}
+
+// TransferFrom is a paid mutator transaction binding the contract method 0x23b872dd.
+//
+// Solidity: function transferFrom(address from, address to, uint256 amount) returns(bool)
+func (_TestERC20 *TestERC20Session) TransferFrom(from common.Address, to common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _TestERC20.Contract.TransferFrom(&_TestERC20.TransactOpts, from, to, amount)
+}
+
+// TransferFrom is a paid mutator transaction binding the contract method 0x23b872dd.
+//
+// Solidity: function transferFrom(address from, address to, uint256 amount) returns(bool)
+func (_TestERC20 *TestERC20TransactorSession) TransferFrom(from common.Address, to common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _TestERC20.Contract.TransferFrom(&_TestERC20.TransactOpts, from, to, amount)
+}
+
+// TestERC20ApprovalIterator is returned from FilterApproval and is used to iterate over the raw logs and unpacked data for Approval events raised by the TestERC20 contract.
+type TestERC20ApprovalIterator struct {
+	Event *TestERC20Approval // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TestERC20ApprovalIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TestERC20Approval)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TestERC20Approval)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TestERC20ApprovalIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TestERC20ApprovalIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TestERC20Approval represents a Approval event raised by the TestERC20 contract.
+type TestERC20Approval struct {
+	Owner   common.Address
+	Spender common.Address
+	Value   *big.Int
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterApproval is a free log retrieval operation binding the contract event 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925.
+//
+// Solidity: event Approval(address indexed owner, address indexed spender, uint256 value)
+func (_TestERC20 *TestERC20Filterer) FilterApproval(opts *bind.FilterOpts, owner []common.Address, spender []common.Address) (*TestERC20ApprovalIterator, error) {
+
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+	var spenderRule []interface{}
+	for _, spenderItem := range spender {
+		spenderRule = append(spenderRule, spenderItem)
+	}
+
+	logs, sub, err := _TestERC20.contract.FilterLogs(opts, "Approval", ownerRule, spenderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &TestERC20ApprovalIterator{contract: _TestERC20.contract, event: "Approval", logs: logs, sub: sub}, nil
+}
+
+// WatchApproval is a free log subscription operation binding the contract event 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925.
+//
+// Solidity: event Approval(address indexed owner, address indexed spender, uint256 value)
+func (_TestERC20 *TestERC20Filterer) WatchApproval(opts *bind.WatchOpts, sink chan<- *TestERC20Approval, owner []common.Address, spender []common.Address) (event.Subscription, error) {
+
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+	var spenderRule []interface{}
+	for _, spenderItem := range spender {
+		spenderRule = append(spenderRule, spenderItem)
+	}
+
+	logs, sub, err := _TestERC20.contract.WatchLogs(opts, "Approval", ownerRule, spenderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TestERC20Approval)
+				if err := _TestERC20.contract.UnpackLog(event, "Approval", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseApproval is a log parse operation binding the contract event 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925.
+//
+// Solidity: event Approval(address indexed owner, address indexed spender, uint256 value)
+func (_TestERC20 *TestERC20Filterer) ParseApproval(log types.Log) (*TestERC20Approval, error) {
+	event := new(TestERC20Approval)
+	if err := _TestERC20.contract.UnpackLog(event, "Approval", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// TestERC20TransferIterator is returned from FilterTransfer and is used to iterate over the raw logs and unpacked data for Transfer events raised by the TestERC20 contract.
+type TestERC20TransferIterator struct {
+	Event *TestERC20Transfer // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TestERC20TransferIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TestERC20Transfer)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TestERC20Transfer)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TestERC20TransferIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TestERC20TransferIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TestERC20Transfer represents a Transfer event raised by the TestERC20 contract.
+type TestERC20Transfer struct {
+	From  common.Address
+	To    common.Address
+	Value *big.Int
+	Raw   types.Log // Blockchain specific contextual infos
+}
+
+// FilterTransfer is a free log retrieval operation binding the contract event 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef.
+//
+// Solidity: event Transfer(address indexed from, address indexed to, uint256 value)
+func (_TestERC20 *TestERC20Filterer) FilterTransfer(opts *bind.FilterOpts, from []common.Address, to []common.Address) (*TestERC20TransferIterator, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _TestERC20.contract.FilterLogs(opts, "Transfer", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return &TestERC20TransferIterator{contract: _TestERC20.contract, event: "Transfer", logs: logs, sub: sub}, nil
+}
+
+// WatchTransfer is a free log subscription operation binding the contract event 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef.
+//
+// Solidity: event Transfer(address indexed from, address indexed to, uint256 value)
+func (_TestERC20 *TestERC20Filterer) WatchTransfer(opts *bind.WatchOpts, sink chan<- *TestERC20Transfer, from []common.Address, to []common.Address) (event.Subscription, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _TestERC20.contract.WatchLogs(opts, "Transfer", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TestERC20Transfer)
+				if err := _TestERC20.contract.UnpackLog(event, "Transfer", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTransfer is a log parse operation binding the contract event 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef.
+//
+// Solidity: event Transfer(address indexed from, address indexed to, uint256 value)
+func (_TestERC20 *TestERC20Filterer) ParseTransfer(log types.Log) (*TestERC20Transfer, error) {
+	event := new(TestERC20Transfer)
+	if err := _TestERC20.contract.UnpackLog(event, "Transfer", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts/zksyncsso/test/testexecutionhook/testexecutionhook.go
+++ b/contracts/zksyncsso/test/testexecutionhook/testexecutionhook.go
@@ -1,0 +1,941 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package testexecutionhook
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// Transaction is an auto generated low-level Go binding around an user-defined struct.
+type Transaction struct {
+	TxType                 *big.Int
+	From                   *big.Int
+	To                     *big.Int
+	GasLimit               *big.Int
+	GasPerPubdataByteLimit *big.Int
+	MaxFeePerGas           *big.Int
+	MaxPriorityFeePerGas   *big.Int
+	Paymaster              *big.Int
+	Nonce                  *big.Int
+	Value                  *big.Int
+	Reserved               [4]*big.Int
+	Data                   []byte
+	Signature              []byte
+	FactoryDeps            [][32]byte
+	PaymasterInput         []byte
+	ReservedDynamic        []byte
+}
+
+// TestExecutionHookMetaData contains all meta data concerning the TestExecutionHook contract.
+var TestExecutionHookMetaData = &bind.MetaData{
+	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"ExecutionHookInstalled\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"ExecutionHookUninstalled\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"}],\"name\":\"PostExecution\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"}],\"name\":\"PreExecution\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"lastTarget\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"onInstall\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"onUninstall\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"context\",\"type\":\"bytes\"}],\"name\":\"postExecutionHook\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[]\",\"name\":\"factoryDeps\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"reservedDynamic\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"transaction\",\"type\":\"tuple\"}],\"name\":\"preExecutionHook\",\"outputs\":[{\"internalType\":\"bytes\",\"name\":\"context\",\"type\":\"bytes\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"}],\"name\":\"supportsInterface\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"pure\",\"type\":\"function\"}]",
+}
+
+// TestExecutionHookABI is the input ABI used to generate the binding from.
+// Deprecated: Use TestExecutionHookMetaData.ABI instead.
+var TestExecutionHookABI = TestExecutionHookMetaData.ABI
+
+// TestExecutionHook is an auto generated Go binding around an Ethereum contract.
+type TestExecutionHook struct {
+	TestExecutionHookCaller     // Read-only binding to the contract
+	TestExecutionHookTransactor // Write-only binding to the contract
+	TestExecutionHookFilterer   // Log filterer for contract events
+}
+
+// TestExecutionHookCaller is an auto generated read-only Go binding around an Ethereum contract.
+type TestExecutionHookCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TestExecutionHookTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type TestExecutionHookTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TestExecutionHookFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type TestExecutionHookFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TestExecutionHookSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type TestExecutionHookSession struct {
+	Contract     *TestExecutionHook // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts      // Call options to use throughout this session
+	TransactOpts bind.TransactOpts  // Transaction auth options to use throughout this session
+}
+
+// TestExecutionHookCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type TestExecutionHookCallerSession struct {
+	Contract *TestExecutionHookCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts            // Call options to use throughout this session
+}
+
+// TestExecutionHookTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type TestExecutionHookTransactorSession struct {
+	Contract     *TestExecutionHookTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts            // Transaction auth options to use throughout this session
+}
+
+// TestExecutionHookRaw is an auto generated low-level Go binding around an Ethereum contract.
+type TestExecutionHookRaw struct {
+	Contract *TestExecutionHook // Generic contract binding to access the raw methods on
+}
+
+// TestExecutionHookCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type TestExecutionHookCallerRaw struct {
+	Contract *TestExecutionHookCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// TestExecutionHookTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type TestExecutionHookTransactorRaw struct {
+	Contract *TestExecutionHookTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewTestExecutionHook creates a new instance of TestExecutionHook, bound to a specific deployed contract.
+func NewTestExecutionHook(address common.Address, backend bind.ContractBackend) (*TestExecutionHook, error) {
+	contract, err := bindTestExecutionHook(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &TestExecutionHook{TestExecutionHookCaller: TestExecutionHookCaller{contract: contract}, TestExecutionHookTransactor: TestExecutionHookTransactor{contract: contract}, TestExecutionHookFilterer: TestExecutionHookFilterer{contract: contract}}, nil
+}
+
+// NewTestExecutionHookCaller creates a new read-only instance of TestExecutionHook, bound to a specific deployed contract.
+func NewTestExecutionHookCaller(address common.Address, caller bind.ContractCaller) (*TestExecutionHookCaller, error) {
+	contract, err := bindTestExecutionHook(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &TestExecutionHookCaller{contract: contract}, nil
+}
+
+// NewTestExecutionHookTransactor creates a new write-only instance of TestExecutionHook, bound to a specific deployed contract.
+func NewTestExecutionHookTransactor(address common.Address, transactor bind.ContractTransactor) (*TestExecutionHookTransactor, error) {
+	contract, err := bindTestExecutionHook(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &TestExecutionHookTransactor{contract: contract}, nil
+}
+
+// NewTestExecutionHookFilterer creates a new log filterer instance of TestExecutionHook, bound to a specific deployed contract.
+func NewTestExecutionHookFilterer(address common.Address, filterer bind.ContractFilterer) (*TestExecutionHookFilterer, error) {
+	contract, err := bindTestExecutionHook(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &TestExecutionHookFilterer{contract: contract}, nil
+}
+
+// bindTestExecutionHook binds a generic wrapper to an already deployed contract.
+func bindTestExecutionHook(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := TestExecutionHookMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_TestExecutionHook *TestExecutionHookRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _TestExecutionHook.Contract.TestExecutionHookCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_TestExecutionHook *TestExecutionHookRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _TestExecutionHook.Contract.TestExecutionHookTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_TestExecutionHook *TestExecutionHookRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _TestExecutionHook.Contract.TestExecutionHookTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_TestExecutionHook *TestExecutionHookCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _TestExecutionHook.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_TestExecutionHook *TestExecutionHookTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _TestExecutionHook.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_TestExecutionHook *TestExecutionHookTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _TestExecutionHook.Contract.contract.Transact(opts, method, params...)
+}
+
+// LastTarget is a free data retrieval call binding the contract method 0x99d48762.
+//
+// Solidity: function lastTarget(address ) view returns(address)
+func (_TestExecutionHook *TestExecutionHookCaller) LastTarget(opts *bind.CallOpts, arg0 common.Address) (common.Address, error) {
+	var out []interface{}
+	err := _TestExecutionHook.contract.Call(opts, &out, "lastTarget", arg0)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// LastTarget is a free data retrieval call binding the contract method 0x99d48762.
+//
+// Solidity: function lastTarget(address ) view returns(address)
+func (_TestExecutionHook *TestExecutionHookSession) LastTarget(arg0 common.Address) (common.Address, error) {
+	return _TestExecutionHook.Contract.LastTarget(&_TestExecutionHook.CallOpts, arg0)
+}
+
+// LastTarget is a free data retrieval call binding the contract method 0x99d48762.
+//
+// Solidity: function lastTarget(address ) view returns(address)
+func (_TestExecutionHook *TestExecutionHookCallerSession) LastTarget(arg0 common.Address) (common.Address, error) {
+	return _TestExecutionHook.Contract.LastTarget(&_TestExecutionHook.CallOpts, arg0)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) pure returns(bool)
+func (_TestExecutionHook *TestExecutionHookCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _TestExecutionHook.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) pure returns(bool)
+func (_TestExecutionHook *TestExecutionHookSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _TestExecutionHook.Contract.SupportsInterface(&_TestExecutionHook.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) pure returns(bool)
+func (_TestExecutionHook *TestExecutionHookCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _TestExecutionHook.Contract.SupportsInterface(&_TestExecutionHook.CallOpts, interfaceId)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_TestExecutionHook *TestExecutionHookTransactor) OnInstall(opts *bind.TransactOpts, data []byte) (*types.Transaction, error) {
+	return _TestExecutionHook.contract.Transact(opts, "onInstall", data)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_TestExecutionHook *TestExecutionHookSession) OnInstall(data []byte) (*types.Transaction, error) {
+	return _TestExecutionHook.Contract.OnInstall(&_TestExecutionHook.TransactOpts, data)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_TestExecutionHook *TestExecutionHookTransactorSession) OnInstall(data []byte) (*types.Transaction, error) {
+	return _TestExecutionHook.Contract.OnInstall(&_TestExecutionHook.TransactOpts, data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_TestExecutionHook *TestExecutionHookTransactor) OnUninstall(opts *bind.TransactOpts, data []byte) (*types.Transaction, error) {
+	return _TestExecutionHook.contract.Transact(opts, "onUninstall", data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_TestExecutionHook *TestExecutionHookSession) OnUninstall(data []byte) (*types.Transaction, error) {
+	return _TestExecutionHook.Contract.OnUninstall(&_TestExecutionHook.TransactOpts, data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_TestExecutionHook *TestExecutionHookTransactorSession) OnUninstall(data []byte) (*types.Transaction, error) {
+	return _TestExecutionHook.Contract.OnUninstall(&_TestExecutionHook.TransactOpts, data)
+}
+
+// PostExecutionHook is a paid mutator transaction binding the contract method 0x3920e539.
+//
+// Solidity: function postExecutionHook(bytes context) returns()
+func (_TestExecutionHook *TestExecutionHookTransactor) PostExecutionHook(opts *bind.TransactOpts, context []byte) (*types.Transaction, error) {
+	return _TestExecutionHook.contract.Transact(opts, "postExecutionHook", context)
+}
+
+// PostExecutionHook is a paid mutator transaction binding the contract method 0x3920e539.
+//
+// Solidity: function postExecutionHook(bytes context) returns()
+func (_TestExecutionHook *TestExecutionHookSession) PostExecutionHook(context []byte) (*types.Transaction, error) {
+	return _TestExecutionHook.Contract.PostExecutionHook(&_TestExecutionHook.TransactOpts, context)
+}
+
+// PostExecutionHook is a paid mutator transaction binding the contract method 0x3920e539.
+//
+// Solidity: function postExecutionHook(bytes context) returns()
+func (_TestExecutionHook *TestExecutionHookTransactorSession) PostExecutionHook(context []byte) (*types.Transaction, error) {
+	return _TestExecutionHook.Contract.PostExecutionHook(&_TestExecutionHook.TransactOpts, context)
+}
+
+// PreExecutionHook is a paid mutator transaction binding the contract method 0x926a74a6.
+//
+// Solidity: function preExecutionHook((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) returns(bytes context)
+func (_TestExecutionHook *TestExecutionHookTransactor) PreExecutionHook(opts *bind.TransactOpts, transaction Transaction) (*types.Transaction, error) {
+	return _TestExecutionHook.contract.Transact(opts, "preExecutionHook", transaction)
+}
+
+// PreExecutionHook is a paid mutator transaction binding the contract method 0x926a74a6.
+//
+// Solidity: function preExecutionHook((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) returns(bytes context)
+func (_TestExecutionHook *TestExecutionHookSession) PreExecutionHook(transaction Transaction) (*types.Transaction, error) {
+	return _TestExecutionHook.Contract.PreExecutionHook(&_TestExecutionHook.TransactOpts, transaction)
+}
+
+// PreExecutionHook is a paid mutator transaction binding the contract method 0x926a74a6.
+//
+// Solidity: function preExecutionHook((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) returns(bytes context)
+func (_TestExecutionHook *TestExecutionHookTransactorSession) PreExecutionHook(transaction Transaction) (*types.Transaction, error) {
+	return _TestExecutionHook.Contract.PreExecutionHook(&_TestExecutionHook.TransactOpts, transaction)
+}
+
+// TestExecutionHookExecutionHookInstalledIterator is returned from FilterExecutionHookInstalled and is used to iterate over the raw logs and unpacked data for ExecutionHookInstalled events raised by the TestExecutionHook contract.
+type TestExecutionHookExecutionHookInstalledIterator struct {
+	Event *TestExecutionHookExecutionHookInstalled // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TestExecutionHookExecutionHookInstalledIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TestExecutionHookExecutionHookInstalled)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TestExecutionHookExecutionHookInstalled)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TestExecutionHookExecutionHookInstalledIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TestExecutionHookExecutionHookInstalledIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TestExecutionHookExecutionHookInstalled represents a ExecutionHookInstalled event raised by the TestExecutionHook contract.
+type TestExecutionHookExecutionHookInstalled struct {
+	Account common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterExecutionHookInstalled is a free log retrieval operation binding the contract event 0x1a4792d8240e108e601cf588feb48e55008ad1ce1e56e8d8f7e737496ad36d5a.
+//
+// Solidity: event ExecutionHookInstalled(address indexed account)
+func (_TestExecutionHook *TestExecutionHookFilterer) FilterExecutionHookInstalled(opts *bind.FilterOpts, account []common.Address) (*TestExecutionHookExecutionHookInstalledIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+
+	logs, sub, err := _TestExecutionHook.contract.FilterLogs(opts, "ExecutionHookInstalled", accountRule)
+	if err != nil {
+		return nil, err
+	}
+	return &TestExecutionHookExecutionHookInstalledIterator{contract: _TestExecutionHook.contract, event: "ExecutionHookInstalled", logs: logs, sub: sub}, nil
+}
+
+// WatchExecutionHookInstalled is a free log subscription operation binding the contract event 0x1a4792d8240e108e601cf588feb48e55008ad1ce1e56e8d8f7e737496ad36d5a.
+//
+// Solidity: event ExecutionHookInstalled(address indexed account)
+func (_TestExecutionHook *TestExecutionHookFilterer) WatchExecutionHookInstalled(opts *bind.WatchOpts, sink chan<- *TestExecutionHookExecutionHookInstalled, account []common.Address) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+
+	logs, sub, err := _TestExecutionHook.contract.WatchLogs(opts, "ExecutionHookInstalled", accountRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TestExecutionHookExecutionHookInstalled)
+				if err := _TestExecutionHook.contract.UnpackLog(event, "ExecutionHookInstalled", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseExecutionHookInstalled is a log parse operation binding the contract event 0x1a4792d8240e108e601cf588feb48e55008ad1ce1e56e8d8f7e737496ad36d5a.
+//
+// Solidity: event ExecutionHookInstalled(address indexed account)
+func (_TestExecutionHook *TestExecutionHookFilterer) ParseExecutionHookInstalled(log types.Log) (*TestExecutionHookExecutionHookInstalled, error) {
+	event := new(TestExecutionHookExecutionHookInstalled)
+	if err := _TestExecutionHook.contract.UnpackLog(event, "ExecutionHookInstalled", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// TestExecutionHookExecutionHookUninstalledIterator is returned from FilterExecutionHookUninstalled and is used to iterate over the raw logs and unpacked data for ExecutionHookUninstalled events raised by the TestExecutionHook contract.
+type TestExecutionHookExecutionHookUninstalledIterator struct {
+	Event *TestExecutionHookExecutionHookUninstalled // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TestExecutionHookExecutionHookUninstalledIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TestExecutionHookExecutionHookUninstalled)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TestExecutionHookExecutionHookUninstalled)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TestExecutionHookExecutionHookUninstalledIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TestExecutionHookExecutionHookUninstalledIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TestExecutionHookExecutionHookUninstalled represents a ExecutionHookUninstalled event raised by the TestExecutionHook contract.
+type TestExecutionHookExecutionHookUninstalled struct {
+	Account common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterExecutionHookUninstalled is a free log retrieval operation binding the contract event 0xf726cef83066d912247b1fe30d29f3cf8ad61df09f96937b3ccee866fbb787f1.
+//
+// Solidity: event ExecutionHookUninstalled(address indexed account)
+func (_TestExecutionHook *TestExecutionHookFilterer) FilterExecutionHookUninstalled(opts *bind.FilterOpts, account []common.Address) (*TestExecutionHookExecutionHookUninstalledIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+
+	logs, sub, err := _TestExecutionHook.contract.FilterLogs(opts, "ExecutionHookUninstalled", accountRule)
+	if err != nil {
+		return nil, err
+	}
+	return &TestExecutionHookExecutionHookUninstalledIterator{contract: _TestExecutionHook.contract, event: "ExecutionHookUninstalled", logs: logs, sub: sub}, nil
+}
+
+// WatchExecutionHookUninstalled is a free log subscription operation binding the contract event 0xf726cef83066d912247b1fe30d29f3cf8ad61df09f96937b3ccee866fbb787f1.
+//
+// Solidity: event ExecutionHookUninstalled(address indexed account)
+func (_TestExecutionHook *TestExecutionHookFilterer) WatchExecutionHookUninstalled(opts *bind.WatchOpts, sink chan<- *TestExecutionHookExecutionHookUninstalled, account []common.Address) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+
+	logs, sub, err := _TestExecutionHook.contract.WatchLogs(opts, "ExecutionHookUninstalled", accountRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TestExecutionHookExecutionHookUninstalled)
+				if err := _TestExecutionHook.contract.UnpackLog(event, "ExecutionHookUninstalled", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseExecutionHookUninstalled is a log parse operation binding the contract event 0xf726cef83066d912247b1fe30d29f3cf8ad61df09f96937b3ccee866fbb787f1.
+//
+// Solidity: event ExecutionHookUninstalled(address indexed account)
+func (_TestExecutionHook *TestExecutionHookFilterer) ParseExecutionHookUninstalled(log types.Log) (*TestExecutionHookExecutionHookUninstalled, error) {
+	event := new(TestExecutionHookExecutionHookUninstalled)
+	if err := _TestExecutionHook.contract.UnpackLog(event, "ExecutionHookUninstalled", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// TestExecutionHookPostExecutionIterator is returned from FilterPostExecution and is used to iterate over the raw logs and unpacked data for PostExecution events raised by the TestExecutionHook contract.
+type TestExecutionHookPostExecutionIterator struct {
+	Event *TestExecutionHookPostExecution // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TestExecutionHookPostExecutionIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TestExecutionHookPostExecution)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TestExecutionHookPostExecution)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TestExecutionHookPostExecutionIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TestExecutionHookPostExecutionIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TestExecutionHookPostExecution represents a PostExecution event raised by the TestExecutionHook contract.
+type TestExecutionHookPostExecution struct {
+	Account common.Address
+	Target  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterPostExecution is a free log retrieval operation binding the contract event 0x61f378cfbc325e0bff59b7fea67f609d10e0e3910e06bf03b8ec822082de5de6.
+//
+// Solidity: event PostExecution(address indexed account, address indexed target)
+func (_TestExecutionHook *TestExecutionHookFilterer) FilterPostExecution(opts *bind.FilterOpts, account []common.Address, target []common.Address) (*TestExecutionHookPostExecutionIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var targetRule []interface{}
+	for _, targetItem := range target {
+		targetRule = append(targetRule, targetItem)
+	}
+
+	logs, sub, err := _TestExecutionHook.contract.FilterLogs(opts, "PostExecution", accountRule, targetRule)
+	if err != nil {
+		return nil, err
+	}
+	return &TestExecutionHookPostExecutionIterator{contract: _TestExecutionHook.contract, event: "PostExecution", logs: logs, sub: sub}, nil
+}
+
+// WatchPostExecution is a free log subscription operation binding the contract event 0x61f378cfbc325e0bff59b7fea67f609d10e0e3910e06bf03b8ec822082de5de6.
+//
+// Solidity: event PostExecution(address indexed account, address indexed target)
+func (_TestExecutionHook *TestExecutionHookFilterer) WatchPostExecution(opts *bind.WatchOpts, sink chan<- *TestExecutionHookPostExecution, account []common.Address, target []common.Address) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var targetRule []interface{}
+	for _, targetItem := range target {
+		targetRule = append(targetRule, targetItem)
+	}
+
+	logs, sub, err := _TestExecutionHook.contract.WatchLogs(opts, "PostExecution", accountRule, targetRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TestExecutionHookPostExecution)
+				if err := _TestExecutionHook.contract.UnpackLog(event, "PostExecution", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePostExecution is a log parse operation binding the contract event 0x61f378cfbc325e0bff59b7fea67f609d10e0e3910e06bf03b8ec822082de5de6.
+//
+// Solidity: event PostExecution(address indexed account, address indexed target)
+func (_TestExecutionHook *TestExecutionHookFilterer) ParsePostExecution(log types.Log) (*TestExecutionHookPostExecution, error) {
+	event := new(TestExecutionHookPostExecution)
+	if err := _TestExecutionHook.contract.UnpackLog(event, "PostExecution", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// TestExecutionHookPreExecutionIterator is returned from FilterPreExecution and is used to iterate over the raw logs and unpacked data for PreExecution events raised by the TestExecutionHook contract.
+type TestExecutionHookPreExecutionIterator struct {
+	Event *TestExecutionHookPreExecution // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TestExecutionHookPreExecutionIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TestExecutionHookPreExecution)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TestExecutionHookPreExecution)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TestExecutionHookPreExecutionIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TestExecutionHookPreExecutionIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TestExecutionHookPreExecution represents a PreExecution event raised by the TestExecutionHook contract.
+type TestExecutionHookPreExecution struct {
+	Account common.Address
+	Target  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterPreExecution is a free log retrieval operation binding the contract event 0x4a145db413bc0ef36bb6eff13d165b8dc2aed778d6a3be333378c25d3a4cc835.
+//
+// Solidity: event PreExecution(address indexed account, address indexed target)
+func (_TestExecutionHook *TestExecutionHookFilterer) FilterPreExecution(opts *bind.FilterOpts, account []common.Address, target []common.Address) (*TestExecutionHookPreExecutionIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var targetRule []interface{}
+	for _, targetItem := range target {
+		targetRule = append(targetRule, targetItem)
+	}
+
+	logs, sub, err := _TestExecutionHook.contract.FilterLogs(opts, "PreExecution", accountRule, targetRule)
+	if err != nil {
+		return nil, err
+	}
+	return &TestExecutionHookPreExecutionIterator{contract: _TestExecutionHook.contract, event: "PreExecution", logs: logs, sub: sub}, nil
+}
+
+// WatchPreExecution is a free log subscription operation binding the contract event 0x4a145db413bc0ef36bb6eff13d165b8dc2aed778d6a3be333378c25d3a4cc835.
+//
+// Solidity: event PreExecution(address indexed account, address indexed target)
+func (_TestExecutionHook *TestExecutionHookFilterer) WatchPreExecution(opts *bind.WatchOpts, sink chan<- *TestExecutionHookPreExecution, account []common.Address, target []common.Address) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var targetRule []interface{}
+	for _, targetItem := range target {
+		targetRule = append(targetRule, targetItem)
+	}
+
+	logs, sub, err := _TestExecutionHook.contract.WatchLogs(opts, "PreExecution", accountRule, targetRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TestExecutionHookPreExecution)
+				if err := _TestExecutionHook.contract.UnpackLog(event, "PreExecution", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePreExecution is a log parse operation binding the contract event 0x4a145db413bc0ef36bb6eff13d165b8dc2aed778d6a3be333378c25d3a4cc835.
+//
+// Solidity: event PreExecution(address indexed account, address indexed target)
+func (_TestExecutionHook *TestExecutionHookFilterer) ParsePreExecution(log types.Log) (*TestExecutionHookPreExecution, error) {
+	event := new(TestExecutionHookPreExecution)
+	if err := _TestExecutionHook.contract.UnpackLog(event, "PreExecution", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts/zksyncsso/test/testpaymaster/testpaymaster.go
+++ b/contracts/zksyncsso/test/testpaymaster/testpaymaster.go
@@ -1,0 +1,264 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package testpaymaster
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// Transaction is an auto generated low-level Go binding around an user-defined struct.
+type Transaction struct {
+	TxType                 *big.Int
+	From                   *big.Int
+	To                     *big.Int
+	GasLimit               *big.Int
+	GasPerPubdataByteLimit *big.Int
+	MaxFeePerGas           *big.Int
+	MaxPriorityFeePerGas   *big.Int
+	Paymaster              *big.Int
+	Nonce                  *big.Int
+	Value                  *big.Int
+	Reserved               [4]*big.Int
+	Data                   []byte
+	Signature              []byte
+	FactoryDeps            [][32]byte
+	PaymasterInput         []byte
+	ReservedDynamic        []byte
+}
+
+// TestPaymasterMetaData contains all meta data concerning the TestPaymaster contract.
+var TestPaymasterMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"_context\",\"type\":\"bytes\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[]\",\"name\":\"factoryDeps\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"reservedDynamic\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"transaction\",\"type\":\"tuple\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"internalType\":\"enumExecutionResult\",\"name\":\"_txResult\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"_maxRefundedGas\",\"type\":\"uint256\"}],\"name\":\"postTransaction\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[]\",\"name\":\"factoryDeps\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"reservedDynamic\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"transaction\",\"type\":\"tuple\"}],\"name\":\"validateAndPayForPaymasterTransaction\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"magic\",\"type\":\"bytes4\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"stateMutability\":\"payable\",\"type\":\"receive\"}]",
+}
+
+// TestPaymasterABI is the input ABI used to generate the binding from.
+// Deprecated: Use TestPaymasterMetaData.ABI instead.
+var TestPaymasterABI = TestPaymasterMetaData.ABI
+
+// TestPaymaster is an auto generated Go binding around an Ethereum contract.
+type TestPaymaster struct {
+	TestPaymasterCaller     // Read-only binding to the contract
+	TestPaymasterTransactor // Write-only binding to the contract
+	TestPaymasterFilterer   // Log filterer for contract events
+}
+
+// TestPaymasterCaller is an auto generated read-only Go binding around an Ethereum contract.
+type TestPaymasterCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TestPaymasterTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type TestPaymasterTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TestPaymasterFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type TestPaymasterFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TestPaymasterSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type TestPaymasterSession struct {
+	Contract     *TestPaymaster    // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// TestPaymasterCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type TestPaymasterCallerSession struct {
+	Contract *TestPaymasterCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts        // Call options to use throughout this session
+}
+
+// TestPaymasterTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type TestPaymasterTransactorSession struct {
+	Contract     *TestPaymasterTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts        // Transaction auth options to use throughout this session
+}
+
+// TestPaymasterRaw is an auto generated low-level Go binding around an Ethereum contract.
+type TestPaymasterRaw struct {
+	Contract *TestPaymaster // Generic contract binding to access the raw methods on
+}
+
+// TestPaymasterCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type TestPaymasterCallerRaw struct {
+	Contract *TestPaymasterCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// TestPaymasterTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type TestPaymasterTransactorRaw struct {
+	Contract *TestPaymasterTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewTestPaymaster creates a new instance of TestPaymaster, bound to a specific deployed contract.
+func NewTestPaymaster(address common.Address, backend bind.ContractBackend) (*TestPaymaster, error) {
+	contract, err := bindTestPaymaster(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &TestPaymaster{TestPaymasterCaller: TestPaymasterCaller{contract: contract}, TestPaymasterTransactor: TestPaymasterTransactor{contract: contract}, TestPaymasterFilterer: TestPaymasterFilterer{contract: contract}}, nil
+}
+
+// NewTestPaymasterCaller creates a new read-only instance of TestPaymaster, bound to a specific deployed contract.
+func NewTestPaymasterCaller(address common.Address, caller bind.ContractCaller) (*TestPaymasterCaller, error) {
+	contract, err := bindTestPaymaster(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &TestPaymasterCaller{contract: contract}, nil
+}
+
+// NewTestPaymasterTransactor creates a new write-only instance of TestPaymaster, bound to a specific deployed contract.
+func NewTestPaymasterTransactor(address common.Address, transactor bind.ContractTransactor) (*TestPaymasterTransactor, error) {
+	contract, err := bindTestPaymaster(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &TestPaymasterTransactor{contract: contract}, nil
+}
+
+// NewTestPaymasterFilterer creates a new log filterer instance of TestPaymaster, bound to a specific deployed contract.
+func NewTestPaymasterFilterer(address common.Address, filterer bind.ContractFilterer) (*TestPaymasterFilterer, error) {
+	contract, err := bindTestPaymaster(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &TestPaymasterFilterer{contract: contract}, nil
+}
+
+// bindTestPaymaster binds a generic wrapper to an already deployed contract.
+func bindTestPaymaster(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := TestPaymasterMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_TestPaymaster *TestPaymasterRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _TestPaymaster.Contract.TestPaymasterCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_TestPaymaster *TestPaymasterRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _TestPaymaster.Contract.TestPaymasterTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_TestPaymaster *TestPaymasterRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _TestPaymaster.Contract.TestPaymasterTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_TestPaymaster *TestPaymasterCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _TestPaymaster.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_TestPaymaster *TestPaymasterTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _TestPaymaster.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_TestPaymaster *TestPaymasterTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _TestPaymaster.Contract.contract.Transact(opts, method, params...)
+}
+
+// PostTransaction is a paid mutator transaction binding the contract method 0x817b17f0.
+//
+// Solidity: function postTransaction(bytes _context, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction, bytes32 , bytes32 , uint8 _txResult, uint256 _maxRefundedGas) payable returns()
+func (_TestPaymaster *TestPaymasterTransactor) PostTransaction(opts *bind.TransactOpts, _context []byte, transaction Transaction, arg2 [32]byte, arg3 [32]byte, _txResult uint8, _maxRefundedGas *big.Int) (*types.Transaction, error) {
+	return _TestPaymaster.contract.Transact(opts, "postTransaction", _context, transaction, arg2, arg3, _txResult, _maxRefundedGas)
+}
+
+// PostTransaction is a paid mutator transaction binding the contract method 0x817b17f0.
+//
+// Solidity: function postTransaction(bytes _context, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction, bytes32 , bytes32 , uint8 _txResult, uint256 _maxRefundedGas) payable returns()
+func (_TestPaymaster *TestPaymasterSession) PostTransaction(_context []byte, transaction Transaction, arg2 [32]byte, arg3 [32]byte, _txResult uint8, _maxRefundedGas *big.Int) (*types.Transaction, error) {
+	return _TestPaymaster.Contract.PostTransaction(&_TestPaymaster.TransactOpts, _context, transaction, arg2, arg3, _txResult, _maxRefundedGas)
+}
+
+// PostTransaction is a paid mutator transaction binding the contract method 0x817b17f0.
+//
+// Solidity: function postTransaction(bytes _context, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction, bytes32 , bytes32 , uint8 _txResult, uint256 _maxRefundedGas) payable returns()
+func (_TestPaymaster *TestPaymasterTransactorSession) PostTransaction(_context []byte, transaction Transaction, arg2 [32]byte, arg3 [32]byte, _txResult uint8, _maxRefundedGas *big.Int) (*types.Transaction, error) {
+	return _TestPaymaster.Contract.PostTransaction(&_TestPaymaster.TransactOpts, _context, transaction, arg2, arg3, _txResult, _maxRefundedGas)
+}
+
+// ValidateAndPayForPaymasterTransaction is a paid mutator transaction binding the contract method 0x038a24bc.
+//
+// Solidity: function validateAndPayForPaymasterTransaction(bytes32 , bytes32 , (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) payable returns(bytes4 magic, bytes)
+func (_TestPaymaster *TestPaymasterTransactor) ValidateAndPayForPaymasterTransaction(opts *bind.TransactOpts, arg0 [32]byte, arg1 [32]byte, transaction Transaction) (*types.Transaction, error) {
+	return _TestPaymaster.contract.Transact(opts, "validateAndPayForPaymasterTransaction", arg0, arg1, transaction)
+}
+
+// ValidateAndPayForPaymasterTransaction is a paid mutator transaction binding the contract method 0x038a24bc.
+//
+// Solidity: function validateAndPayForPaymasterTransaction(bytes32 , bytes32 , (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) payable returns(bytes4 magic, bytes)
+func (_TestPaymaster *TestPaymasterSession) ValidateAndPayForPaymasterTransaction(arg0 [32]byte, arg1 [32]byte, transaction Transaction) (*types.Transaction, error) {
+	return _TestPaymaster.Contract.ValidateAndPayForPaymasterTransaction(&_TestPaymaster.TransactOpts, arg0, arg1, transaction)
+}
+
+// ValidateAndPayForPaymasterTransaction is a paid mutator transaction binding the contract method 0x038a24bc.
+//
+// Solidity: function validateAndPayForPaymasterTransaction(bytes32 , bytes32 , (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) payable returns(bytes4 magic, bytes)
+func (_TestPaymaster *TestPaymasterTransactorSession) ValidateAndPayForPaymasterTransaction(arg0 [32]byte, arg1 [32]byte, transaction Transaction) (*types.Transaction, error) {
+	return _TestPaymaster.Contract.ValidateAndPayForPaymasterTransaction(&_TestPaymaster.TransactOpts, arg0, arg1, transaction)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_TestPaymaster *TestPaymasterTransactor) Receive(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _TestPaymaster.contract.RawTransact(opts, nil) // calldata is disallowed for receive function
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_TestPaymaster *TestPaymasterSession) Receive() (*types.Transaction, error) {
+	return _TestPaymaster.Contract.Receive(&_TestPaymaster.TransactOpts)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_TestPaymaster *TestPaymasterTransactorSession) Receive() (*types.Transaction, error) {
+	return _TestPaymaster.Contract.Receive(&_TestPaymaster.TransactOpts)
+}

--- a/contracts/zksyncsso/test/testvalidationhook/testvalidationhook.go
+++ b/contracts/zksyncsso/test/testvalidationhook/testvalidationhook.go
@@ -1,0 +1,767 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package testvalidationhook
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// Transaction is an auto generated low-level Go binding around an user-defined struct.
+type Transaction struct {
+	TxType                 *big.Int
+	From                   *big.Int
+	To                     *big.Int
+	GasLimit               *big.Int
+	GasPerPubdataByteLimit *big.Int
+	MaxFeePerGas           *big.Int
+	MaxPriorityFeePerGas   *big.Int
+	Paymaster              *big.Int
+	Nonce                  *big.Int
+	Value                  *big.Int
+	Reserved               [4]*big.Int
+	Data                   []byte
+	Signature              []byte
+	FactoryDeps            [][32]byte
+	PaymasterInput         []byte
+	ReservedDynamic        []byte
+}
+
+// TestValidationHookMetaData contains all meta data concerning the TestValidationHook contract.
+var TestValidationHookMetaData = &bind.MetaData{
+	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"ValidationHookInstalled\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"}],\"name\":\"ValidationHookTriggered\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"ValidationHookUninstalled\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"lastTarget\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"onInstall\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"onUninstall\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"}],\"name\":\"supportsInterface\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"signedHash\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[]\",\"name\":\"factoryDeps\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"reservedDynamic\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"transaction\",\"type\":\"tuple\"}],\"name\":\"validationHook\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+}
+
+// TestValidationHookABI is the input ABI used to generate the binding from.
+// Deprecated: Use TestValidationHookMetaData.ABI instead.
+var TestValidationHookABI = TestValidationHookMetaData.ABI
+
+// TestValidationHook is an auto generated Go binding around an Ethereum contract.
+type TestValidationHook struct {
+	TestValidationHookCaller     // Read-only binding to the contract
+	TestValidationHookTransactor // Write-only binding to the contract
+	TestValidationHookFilterer   // Log filterer for contract events
+}
+
+// TestValidationHookCaller is an auto generated read-only Go binding around an Ethereum contract.
+type TestValidationHookCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TestValidationHookTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type TestValidationHookTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TestValidationHookFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type TestValidationHookFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TestValidationHookSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type TestValidationHookSession struct {
+	Contract     *TestValidationHook // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts       // Call options to use throughout this session
+	TransactOpts bind.TransactOpts   // Transaction auth options to use throughout this session
+}
+
+// TestValidationHookCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type TestValidationHookCallerSession struct {
+	Contract *TestValidationHookCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts             // Call options to use throughout this session
+}
+
+// TestValidationHookTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type TestValidationHookTransactorSession struct {
+	Contract     *TestValidationHookTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts             // Transaction auth options to use throughout this session
+}
+
+// TestValidationHookRaw is an auto generated low-level Go binding around an Ethereum contract.
+type TestValidationHookRaw struct {
+	Contract *TestValidationHook // Generic contract binding to access the raw methods on
+}
+
+// TestValidationHookCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type TestValidationHookCallerRaw struct {
+	Contract *TestValidationHookCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// TestValidationHookTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type TestValidationHookTransactorRaw struct {
+	Contract *TestValidationHookTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewTestValidationHook creates a new instance of TestValidationHook, bound to a specific deployed contract.
+func NewTestValidationHook(address common.Address, backend bind.ContractBackend) (*TestValidationHook, error) {
+	contract, err := bindTestValidationHook(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &TestValidationHook{TestValidationHookCaller: TestValidationHookCaller{contract: contract}, TestValidationHookTransactor: TestValidationHookTransactor{contract: contract}, TestValidationHookFilterer: TestValidationHookFilterer{contract: contract}}, nil
+}
+
+// NewTestValidationHookCaller creates a new read-only instance of TestValidationHook, bound to a specific deployed contract.
+func NewTestValidationHookCaller(address common.Address, caller bind.ContractCaller) (*TestValidationHookCaller, error) {
+	contract, err := bindTestValidationHook(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &TestValidationHookCaller{contract: contract}, nil
+}
+
+// NewTestValidationHookTransactor creates a new write-only instance of TestValidationHook, bound to a specific deployed contract.
+func NewTestValidationHookTransactor(address common.Address, transactor bind.ContractTransactor) (*TestValidationHookTransactor, error) {
+	contract, err := bindTestValidationHook(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &TestValidationHookTransactor{contract: contract}, nil
+}
+
+// NewTestValidationHookFilterer creates a new log filterer instance of TestValidationHook, bound to a specific deployed contract.
+func NewTestValidationHookFilterer(address common.Address, filterer bind.ContractFilterer) (*TestValidationHookFilterer, error) {
+	contract, err := bindTestValidationHook(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &TestValidationHookFilterer{contract: contract}, nil
+}
+
+// bindTestValidationHook binds a generic wrapper to an already deployed contract.
+func bindTestValidationHook(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := TestValidationHookMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_TestValidationHook *TestValidationHookRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _TestValidationHook.Contract.TestValidationHookCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_TestValidationHook *TestValidationHookRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _TestValidationHook.Contract.TestValidationHookTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_TestValidationHook *TestValidationHookRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _TestValidationHook.Contract.TestValidationHookTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_TestValidationHook *TestValidationHookCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _TestValidationHook.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_TestValidationHook *TestValidationHookTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _TestValidationHook.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_TestValidationHook *TestValidationHookTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _TestValidationHook.Contract.contract.Transact(opts, method, params...)
+}
+
+// LastTarget is a free data retrieval call binding the contract method 0x99d48762.
+//
+// Solidity: function lastTarget(address ) view returns(address)
+func (_TestValidationHook *TestValidationHookCaller) LastTarget(opts *bind.CallOpts, arg0 common.Address) (common.Address, error) {
+	var out []interface{}
+	err := _TestValidationHook.contract.Call(opts, &out, "lastTarget", arg0)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// LastTarget is a free data retrieval call binding the contract method 0x99d48762.
+//
+// Solidity: function lastTarget(address ) view returns(address)
+func (_TestValidationHook *TestValidationHookSession) LastTarget(arg0 common.Address) (common.Address, error) {
+	return _TestValidationHook.Contract.LastTarget(&_TestValidationHook.CallOpts, arg0)
+}
+
+// LastTarget is a free data retrieval call binding the contract method 0x99d48762.
+//
+// Solidity: function lastTarget(address ) view returns(address)
+func (_TestValidationHook *TestValidationHookCallerSession) LastTarget(arg0 common.Address) (common.Address, error) {
+	return _TestValidationHook.Contract.LastTarget(&_TestValidationHook.CallOpts, arg0)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) pure returns(bool)
+func (_TestValidationHook *TestValidationHookCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _TestValidationHook.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) pure returns(bool)
+func (_TestValidationHook *TestValidationHookSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _TestValidationHook.Contract.SupportsInterface(&_TestValidationHook.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) pure returns(bool)
+func (_TestValidationHook *TestValidationHookCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _TestValidationHook.Contract.SupportsInterface(&_TestValidationHook.CallOpts, interfaceId)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_TestValidationHook *TestValidationHookTransactor) OnInstall(opts *bind.TransactOpts, data []byte) (*types.Transaction, error) {
+	return _TestValidationHook.contract.Transact(opts, "onInstall", data)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_TestValidationHook *TestValidationHookSession) OnInstall(data []byte) (*types.Transaction, error) {
+	return _TestValidationHook.Contract.OnInstall(&_TestValidationHook.TransactOpts, data)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_TestValidationHook *TestValidationHookTransactorSession) OnInstall(data []byte) (*types.Transaction, error) {
+	return _TestValidationHook.Contract.OnInstall(&_TestValidationHook.TransactOpts, data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_TestValidationHook *TestValidationHookTransactor) OnUninstall(opts *bind.TransactOpts, data []byte) (*types.Transaction, error) {
+	return _TestValidationHook.contract.Transact(opts, "onUninstall", data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_TestValidationHook *TestValidationHookSession) OnUninstall(data []byte) (*types.Transaction, error) {
+	return _TestValidationHook.Contract.OnUninstall(&_TestValidationHook.TransactOpts, data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_TestValidationHook *TestValidationHookTransactorSession) OnUninstall(data []byte) (*types.Transaction, error) {
+	return _TestValidationHook.Contract.OnUninstall(&_TestValidationHook.TransactOpts, data)
+}
+
+// ValidationHook is a paid mutator transaction binding the contract method 0x37d5f03a.
+//
+// Solidity: function validationHook(bytes32 signedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) returns()
+func (_TestValidationHook *TestValidationHookTransactor) ValidationHook(opts *bind.TransactOpts, signedHash [32]byte, transaction Transaction) (*types.Transaction, error) {
+	return _TestValidationHook.contract.Transact(opts, "validationHook", signedHash, transaction)
+}
+
+// ValidationHook is a paid mutator transaction binding the contract method 0x37d5f03a.
+//
+// Solidity: function validationHook(bytes32 signedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) returns()
+func (_TestValidationHook *TestValidationHookSession) ValidationHook(signedHash [32]byte, transaction Transaction) (*types.Transaction, error) {
+	return _TestValidationHook.Contract.ValidationHook(&_TestValidationHook.TransactOpts, signedHash, transaction)
+}
+
+// ValidationHook is a paid mutator transaction binding the contract method 0x37d5f03a.
+//
+// Solidity: function validationHook(bytes32 signedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) returns()
+func (_TestValidationHook *TestValidationHookTransactorSession) ValidationHook(signedHash [32]byte, transaction Transaction) (*types.Transaction, error) {
+	return _TestValidationHook.Contract.ValidationHook(&_TestValidationHook.TransactOpts, signedHash, transaction)
+}
+
+// TestValidationHookValidationHookInstalledIterator is returned from FilterValidationHookInstalled and is used to iterate over the raw logs and unpacked data for ValidationHookInstalled events raised by the TestValidationHook contract.
+type TestValidationHookValidationHookInstalledIterator struct {
+	Event *TestValidationHookValidationHookInstalled // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TestValidationHookValidationHookInstalledIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TestValidationHookValidationHookInstalled)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TestValidationHookValidationHookInstalled)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TestValidationHookValidationHookInstalledIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TestValidationHookValidationHookInstalledIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TestValidationHookValidationHookInstalled represents a ValidationHookInstalled event raised by the TestValidationHook contract.
+type TestValidationHookValidationHookInstalled struct {
+	Account common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterValidationHookInstalled is a free log retrieval operation binding the contract event 0xd76f8f3aa13d67cda2f8afeae0e727faf7d8a6ceac6431058522a06bbe0c2e3a.
+//
+// Solidity: event ValidationHookInstalled(address indexed account)
+func (_TestValidationHook *TestValidationHookFilterer) FilterValidationHookInstalled(opts *bind.FilterOpts, account []common.Address) (*TestValidationHookValidationHookInstalledIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+
+	logs, sub, err := _TestValidationHook.contract.FilterLogs(opts, "ValidationHookInstalled", accountRule)
+	if err != nil {
+		return nil, err
+	}
+	return &TestValidationHookValidationHookInstalledIterator{contract: _TestValidationHook.contract, event: "ValidationHookInstalled", logs: logs, sub: sub}, nil
+}
+
+// WatchValidationHookInstalled is a free log subscription operation binding the contract event 0xd76f8f3aa13d67cda2f8afeae0e727faf7d8a6ceac6431058522a06bbe0c2e3a.
+//
+// Solidity: event ValidationHookInstalled(address indexed account)
+func (_TestValidationHook *TestValidationHookFilterer) WatchValidationHookInstalled(opts *bind.WatchOpts, sink chan<- *TestValidationHookValidationHookInstalled, account []common.Address) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+
+	logs, sub, err := _TestValidationHook.contract.WatchLogs(opts, "ValidationHookInstalled", accountRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TestValidationHookValidationHookInstalled)
+				if err := _TestValidationHook.contract.UnpackLog(event, "ValidationHookInstalled", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseValidationHookInstalled is a log parse operation binding the contract event 0xd76f8f3aa13d67cda2f8afeae0e727faf7d8a6ceac6431058522a06bbe0c2e3a.
+//
+// Solidity: event ValidationHookInstalled(address indexed account)
+func (_TestValidationHook *TestValidationHookFilterer) ParseValidationHookInstalled(log types.Log) (*TestValidationHookValidationHookInstalled, error) {
+	event := new(TestValidationHookValidationHookInstalled)
+	if err := _TestValidationHook.contract.UnpackLog(event, "ValidationHookInstalled", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// TestValidationHookValidationHookTriggeredIterator is returned from FilterValidationHookTriggered and is used to iterate over the raw logs and unpacked data for ValidationHookTriggered events raised by the TestValidationHook contract.
+type TestValidationHookValidationHookTriggeredIterator struct {
+	Event *TestValidationHookValidationHookTriggered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TestValidationHookValidationHookTriggeredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TestValidationHookValidationHookTriggered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TestValidationHookValidationHookTriggered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TestValidationHookValidationHookTriggeredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TestValidationHookValidationHookTriggeredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TestValidationHookValidationHookTriggered represents a ValidationHookTriggered event raised by the TestValidationHook contract.
+type TestValidationHookValidationHookTriggered struct {
+	Account common.Address
+	Target  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterValidationHookTriggered is a free log retrieval operation binding the contract event 0x940ef28342a837d716d690d57f37540f3cc25b12a8cba8ba05f292becd2607b0.
+//
+// Solidity: event ValidationHookTriggered(address indexed account, address indexed target)
+func (_TestValidationHook *TestValidationHookFilterer) FilterValidationHookTriggered(opts *bind.FilterOpts, account []common.Address, target []common.Address) (*TestValidationHookValidationHookTriggeredIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var targetRule []interface{}
+	for _, targetItem := range target {
+		targetRule = append(targetRule, targetItem)
+	}
+
+	logs, sub, err := _TestValidationHook.contract.FilterLogs(opts, "ValidationHookTriggered", accountRule, targetRule)
+	if err != nil {
+		return nil, err
+	}
+	return &TestValidationHookValidationHookTriggeredIterator{contract: _TestValidationHook.contract, event: "ValidationHookTriggered", logs: logs, sub: sub}, nil
+}
+
+// WatchValidationHookTriggered is a free log subscription operation binding the contract event 0x940ef28342a837d716d690d57f37540f3cc25b12a8cba8ba05f292becd2607b0.
+//
+// Solidity: event ValidationHookTriggered(address indexed account, address indexed target)
+func (_TestValidationHook *TestValidationHookFilterer) WatchValidationHookTriggered(opts *bind.WatchOpts, sink chan<- *TestValidationHookValidationHookTriggered, account []common.Address, target []common.Address) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var targetRule []interface{}
+	for _, targetItem := range target {
+		targetRule = append(targetRule, targetItem)
+	}
+
+	logs, sub, err := _TestValidationHook.contract.WatchLogs(opts, "ValidationHookTriggered", accountRule, targetRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TestValidationHookValidationHookTriggered)
+				if err := _TestValidationHook.contract.UnpackLog(event, "ValidationHookTriggered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseValidationHookTriggered is a log parse operation binding the contract event 0x940ef28342a837d716d690d57f37540f3cc25b12a8cba8ba05f292becd2607b0.
+//
+// Solidity: event ValidationHookTriggered(address indexed account, address indexed target)
+func (_TestValidationHook *TestValidationHookFilterer) ParseValidationHookTriggered(log types.Log) (*TestValidationHookValidationHookTriggered, error) {
+	event := new(TestValidationHookValidationHookTriggered)
+	if err := _TestValidationHook.contract.UnpackLog(event, "ValidationHookTriggered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// TestValidationHookValidationHookUninstalledIterator is returned from FilterValidationHookUninstalled and is used to iterate over the raw logs and unpacked data for ValidationHookUninstalled events raised by the TestValidationHook contract.
+type TestValidationHookValidationHookUninstalledIterator struct {
+	Event *TestValidationHookValidationHookUninstalled // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TestValidationHookValidationHookUninstalledIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TestValidationHookValidationHookUninstalled)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TestValidationHookValidationHookUninstalled)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TestValidationHookValidationHookUninstalledIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TestValidationHookValidationHookUninstalledIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TestValidationHookValidationHookUninstalled represents a ValidationHookUninstalled event raised by the TestValidationHook contract.
+type TestValidationHookValidationHookUninstalled struct {
+	Account common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterValidationHookUninstalled is a free log retrieval operation binding the contract event 0x1055ac92b9f330f212b97da321a321a1f6c5990238245855b75b9d7f6eaa6dce.
+//
+// Solidity: event ValidationHookUninstalled(address indexed account)
+func (_TestValidationHook *TestValidationHookFilterer) FilterValidationHookUninstalled(opts *bind.FilterOpts, account []common.Address) (*TestValidationHookValidationHookUninstalledIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+
+	logs, sub, err := _TestValidationHook.contract.FilterLogs(opts, "ValidationHookUninstalled", accountRule)
+	if err != nil {
+		return nil, err
+	}
+	return &TestValidationHookValidationHookUninstalledIterator{contract: _TestValidationHook.contract, event: "ValidationHookUninstalled", logs: logs, sub: sub}, nil
+}
+
+// WatchValidationHookUninstalled is a free log subscription operation binding the contract event 0x1055ac92b9f330f212b97da321a321a1f6c5990238245855b75b9d7f6eaa6dce.
+//
+// Solidity: event ValidationHookUninstalled(address indexed account)
+func (_TestValidationHook *TestValidationHookFilterer) WatchValidationHookUninstalled(opts *bind.WatchOpts, sink chan<- *TestValidationHookValidationHookUninstalled, account []common.Address) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+
+	logs, sub, err := _TestValidationHook.contract.WatchLogs(opts, "ValidationHookUninstalled", accountRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TestValidationHookValidationHookUninstalled)
+				if err := _TestValidationHook.contract.UnpackLog(event, "ValidationHookUninstalled", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseValidationHookUninstalled is a log parse operation binding the contract event 0x1055ac92b9f330f212b97da321a321a1f6c5990238245855b75b9d7f6eaa6dce.
+//
+// Solidity: event ValidationHookUninstalled(address indexed account)
+func (_TestValidationHook *TestValidationHookFilterer) ParseValidationHookUninstalled(log types.Log) (*TestValidationHookValidationHookUninstalled, error) {
+	event := new(TestValidationHookValidationHookUninstalled)
+	if err := _TestValidationHook.contract.UnpackLog(event, "ValidationHookUninstalled", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts/zksyncsso/transparentproxy/transparentproxy.go
+++ b/contracts/zksyncsso/transparentproxy/transparentproxy.go
@@ -1,0 +1,646 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package transparentproxy
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// TransparentProxyMetaData contains all meta data concerning the TransparentProxy contract.
+var TransparentProxyMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"implementation\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"previousAdmin\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"newAdmin\",\"type\":\"address\"}],\"name\":\"AdminChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"beacon\",\"type\":\"address\"}],\"name\":\"BeaconUpgraded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"implementation\",\"type\":\"address\"}],\"name\":\"Upgraded\",\"type\":\"event\"},{\"stateMutability\":\"payable\",\"type\":\"fallback\"},{\"stateMutability\":\"payable\",\"type\":\"receive\"}]",
+}
+
+// TransparentProxyABI is the input ABI used to generate the binding from.
+// Deprecated: Use TransparentProxyMetaData.ABI instead.
+var TransparentProxyABI = TransparentProxyMetaData.ABI
+
+// TransparentProxy is an auto generated Go binding around an Ethereum contract.
+type TransparentProxy struct {
+	TransparentProxyCaller     // Read-only binding to the contract
+	TransparentProxyTransactor // Write-only binding to the contract
+	TransparentProxyFilterer   // Log filterer for contract events
+}
+
+// TransparentProxyCaller is an auto generated read-only Go binding around an Ethereum contract.
+type TransparentProxyCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TransparentProxyTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type TransparentProxyTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TransparentProxyFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type TransparentProxyFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TransparentProxySession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type TransparentProxySession struct {
+	Contract     *TransparentProxy // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// TransparentProxyCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type TransparentProxyCallerSession struct {
+	Contract *TransparentProxyCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts           // Call options to use throughout this session
+}
+
+// TransparentProxyTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type TransparentProxyTransactorSession struct {
+	Contract     *TransparentProxyTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts           // Transaction auth options to use throughout this session
+}
+
+// TransparentProxyRaw is an auto generated low-level Go binding around an Ethereum contract.
+type TransparentProxyRaw struct {
+	Contract *TransparentProxy // Generic contract binding to access the raw methods on
+}
+
+// TransparentProxyCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type TransparentProxyCallerRaw struct {
+	Contract *TransparentProxyCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// TransparentProxyTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type TransparentProxyTransactorRaw struct {
+	Contract *TransparentProxyTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewTransparentProxy creates a new instance of TransparentProxy, bound to a specific deployed contract.
+func NewTransparentProxy(address common.Address, backend bind.ContractBackend) (*TransparentProxy, error) {
+	contract, err := bindTransparentProxy(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &TransparentProxy{TransparentProxyCaller: TransparentProxyCaller{contract: contract}, TransparentProxyTransactor: TransparentProxyTransactor{contract: contract}, TransparentProxyFilterer: TransparentProxyFilterer{contract: contract}}, nil
+}
+
+// NewTransparentProxyCaller creates a new read-only instance of TransparentProxy, bound to a specific deployed contract.
+func NewTransparentProxyCaller(address common.Address, caller bind.ContractCaller) (*TransparentProxyCaller, error) {
+	contract, err := bindTransparentProxy(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &TransparentProxyCaller{contract: contract}, nil
+}
+
+// NewTransparentProxyTransactor creates a new write-only instance of TransparentProxy, bound to a specific deployed contract.
+func NewTransparentProxyTransactor(address common.Address, transactor bind.ContractTransactor) (*TransparentProxyTransactor, error) {
+	contract, err := bindTransparentProxy(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &TransparentProxyTransactor{contract: contract}, nil
+}
+
+// NewTransparentProxyFilterer creates a new log filterer instance of TransparentProxy, bound to a specific deployed contract.
+func NewTransparentProxyFilterer(address common.Address, filterer bind.ContractFilterer) (*TransparentProxyFilterer, error) {
+	contract, err := bindTransparentProxy(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &TransparentProxyFilterer{contract: contract}, nil
+}
+
+// bindTransparentProxy binds a generic wrapper to an already deployed contract.
+func bindTransparentProxy(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := TransparentProxyMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_TransparentProxy *TransparentProxyRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _TransparentProxy.Contract.TransparentProxyCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_TransparentProxy *TransparentProxyRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _TransparentProxy.Contract.TransparentProxyTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_TransparentProxy *TransparentProxyRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _TransparentProxy.Contract.TransparentProxyTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_TransparentProxy *TransparentProxyCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _TransparentProxy.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_TransparentProxy *TransparentProxyTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _TransparentProxy.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_TransparentProxy *TransparentProxyTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _TransparentProxy.Contract.contract.Transact(opts, method, params...)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() payable returns()
+func (_TransparentProxy *TransparentProxyTransactor) Fallback(opts *bind.TransactOpts, calldata []byte) (*types.Transaction, error) {
+	return _TransparentProxy.contract.RawTransact(opts, calldata)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() payable returns()
+func (_TransparentProxy *TransparentProxySession) Fallback(calldata []byte) (*types.Transaction, error) {
+	return _TransparentProxy.Contract.Fallback(&_TransparentProxy.TransactOpts, calldata)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() payable returns()
+func (_TransparentProxy *TransparentProxyTransactorSession) Fallback(calldata []byte) (*types.Transaction, error) {
+	return _TransparentProxy.Contract.Fallback(&_TransparentProxy.TransactOpts, calldata)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_TransparentProxy *TransparentProxyTransactor) Receive(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _TransparentProxy.contract.RawTransact(opts, nil) // calldata is disallowed for receive function
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_TransparentProxy *TransparentProxySession) Receive() (*types.Transaction, error) {
+	return _TransparentProxy.Contract.Receive(&_TransparentProxy.TransactOpts)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_TransparentProxy *TransparentProxyTransactorSession) Receive() (*types.Transaction, error) {
+	return _TransparentProxy.Contract.Receive(&_TransparentProxy.TransactOpts)
+}
+
+// TransparentProxyAdminChangedIterator is returned from FilterAdminChanged and is used to iterate over the raw logs and unpacked data for AdminChanged events raised by the TransparentProxy contract.
+type TransparentProxyAdminChangedIterator struct {
+	Event *TransparentProxyAdminChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TransparentProxyAdminChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TransparentProxyAdminChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TransparentProxyAdminChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TransparentProxyAdminChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TransparentProxyAdminChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TransparentProxyAdminChanged represents a AdminChanged event raised by the TransparentProxy contract.
+type TransparentProxyAdminChanged struct {
+	PreviousAdmin common.Address
+	NewAdmin      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterAdminChanged is a free log retrieval operation binding the contract event 0x7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f.
+//
+// Solidity: event AdminChanged(address previousAdmin, address newAdmin)
+func (_TransparentProxy *TransparentProxyFilterer) FilterAdminChanged(opts *bind.FilterOpts) (*TransparentProxyAdminChangedIterator, error) {
+
+	logs, sub, err := _TransparentProxy.contract.FilterLogs(opts, "AdminChanged")
+	if err != nil {
+		return nil, err
+	}
+	return &TransparentProxyAdminChangedIterator{contract: _TransparentProxy.contract, event: "AdminChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchAdminChanged is a free log subscription operation binding the contract event 0x7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f.
+//
+// Solidity: event AdminChanged(address previousAdmin, address newAdmin)
+func (_TransparentProxy *TransparentProxyFilterer) WatchAdminChanged(opts *bind.WatchOpts, sink chan<- *TransparentProxyAdminChanged) (event.Subscription, error) {
+
+	logs, sub, err := _TransparentProxy.contract.WatchLogs(opts, "AdminChanged")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TransparentProxyAdminChanged)
+				if err := _TransparentProxy.contract.UnpackLog(event, "AdminChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseAdminChanged is a log parse operation binding the contract event 0x7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f.
+//
+// Solidity: event AdminChanged(address previousAdmin, address newAdmin)
+func (_TransparentProxy *TransparentProxyFilterer) ParseAdminChanged(log types.Log) (*TransparentProxyAdminChanged, error) {
+	event := new(TransparentProxyAdminChanged)
+	if err := _TransparentProxy.contract.UnpackLog(event, "AdminChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// TransparentProxyBeaconUpgradedIterator is returned from FilterBeaconUpgraded and is used to iterate over the raw logs and unpacked data for BeaconUpgraded events raised by the TransparentProxy contract.
+type TransparentProxyBeaconUpgradedIterator struct {
+	Event *TransparentProxyBeaconUpgraded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TransparentProxyBeaconUpgradedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TransparentProxyBeaconUpgraded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TransparentProxyBeaconUpgraded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TransparentProxyBeaconUpgradedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TransparentProxyBeaconUpgradedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TransparentProxyBeaconUpgraded represents a BeaconUpgraded event raised by the TransparentProxy contract.
+type TransparentProxyBeaconUpgraded struct {
+	Beacon common.Address
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterBeaconUpgraded is a free log retrieval operation binding the contract event 0x1cf3b03a6cf19fa2baba4df148e9dcabedea7f8a5c07840e207e5c089be95d3e.
+//
+// Solidity: event BeaconUpgraded(address indexed beacon)
+func (_TransparentProxy *TransparentProxyFilterer) FilterBeaconUpgraded(opts *bind.FilterOpts, beacon []common.Address) (*TransparentProxyBeaconUpgradedIterator, error) {
+
+	var beaconRule []interface{}
+	for _, beaconItem := range beacon {
+		beaconRule = append(beaconRule, beaconItem)
+	}
+
+	logs, sub, err := _TransparentProxy.contract.FilterLogs(opts, "BeaconUpgraded", beaconRule)
+	if err != nil {
+		return nil, err
+	}
+	return &TransparentProxyBeaconUpgradedIterator{contract: _TransparentProxy.contract, event: "BeaconUpgraded", logs: logs, sub: sub}, nil
+}
+
+// WatchBeaconUpgraded is a free log subscription operation binding the contract event 0x1cf3b03a6cf19fa2baba4df148e9dcabedea7f8a5c07840e207e5c089be95d3e.
+//
+// Solidity: event BeaconUpgraded(address indexed beacon)
+func (_TransparentProxy *TransparentProxyFilterer) WatchBeaconUpgraded(opts *bind.WatchOpts, sink chan<- *TransparentProxyBeaconUpgraded, beacon []common.Address) (event.Subscription, error) {
+
+	var beaconRule []interface{}
+	for _, beaconItem := range beacon {
+		beaconRule = append(beaconRule, beaconItem)
+	}
+
+	logs, sub, err := _TransparentProxy.contract.WatchLogs(opts, "BeaconUpgraded", beaconRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TransparentProxyBeaconUpgraded)
+				if err := _TransparentProxy.contract.UnpackLog(event, "BeaconUpgraded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBeaconUpgraded is a log parse operation binding the contract event 0x1cf3b03a6cf19fa2baba4df148e9dcabedea7f8a5c07840e207e5c089be95d3e.
+//
+// Solidity: event BeaconUpgraded(address indexed beacon)
+func (_TransparentProxy *TransparentProxyFilterer) ParseBeaconUpgraded(log types.Log) (*TransparentProxyBeaconUpgraded, error) {
+	event := new(TransparentProxyBeaconUpgraded)
+	if err := _TransparentProxy.contract.UnpackLog(event, "BeaconUpgraded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// TransparentProxyUpgradedIterator is returned from FilterUpgraded and is used to iterate over the raw logs and unpacked data for Upgraded events raised by the TransparentProxy contract.
+type TransparentProxyUpgradedIterator struct {
+	Event *TransparentProxyUpgraded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TransparentProxyUpgradedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TransparentProxyUpgraded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TransparentProxyUpgraded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TransparentProxyUpgradedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TransparentProxyUpgradedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TransparentProxyUpgraded represents a Upgraded event raised by the TransparentProxy contract.
+type TransparentProxyUpgraded struct {
+	Implementation common.Address
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterUpgraded is a free log retrieval operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_TransparentProxy *TransparentProxyFilterer) FilterUpgraded(opts *bind.FilterOpts, implementation []common.Address) (*TransparentProxyUpgradedIterator, error) {
+
+	var implementationRule []interface{}
+	for _, implementationItem := range implementation {
+		implementationRule = append(implementationRule, implementationItem)
+	}
+
+	logs, sub, err := _TransparentProxy.contract.FilterLogs(opts, "Upgraded", implementationRule)
+	if err != nil {
+		return nil, err
+	}
+	return &TransparentProxyUpgradedIterator{contract: _TransparentProxy.contract, event: "Upgraded", logs: logs, sub: sub}, nil
+}
+
+// WatchUpgraded is a free log subscription operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_TransparentProxy *TransparentProxyFilterer) WatchUpgraded(opts *bind.WatchOpts, sink chan<- *TransparentProxyUpgraded, implementation []common.Address) (event.Subscription, error) {
+
+	var implementationRule []interface{}
+	for _, implementationItem := range implementation {
+		implementationRule = append(implementationRule, implementationItem)
+	}
+
+	logs, sub, err := _TransparentProxy.contract.WatchLogs(opts, "Upgraded", implementationRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TransparentProxyUpgraded)
+				if err := _TransparentProxy.contract.UnpackLog(event, "Upgraded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUpgraded is a log parse operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_TransparentProxy *TransparentProxyFilterer) ParseUpgraded(log types.Log) (*TransparentProxyUpgraded, error) {
+	event := new(TransparentProxyUpgraded)
+	if err := _TransparentProxy.contract.UnpackLog(event, "Upgraded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts/zksyncsso/validators/guardianrecoveryvalidator/guardianrecoveryvalidator.go
+++ b/contracts/zksyncsso/validators/guardianrecoveryvalidator/guardianrecoveryvalidator.go
@@ -1,0 +1,2115 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package guardianrecoveryvalidator
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// IGuardianRecoveryValidatorGuardian is an auto generated low-level Go binding around an user-defined struct.
+type IGuardianRecoveryValidatorGuardian struct {
+	Addr    common.Address
+	IsReady bool
+	AddedAt uint64
+}
+
+// IGuardianRecoveryValidatorRecoveryRequest is an auto generated low-level Go binding around an user-defined struct.
+type IGuardianRecoveryValidatorRecoveryRequest struct {
+	HashedCredentialId [32]byte
+	RawPublicKey       [2][32]byte
+	Timestamp          *big.Int
+}
+
+// Transaction is an auto generated low-level Go binding around an user-defined struct.
+type Transaction struct {
+	TxType                 *big.Int
+	From                   *big.Int
+	To                     *big.Int
+	GasLimit               *big.Int
+	GasPerPubdataByteLimit *big.Int
+	MaxFeePerGas           *big.Int
+	MaxPriorityFeePerGas   *big.Int
+	Paymaster              *big.Int
+	Nonce                  *big.Int
+	Value                  *big.Int
+	Reserved               [4]*big.Int
+	Data                   []byte
+	Signature              []byte
+	FactoryDeps            [][32]byte
+	PaymasterInput         []byte
+	ReservedDynamic        []byte
+}
+
+// GuardianRecoveryValidatorMetaData contains all meta data concerning the GuardianRecoveryValidator contract.
+var GuardianRecoveryValidatorMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"ADDRESS_CAST_OVERFLOW\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"guardian\",\"type\":\"address\"}],\"name\":\"AccountAlreadyGuardedByGuardian\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"guardian\",\"type\":\"address\"}],\"name\":\"AccountNotGuardedByAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"AccountRecoveryInProgress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"GuardianCannotBeSelf\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"guardian\",\"type\":\"address\"}],\"name\":\"GuardianNotFound\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"guardian\",\"type\":\"address\"}],\"name\":\"GuardianNotProposed\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidAccountToGuardAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidAccountToRecoverAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidGuardianAddress\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidWebAuthValidatorAddress\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"chainId\",\"type\":\"uint256\"}],\"name\":\"NO_TIMESTAMP_ASSERTER\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NonFunctionCallTransaction\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"}],\"name\":\"UnknownHashedOriginDomain\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"WebAuthValidatorNotEnabled\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"guardian\",\"type\":\"address\"}],\"name\":\"GuardianAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"guardian\",\"type\":\"address\"}],\"name\":\"GuardianProposed\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"guardian\",\"type\":\"address\"}],\"name\":\"GuardianRemoved\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"}],\"name\":\"HashedOriginDomainDisabledForAccount\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"}],\"name\":\"HashedOriginDomainEnabledForAccount\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"version\",\"type\":\"uint8\"}],\"name\":\"Initialized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"hashedCredentialId\",\"type\":\"bytes32\"}],\"name\":\"RecoveryDiscarded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"hashedCredentialId\",\"type\":\"bytes32\"}],\"name\":\"RecoveryFinished\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"hashedCredentialId\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"guardian\",\"type\":\"address\"}],\"name\":\"RecoveryInitiated\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"REQUEST_DELAY_TIME\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"REQUEST_VALIDITY_TIME\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"guardian\",\"type\":\"address\"}],\"name\":\"accountGuardianData\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isReady\",\"type\":\"bool\"},{\"internalType\":\"uint64\",\"name\":\"addedAt\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"accountToGuard\",\"type\":\"address\"}],\"name\":\"addGuardian\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"}],\"name\":\"discardRecovery\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"getPendingRecoveryData\",\"outputs\":[{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"hashedCredentialId\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32[2]\",\"name\":\"rawPublicKey\",\"type\":\"bytes32[2]\"},{\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"internalType\":\"structIGuardianRecoveryValidator.RecoveryRequest\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"guardian\",\"type\":\"address\"}],\"name\":\"guardianOf\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"guardiansFor\",\"outputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isReady\",\"type\":\"bool\"},{\"internalType\":\"uint64\",\"name\":\"addedAt\",\"type\":\"uint64\"}],\"internalType\":\"structIGuardianRecoveryValidator.Guardian[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"accountToRecover\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"hashedCredentialId\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32[2]\",\"name\":\"rawPublicKey\",\"type\":\"bytes32[2]\"},{\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"}],\"name\":\"initRecovery\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"contractWebAuthValidator\",\"name\":\"_webAuthValidator\",\"type\":\"address\"}],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"name\":\"onInstall\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"name\":\"onUninstall\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"newGuardian\",\"type\":\"address\"}],\"name\":\"proposeGuardian\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"hashedOriginDomain\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"guardianToRemove\",\"type\":\"address\"}],\"name\":\"removeGuardian\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"}],\"name\":\"supportsInterface\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"name\":\"validateSignature\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[]\",\"name\":\"factoryDeps\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"reservedDynamic\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"transaction\",\"type\":\"tuple\"}],\"name\":\"validateTransaction\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"webAuthValidator\",\"outputs\":[{\"internalType\":\"contractWebAuthValidator\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+}
+
+// GuardianRecoveryValidatorABI is the input ABI used to generate the binding from.
+// Deprecated: Use GuardianRecoveryValidatorMetaData.ABI instead.
+var GuardianRecoveryValidatorABI = GuardianRecoveryValidatorMetaData.ABI
+
+// GuardianRecoveryValidator is an auto generated Go binding around an Ethereum contract.
+type GuardianRecoveryValidator struct {
+	GuardianRecoveryValidatorCaller     // Read-only binding to the contract
+	GuardianRecoveryValidatorTransactor // Write-only binding to the contract
+	GuardianRecoveryValidatorFilterer   // Log filterer for contract events
+}
+
+// GuardianRecoveryValidatorCaller is an auto generated read-only Go binding around an Ethereum contract.
+type GuardianRecoveryValidatorCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// GuardianRecoveryValidatorTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type GuardianRecoveryValidatorTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// GuardianRecoveryValidatorFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type GuardianRecoveryValidatorFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// GuardianRecoveryValidatorSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type GuardianRecoveryValidatorSession struct {
+	Contract     *GuardianRecoveryValidator // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts              // Call options to use throughout this session
+	TransactOpts bind.TransactOpts          // Transaction auth options to use throughout this session
+}
+
+// GuardianRecoveryValidatorCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type GuardianRecoveryValidatorCallerSession struct {
+	Contract *GuardianRecoveryValidatorCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts                    // Call options to use throughout this session
+}
+
+// GuardianRecoveryValidatorTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type GuardianRecoveryValidatorTransactorSession struct {
+	Contract     *GuardianRecoveryValidatorTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts                    // Transaction auth options to use throughout this session
+}
+
+// GuardianRecoveryValidatorRaw is an auto generated low-level Go binding around an Ethereum contract.
+type GuardianRecoveryValidatorRaw struct {
+	Contract *GuardianRecoveryValidator // Generic contract binding to access the raw methods on
+}
+
+// GuardianRecoveryValidatorCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type GuardianRecoveryValidatorCallerRaw struct {
+	Contract *GuardianRecoveryValidatorCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// GuardianRecoveryValidatorTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type GuardianRecoveryValidatorTransactorRaw struct {
+	Contract *GuardianRecoveryValidatorTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewGuardianRecoveryValidator creates a new instance of GuardianRecoveryValidator, bound to a specific deployed contract.
+func NewGuardianRecoveryValidator(address common.Address, backend bind.ContractBackend) (*GuardianRecoveryValidator, error) {
+	contract, err := bindGuardianRecoveryValidator(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &GuardianRecoveryValidator{GuardianRecoveryValidatorCaller: GuardianRecoveryValidatorCaller{contract: contract}, GuardianRecoveryValidatorTransactor: GuardianRecoveryValidatorTransactor{contract: contract}, GuardianRecoveryValidatorFilterer: GuardianRecoveryValidatorFilterer{contract: contract}}, nil
+}
+
+// NewGuardianRecoveryValidatorCaller creates a new read-only instance of GuardianRecoveryValidator, bound to a specific deployed contract.
+func NewGuardianRecoveryValidatorCaller(address common.Address, caller bind.ContractCaller) (*GuardianRecoveryValidatorCaller, error) {
+	contract, err := bindGuardianRecoveryValidator(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &GuardianRecoveryValidatorCaller{contract: contract}, nil
+}
+
+// NewGuardianRecoveryValidatorTransactor creates a new write-only instance of GuardianRecoveryValidator, bound to a specific deployed contract.
+func NewGuardianRecoveryValidatorTransactor(address common.Address, transactor bind.ContractTransactor) (*GuardianRecoveryValidatorTransactor, error) {
+	contract, err := bindGuardianRecoveryValidator(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &GuardianRecoveryValidatorTransactor{contract: contract}, nil
+}
+
+// NewGuardianRecoveryValidatorFilterer creates a new log filterer instance of GuardianRecoveryValidator, bound to a specific deployed contract.
+func NewGuardianRecoveryValidatorFilterer(address common.Address, filterer bind.ContractFilterer) (*GuardianRecoveryValidatorFilterer, error) {
+	contract, err := bindGuardianRecoveryValidator(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &GuardianRecoveryValidatorFilterer{contract: contract}, nil
+}
+
+// bindGuardianRecoveryValidator binds a generic wrapper to an already deployed contract.
+func bindGuardianRecoveryValidator(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := GuardianRecoveryValidatorMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _GuardianRecoveryValidator.Contract.GuardianRecoveryValidatorCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.Contract.GuardianRecoveryValidatorTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.Contract.GuardianRecoveryValidatorTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _GuardianRecoveryValidator.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.Contract.contract.Transact(opts, method, params...)
+}
+
+// REQUESTDELAYTIME is a free data retrieval call binding the contract method 0xfe8d85ab.
+//
+// Solidity: function REQUEST_DELAY_TIME() view returns(uint256)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorCaller) REQUESTDELAYTIME(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _GuardianRecoveryValidator.contract.Call(opts, &out, "REQUEST_DELAY_TIME")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// REQUESTDELAYTIME is a free data retrieval call binding the contract method 0xfe8d85ab.
+//
+// Solidity: function REQUEST_DELAY_TIME() view returns(uint256)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorSession) REQUESTDELAYTIME() (*big.Int, error) {
+	return _GuardianRecoveryValidator.Contract.REQUESTDELAYTIME(&_GuardianRecoveryValidator.CallOpts)
+}
+
+// REQUESTDELAYTIME is a free data retrieval call binding the contract method 0xfe8d85ab.
+//
+// Solidity: function REQUEST_DELAY_TIME() view returns(uint256)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorCallerSession) REQUESTDELAYTIME() (*big.Int, error) {
+	return _GuardianRecoveryValidator.Contract.REQUESTDELAYTIME(&_GuardianRecoveryValidator.CallOpts)
+}
+
+// REQUESTVALIDITYTIME is a free data retrieval call binding the contract method 0x32c768a9.
+//
+// Solidity: function REQUEST_VALIDITY_TIME() view returns(uint256)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorCaller) REQUESTVALIDITYTIME(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _GuardianRecoveryValidator.contract.Call(opts, &out, "REQUEST_VALIDITY_TIME")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// REQUESTVALIDITYTIME is a free data retrieval call binding the contract method 0x32c768a9.
+//
+// Solidity: function REQUEST_VALIDITY_TIME() view returns(uint256)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorSession) REQUESTVALIDITYTIME() (*big.Int, error) {
+	return _GuardianRecoveryValidator.Contract.REQUESTVALIDITYTIME(&_GuardianRecoveryValidator.CallOpts)
+}
+
+// REQUESTVALIDITYTIME is a free data retrieval call binding the contract method 0x32c768a9.
+//
+// Solidity: function REQUEST_VALIDITY_TIME() view returns(uint256)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorCallerSession) REQUESTVALIDITYTIME() (*big.Int, error) {
+	return _GuardianRecoveryValidator.Contract.REQUESTVALIDITYTIME(&_GuardianRecoveryValidator.CallOpts)
+}
+
+// AccountGuardianData is a free data retrieval call binding the contract method 0x9b99752a.
+//
+// Solidity: function accountGuardianData(bytes32 hashedOriginDomain, address account, address guardian) view returns(address addr, bool isReady, uint64 addedAt)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorCaller) AccountGuardianData(opts *bind.CallOpts, hashedOriginDomain [32]byte, account common.Address, guardian common.Address) (struct {
+	Addr    common.Address
+	IsReady bool
+	AddedAt uint64
+}, error) {
+	var out []interface{}
+	err := _GuardianRecoveryValidator.contract.Call(opts, &out, "accountGuardianData", hashedOriginDomain, account, guardian)
+
+	outstruct := new(struct {
+		Addr    common.Address
+		IsReady bool
+		AddedAt uint64
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Addr = *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+	outstruct.IsReady = *abi.ConvertType(out[1], new(bool)).(*bool)
+	outstruct.AddedAt = *abi.ConvertType(out[2], new(uint64)).(*uint64)
+
+	return *outstruct, err
+
+}
+
+// AccountGuardianData is a free data retrieval call binding the contract method 0x9b99752a.
+//
+// Solidity: function accountGuardianData(bytes32 hashedOriginDomain, address account, address guardian) view returns(address addr, bool isReady, uint64 addedAt)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorSession) AccountGuardianData(hashedOriginDomain [32]byte, account common.Address, guardian common.Address) (struct {
+	Addr    common.Address
+	IsReady bool
+	AddedAt uint64
+}, error) {
+	return _GuardianRecoveryValidator.Contract.AccountGuardianData(&_GuardianRecoveryValidator.CallOpts, hashedOriginDomain, account, guardian)
+}
+
+// AccountGuardianData is a free data retrieval call binding the contract method 0x9b99752a.
+//
+// Solidity: function accountGuardianData(bytes32 hashedOriginDomain, address account, address guardian) view returns(address addr, bool isReady, uint64 addedAt)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorCallerSession) AccountGuardianData(hashedOriginDomain [32]byte, account common.Address, guardian common.Address) (struct {
+	Addr    common.Address
+	IsReady bool
+	AddedAt uint64
+}, error) {
+	return _GuardianRecoveryValidator.Contract.AccountGuardianData(&_GuardianRecoveryValidator.CallOpts, hashedOriginDomain, account, guardian)
+}
+
+// GetPendingRecoveryData is a free data retrieval call binding the contract method 0xab9d5fff.
+//
+// Solidity: function getPendingRecoveryData(bytes32 hashedOriginDomain, address account) view returns((bytes32,bytes32[2],uint256))
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorCaller) GetPendingRecoveryData(opts *bind.CallOpts, hashedOriginDomain [32]byte, account common.Address) (IGuardianRecoveryValidatorRecoveryRequest, error) {
+	var out []interface{}
+	err := _GuardianRecoveryValidator.contract.Call(opts, &out, "getPendingRecoveryData", hashedOriginDomain, account)
+
+	if err != nil {
+		return *new(IGuardianRecoveryValidatorRecoveryRequest), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(IGuardianRecoveryValidatorRecoveryRequest)).(*IGuardianRecoveryValidatorRecoveryRequest)
+
+	return out0, err
+
+}
+
+// GetPendingRecoveryData is a free data retrieval call binding the contract method 0xab9d5fff.
+//
+// Solidity: function getPendingRecoveryData(bytes32 hashedOriginDomain, address account) view returns((bytes32,bytes32[2],uint256))
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorSession) GetPendingRecoveryData(hashedOriginDomain [32]byte, account common.Address) (IGuardianRecoveryValidatorRecoveryRequest, error) {
+	return _GuardianRecoveryValidator.Contract.GetPendingRecoveryData(&_GuardianRecoveryValidator.CallOpts, hashedOriginDomain, account)
+}
+
+// GetPendingRecoveryData is a free data retrieval call binding the contract method 0xab9d5fff.
+//
+// Solidity: function getPendingRecoveryData(bytes32 hashedOriginDomain, address account) view returns((bytes32,bytes32[2],uint256))
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorCallerSession) GetPendingRecoveryData(hashedOriginDomain [32]byte, account common.Address) (IGuardianRecoveryValidatorRecoveryRequest, error) {
+	return _GuardianRecoveryValidator.Contract.GetPendingRecoveryData(&_GuardianRecoveryValidator.CallOpts, hashedOriginDomain, account)
+}
+
+// GuardianOf is a free data retrieval call binding the contract method 0xcb339850.
+//
+// Solidity: function guardianOf(bytes32 hashedOriginDomain, address guardian) view returns(address[])
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorCaller) GuardianOf(opts *bind.CallOpts, hashedOriginDomain [32]byte, guardian common.Address) ([]common.Address, error) {
+	var out []interface{}
+	err := _GuardianRecoveryValidator.contract.Call(opts, &out, "guardianOf", hashedOriginDomain, guardian)
+
+	if err != nil {
+		return *new([]common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
+
+	return out0, err
+
+}
+
+// GuardianOf is a free data retrieval call binding the contract method 0xcb339850.
+//
+// Solidity: function guardianOf(bytes32 hashedOriginDomain, address guardian) view returns(address[])
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorSession) GuardianOf(hashedOriginDomain [32]byte, guardian common.Address) ([]common.Address, error) {
+	return _GuardianRecoveryValidator.Contract.GuardianOf(&_GuardianRecoveryValidator.CallOpts, hashedOriginDomain, guardian)
+}
+
+// GuardianOf is a free data retrieval call binding the contract method 0xcb339850.
+//
+// Solidity: function guardianOf(bytes32 hashedOriginDomain, address guardian) view returns(address[])
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorCallerSession) GuardianOf(hashedOriginDomain [32]byte, guardian common.Address) ([]common.Address, error) {
+	return _GuardianRecoveryValidator.Contract.GuardianOf(&_GuardianRecoveryValidator.CallOpts, hashedOriginDomain, guardian)
+}
+
+// GuardiansFor is a free data retrieval call binding the contract method 0x511f723d.
+//
+// Solidity: function guardiansFor(bytes32 hashedOriginDomain, address addr) view returns((address,bool,uint64)[])
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorCaller) GuardiansFor(opts *bind.CallOpts, hashedOriginDomain [32]byte, addr common.Address) ([]IGuardianRecoveryValidatorGuardian, error) {
+	var out []interface{}
+	err := _GuardianRecoveryValidator.contract.Call(opts, &out, "guardiansFor", hashedOriginDomain, addr)
+
+	if err != nil {
+		return *new([]IGuardianRecoveryValidatorGuardian), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]IGuardianRecoveryValidatorGuardian)).(*[]IGuardianRecoveryValidatorGuardian)
+
+	return out0, err
+
+}
+
+// GuardiansFor is a free data retrieval call binding the contract method 0x511f723d.
+//
+// Solidity: function guardiansFor(bytes32 hashedOriginDomain, address addr) view returns((address,bool,uint64)[])
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorSession) GuardiansFor(hashedOriginDomain [32]byte, addr common.Address) ([]IGuardianRecoveryValidatorGuardian, error) {
+	return _GuardianRecoveryValidator.Contract.GuardiansFor(&_GuardianRecoveryValidator.CallOpts, hashedOriginDomain, addr)
+}
+
+// GuardiansFor is a free data retrieval call binding the contract method 0x511f723d.
+//
+// Solidity: function guardiansFor(bytes32 hashedOriginDomain, address addr) view returns((address,bool,uint64)[])
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorCallerSession) GuardiansFor(hashedOriginDomain [32]byte, addr common.Address) ([]IGuardianRecoveryValidatorGuardian, error) {
+	return _GuardianRecoveryValidator.Contract.GuardiansFor(&_GuardianRecoveryValidator.CallOpts, hashedOriginDomain, addr)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) pure returns(bool)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _GuardianRecoveryValidator.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) pure returns(bool)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _GuardianRecoveryValidator.Contract.SupportsInterface(&_GuardianRecoveryValidator.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) pure returns(bool)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _GuardianRecoveryValidator.Contract.SupportsInterface(&_GuardianRecoveryValidator.CallOpts, interfaceId)
+}
+
+// ValidateSignature is a free data retrieval call binding the contract method 0x333daf92.
+//
+// Solidity: function validateSignature(bytes32 , bytes ) pure returns(bool)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorCaller) ValidateSignature(opts *bind.CallOpts, arg0 [32]byte, arg1 []byte) (bool, error) {
+	var out []interface{}
+	err := _GuardianRecoveryValidator.contract.Call(opts, &out, "validateSignature", arg0, arg1)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// ValidateSignature is a free data retrieval call binding the contract method 0x333daf92.
+//
+// Solidity: function validateSignature(bytes32 , bytes ) pure returns(bool)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorSession) ValidateSignature(arg0 [32]byte, arg1 []byte) (bool, error) {
+	return _GuardianRecoveryValidator.Contract.ValidateSignature(&_GuardianRecoveryValidator.CallOpts, arg0, arg1)
+}
+
+// ValidateSignature is a free data retrieval call binding the contract method 0x333daf92.
+//
+// Solidity: function validateSignature(bytes32 , bytes ) pure returns(bool)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorCallerSession) ValidateSignature(arg0 [32]byte, arg1 []byte) (bool, error) {
+	return _GuardianRecoveryValidator.Contract.ValidateSignature(&_GuardianRecoveryValidator.CallOpts, arg0, arg1)
+}
+
+// WebAuthValidator is a free data retrieval call binding the contract method 0x25290a37.
+//
+// Solidity: function webAuthValidator() view returns(address)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorCaller) WebAuthValidator(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _GuardianRecoveryValidator.contract.Call(opts, &out, "webAuthValidator")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// WebAuthValidator is a free data retrieval call binding the contract method 0x25290a37.
+//
+// Solidity: function webAuthValidator() view returns(address)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorSession) WebAuthValidator() (common.Address, error) {
+	return _GuardianRecoveryValidator.Contract.WebAuthValidator(&_GuardianRecoveryValidator.CallOpts)
+}
+
+// WebAuthValidator is a free data retrieval call binding the contract method 0x25290a37.
+//
+// Solidity: function webAuthValidator() view returns(address)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorCallerSession) WebAuthValidator() (common.Address, error) {
+	return _GuardianRecoveryValidator.Contract.WebAuthValidator(&_GuardianRecoveryValidator.CallOpts)
+}
+
+// AddGuardian is a paid mutator transaction binding the contract method 0x85431596.
+//
+// Solidity: function addGuardian(bytes32 hashedOriginDomain, address accountToGuard) returns(bool)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorTransactor) AddGuardian(opts *bind.TransactOpts, hashedOriginDomain [32]byte, accountToGuard common.Address) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.contract.Transact(opts, "addGuardian", hashedOriginDomain, accountToGuard)
+}
+
+// AddGuardian is a paid mutator transaction binding the contract method 0x85431596.
+//
+// Solidity: function addGuardian(bytes32 hashedOriginDomain, address accountToGuard) returns(bool)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorSession) AddGuardian(hashedOriginDomain [32]byte, accountToGuard common.Address) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.Contract.AddGuardian(&_GuardianRecoveryValidator.TransactOpts, hashedOriginDomain, accountToGuard)
+}
+
+// AddGuardian is a paid mutator transaction binding the contract method 0x85431596.
+//
+// Solidity: function addGuardian(bytes32 hashedOriginDomain, address accountToGuard) returns(bool)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorTransactorSession) AddGuardian(hashedOriginDomain [32]byte, accountToGuard common.Address) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.Contract.AddGuardian(&_GuardianRecoveryValidator.TransactOpts, hashedOriginDomain, accountToGuard)
+}
+
+// DiscardRecovery is a paid mutator transaction binding the contract method 0x51bd1f69.
+//
+// Solidity: function discardRecovery(bytes32 hashedOriginDomain) returns()
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorTransactor) DiscardRecovery(opts *bind.TransactOpts, hashedOriginDomain [32]byte) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.contract.Transact(opts, "discardRecovery", hashedOriginDomain)
+}
+
+// DiscardRecovery is a paid mutator transaction binding the contract method 0x51bd1f69.
+//
+// Solidity: function discardRecovery(bytes32 hashedOriginDomain) returns()
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorSession) DiscardRecovery(hashedOriginDomain [32]byte) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.Contract.DiscardRecovery(&_GuardianRecoveryValidator.TransactOpts, hashedOriginDomain)
+}
+
+// DiscardRecovery is a paid mutator transaction binding the contract method 0x51bd1f69.
+//
+// Solidity: function discardRecovery(bytes32 hashedOriginDomain) returns()
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorTransactorSession) DiscardRecovery(hashedOriginDomain [32]byte) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.Contract.DiscardRecovery(&_GuardianRecoveryValidator.TransactOpts, hashedOriginDomain)
+}
+
+// InitRecovery is a paid mutator transaction binding the contract method 0x236ad679.
+//
+// Solidity: function initRecovery(address accountToRecover, bytes32 hashedCredentialId, bytes32[2] rawPublicKey, bytes32 hashedOriginDomain) returns()
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorTransactor) InitRecovery(opts *bind.TransactOpts, accountToRecover common.Address, hashedCredentialId [32]byte, rawPublicKey [2][32]byte, hashedOriginDomain [32]byte) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.contract.Transact(opts, "initRecovery", accountToRecover, hashedCredentialId, rawPublicKey, hashedOriginDomain)
+}
+
+// InitRecovery is a paid mutator transaction binding the contract method 0x236ad679.
+//
+// Solidity: function initRecovery(address accountToRecover, bytes32 hashedCredentialId, bytes32[2] rawPublicKey, bytes32 hashedOriginDomain) returns()
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorSession) InitRecovery(accountToRecover common.Address, hashedCredentialId [32]byte, rawPublicKey [2][32]byte, hashedOriginDomain [32]byte) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.Contract.InitRecovery(&_GuardianRecoveryValidator.TransactOpts, accountToRecover, hashedCredentialId, rawPublicKey, hashedOriginDomain)
+}
+
+// InitRecovery is a paid mutator transaction binding the contract method 0x236ad679.
+//
+// Solidity: function initRecovery(address accountToRecover, bytes32 hashedCredentialId, bytes32[2] rawPublicKey, bytes32 hashedOriginDomain) returns()
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorTransactorSession) InitRecovery(accountToRecover common.Address, hashedCredentialId [32]byte, rawPublicKey [2][32]byte, hashedOriginDomain [32]byte) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.Contract.InitRecovery(&_GuardianRecoveryValidator.TransactOpts, accountToRecover, hashedCredentialId, rawPublicKey, hashedOriginDomain)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xc4d66de8.
+//
+// Solidity: function initialize(address _webAuthValidator) returns()
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorTransactor) Initialize(opts *bind.TransactOpts, _webAuthValidator common.Address) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.contract.Transact(opts, "initialize", _webAuthValidator)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xc4d66de8.
+//
+// Solidity: function initialize(address _webAuthValidator) returns()
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorSession) Initialize(_webAuthValidator common.Address) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.Contract.Initialize(&_GuardianRecoveryValidator.TransactOpts, _webAuthValidator)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xc4d66de8.
+//
+// Solidity: function initialize(address _webAuthValidator) returns()
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorTransactorSession) Initialize(_webAuthValidator common.Address) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.Contract.Initialize(&_GuardianRecoveryValidator.TransactOpts, _webAuthValidator)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes ) returns()
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorTransactor) OnInstall(opts *bind.TransactOpts, arg0 []byte) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.contract.Transact(opts, "onInstall", arg0)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes ) returns()
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorSession) OnInstall(arg0 []byte) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.Contract.OnInstall(&_GuardianRecoveryValidator.TransactOpts, arg0)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes ) returns()
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorTransactorSession) OnInstall(arg0 []byte) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.Contract.OnInstall(&_GuardianRecoveryValidator.TransactOpts, arg0)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes ) returns()
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorTransactor) OnUninstall(opts *bind.TransactOpts, arg0 []byte) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.contract.Transact(opts, "onUninstall", arg0)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes ) returns()
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorSession) OnUninstall(arg0 []byte) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.Contract.OnUninstall(&_GuardianRecoveryValidator.TransactOpts, arg0)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes ) returns()
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorTransactorSession) OnUninstall(arg0 []byte) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.Contract.OnUninstall(&_GuardianRecoveryValidator.TransactOpts, arg0)
+}
+
+// ProposeGuardian is a paid mutator transaction binding the contract method 0x9f5d29c9.
+//
+// Solidity: function proposeGuardian(bytes32 hashedOriginDomain, address newGuardian) returns()
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorTransactor) ProposeGuardian(opts *bind.TransactOpts, hashedOriginDomain [32]byte, newGuardian common.Address) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.contract.Transact(opts, "proposeGuardian", hashedOriginDomain, newGuardian)
+}
+
+// ProposeGuardian is a paid mutator transaction binding the contract method 0x9f5d29c9.
+//
+// Solidity: function proposeGuardian(bytes32 hashedOriginDomain, address newGuardian) returns()
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorSession) ProposeGuardian(hashedOriginDomain [32]byte, newGuardian common.Address) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.Contract.ProposeGuardian(&_GuardianRecoveryValidator.TransactOpts, hashedOriginDomain, newGuardian)
+}
+
+// ProposeGuardian is a paid mutator transaction binding the contract method 0x9f5d29c9.
+//
+// Solidity: function proposeGuardian(bytes32 hashedOriginDomain, address newGuardian) returns()
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorTransactorSession) ProposeGuardian(hashedOriginDomain [32]byte, newGuardian common.Address) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.Contract.ProposeGuardian(&_GuardianRecoveryValidator.TransactOpts, hashedOriginDomain, newGuardian)
+}
+
+// RemoveGuardian is a paid mutator transaction binding the contract method 0x3cab947d.
+//
+// Solidity: function removeGuardian(bytes32 hashedOriginDomain, address guardianToRemove) returns()
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorTransactor) RemoveGuardian(opts *bind.TransactOpts, hashedOriginDomain [32]byte, guardianToRemove common.Address) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.contract.Transact(opts, "removeGuardian", hashedOriginDomain, guardianToRemove)
+}
+
+// RemoveGuardian is a paid mutator transaction binding the contract method 0x3cab947d.
+//
+// Solidity: function removeGuardian(bytes32 hashedOriginDomain, address guardianToRemove) returns()
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorSession) RemoveGuardian(hashedOriginDomain [32]byte, guardianToRemove common.Address) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.Contract.RemoveGuardian(&_GuardianRecoveryValidator.TransactOpts, hashedOriginDomain, guardianToRemove)
+}
+
+// RemoveGuardian is a paid mutator transaction binding the contract method 0x3cab947d.
+//
+// Solidity: function removeGuardian(bytes32 hashedOriginDomain, address guardianToRemove) returns()
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorTransactorSession) RemoveGuardian(hashedOriginDomain [32]byte, guardianToRemove common.Address) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.Contract.RemoveGuardian(&_GuardianRecoveryValidator.TransactOpts, hashedOriginDomain, guardianToRemove)
+}
+
+// ValidateTransaction is a paid mutator transaction binding the contract method 0xbf1733f9.
+//
+// Solidity: function validateTransaction(bytes32 , (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) returns(bool)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorTransactor) ValidateTransaction(opts *bind.TransactOpts, arg0 [32]byte, transaction Transaction) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.contract.Transact(opts, "validateTransaction", arg0, transaction)
+}
+
+// ValidateTransaction is a paid mutator transaction binding the contract method 0xbf1733f9.
+//
+// Solidity: function validateTransaction(bytes32 , (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) returns(bool)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorSession) ValidateTransaction(arg0 [32]byte, transaction Transaction) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.Contract.ValidateTransaction(&_GuardianRecoveryValidator.TransactOpts, arg0, transaction)
+}
+
+// ValidateTransaction is a paid mutator transaction binding the contract method 0xbf1733f9.
+//
+// Solidity: function validateTransaction(bytes32 , (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) returns(bool)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorTransactorSession) ValidateTransaction(arg0 [32]byte, transaction Transaction) (*types.Transaction, error) {
+	return _GuardianRecoveryValidator.Contract.ValidateTransaction(&_GuardianRecoveryValidator.TransactOpts, arg0, transaction)
+}
+
+// GuardianRecoveryValidatorGuardianAddedIterator is returned from FilterGuardianAdded and is used to iterate over the raw logs and unpacked data for GuardianAdded events raised by the GuardianRecoveryValidator contract.
+type GuardianRecoveryValidatorGuardianAddedIterator struct {
+	Event *GuardianRecoveryValidatorGuardianAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GuardianRecoveryValidatorGuardianAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GuardianRecoveryValidatorGuardianAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GuardianRecoveryValidatorGuardianAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GuardianRecoveryValidatorGuardianAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GuardianRecoveryValidatorGuardianAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GuardianRecoveryValidatorGuardianAdded represents a GuardianAdded event raised by the GuardianRecoveryValidator contract.
+type GuardianRecoveryValidatorGuardianAdded struct {
+	Account            common.Address
+	HashedOriginDomain [32]byte
+	Guardian           common.Address
+	Raw                types.Log // Blockchain specific contextual infos
+}
+
+// FilterGuardianAdded is a free log retrieval operation binding the contract event 0x6aba2dccf4edc3319e24e776ffc5d7f8fa89456e0f15421abf316d28d427ed33.
+//
+// Solidity: event GuardianAdded(address indexed account, bytes32 indexed hashedOriginDomain, address indexed guardian)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) FilterGuardianAdded(opts *bind.FilterOpts, account []common.Address, hashedOriginDomain [][32]byte, guardian []common.Address) (*GuardianRecoveryValidatorGuardianAddedIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+	var guardianRule []interface{}
+	for _, guardianItem := range guardian {
+		guardianRule = append(guardianRule, guardianItem)
+	}
+
+	logs, sub, err := _GuardianRecoveryValidator.contract.FilterLogs(opts, "GuardianAdded", accountRule, hashedOriginDomainRule, guardianRule)
+	if err != nil {
+		return nil, err
+	}
+	return &GuardianRecoveryValidatorGuardianAddedIterator{contract: _GuardianRecoveryValidator.contract, event: "GuardianAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchGuardianAdded is a free log subscription operation binding the contract event 0x6aba2dccf4edc3319e24e776ffc5d7f8fa89456e0f15421abf316d28d427ed33.
+//
+// Solidity: event GuardianAdded(address indexed account, bytes32 indexed hashedOriginDomain, address indexed guardian)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) WatchGuardianAdded(opts *bind.WatchOpts, sink chan<- *GuardianRecoveryValidatorGuardianAdded, account []common.Address, hashedOriginDomain [][32]byte, guardian []common.Address) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+	var guardianRule []interface{}
+	for _, guardianItem := range guardian {
+		guardianRule = append(guardianRule, guardianItem)
+	}
+
+	logs, sub, err := _GuardianRecoveryValidator.contract.WatchLogs(opts, "GuardianAdded", accountRule, hashedOriginDomainRule, guardianRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GuardianRecoveryValidatorGuardianAdded)
+				if err := _GuardianRecoveryValidator.contract.UnpackLog(event, "GuardianAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseGuardianAdded is a log parse operation binding the contract event 0x6aba2dccf4edc3319e24e776ffc5d7f8fa89456e0f15421abf316d28d427ed33.
+//
+// Solidity: event GuardianAdded(address indexed account, bytes32 indexed hashedOriginDomain, address indexed guardian)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) ParseGuardianAdded(log types.Log) (*GuardianRecoveryValidatorGuardianAdded, error) {
+	event := new(GuardianRecoveryValidatorGuardianAdded)
+	if err := _GuardianRecoveryValidator.contract.UnpackLog(event, "GuardianAdded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// GuardianRecoveryValidatorGuardianProposedIterator is returned from FilterGuardianProposed and is used to iterate over the raw logs and unpacked data for GuardianProposed events raised by the GuardianRecoveryValidator contract.
+type GuardianRecoveryValidatorGuardianProposedIterator struct {
+	Event *GuardianRecoveryValidatorGuardianProposed // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GuardianRecoveryValidatorGuardianProposedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GuardianRecoveryValidatorGuardianProposed)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GuardianRecoveryValidatorGuardianProposed)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GuardianRecoveryValidatorGuardianProposedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GuardianRecoveryValidatorGuardianProposedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GuardianRecoveryValidatorGuardianProposed represents a GuardianProposed event raised by the GuardianRecoveryValidator contract.
+type GuardianRecoveryValidatorGuardianProposed struct {
+	Account            common.Address
+	HashedOriginDomain [32]byte
+	Guardian           common.Address
+	Raw                types.Log // Blockchain specific contextual infos
+}
+
+// FilterGuardianProposed is a free log retrieval operation binding the contract event 0x3deaf0877005efc7ea2c571de4f96ff33bf60c0b32e188f1fa32bab3da8b870e.
+//
+// Solidity: event GuardianProposed(address indexed account, bytes32 indexed hashedOriginDomain, address indexed guardian)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) FilterGuardianProposed(opts *bind.FilterOpts, account []common.Address, hashedOriginDomain [][32]byte, guardian []common.Address) (*GuardianRecoveryValidatorGuardianProposedIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+	var guardianRule []interface{}
+	for _, guardianItem := range guardian {
+		guardianRule = append(guardianRule, guardianItem)
+	}
+
+	logs, sub, err := _GuardianRecoveryValidator.contract.FilterLogs(opts, "GuardianProposed", accountRule, hashedOriginDomainRule, guardianRule)
+	if err != nil {
+		return nil, err
+	}
+	return &GuardianRecoveryValidatorGuardianProposedIterator{contract: _GuardianRecoveryValidator.contract, event: "GuardianProposed", logs: logs, sub: sub}, nil
+}
+
+// WatchGuardianProposed is a free log subscription operation binding the contract event 0x3deaf0877005efc7ea2c571de4f96ff33bf60c0b32e188f1fa32bab3da8b870e.
+//
+// Solidity: event GuardianProposed(address indexed account, bytes32 indexed hashedOriginDomain, address indexed guardian)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) WatchGuardianProposed(opts *bind.WatchOpts, sink chan<- *GuardianRecoveryValidatorGuardianProposed, account []common.Address, hashedOriginDomain [][32]byte, guardian []common.Address) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+	var guardianRule []interface{}
+	for _, guardianItem := range guardian {
+		guardianRule = append(guardianRule, guardianItem)
+	}
+
+	logs, sub, err := _GuardianRecoveryValidator.contract.WatchLogs(opts, "GuardianProposed", accountRule, hashedOriginDomainRule, guardianRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GuardianRecoveryValidatorGuardianProposed)
+				if err := _GuardianRecoveryValidator.contract.UnpackLog(event, "GuardianProposed", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseGuardianProposed is a log parse operation binding the contract event 0x3deaf0877005efc7ea2c571de4f96ff33bf60c0b32e188f1fa32bab3da8b870e.
+//
+// Solidity: event GuardianProposed(address indexed account, bytes32 indexed hashedOriginDomain, address indexed guardian)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) ParseGuardianProposed(log types.Log) (*GuardianRecoveryValidatorGuardianProposed, error) {
+	event := new(GuardianRecoveryValidatorGuardianProposed)
+	if err := _GuardianRecoveryValidator.contract.UnpackLog(event, "GuardianProposed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// GuardianRecoveryValidatorGuardianRemovedIterator is returned from FilterGuardianRemoved and is used to iterate over the raw logs and unpacked data for GuardianRemoved events raised by the GuardianRecoveryValidator contract.
+type GuardianRecoveryValidatorGuardianRemovedIterator struct {
+	Event *GuardianRecoveryValidatorGuardianRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GuardianRecoveryValidatorGuardianRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GuardianRecoveryValidatorGuardianRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GuardianRecoveryValidatorGuardianRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GuardianRecoveryValidatorGuardianRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GuardianRecoveryValidatorGuardianRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GuardianRecoveryValidatorGuardianRemoved represents a GuardianRemoved event raised by the GuardianRecoveryValidator contract.
+type GuardianRecoveryValidatorGuardianRemoved struct {
+	Account            common.Address
+	HashedOriginDomain [32]byte
+	Guardian           common.Address
+	Raw                types.Log // Blockchain specific contextual infos
+}
+
+// FilterGuardianRemoved is a free log retrieval operation binding the contract event 0xb9c57fa4d0e004062979bfe03380ddabcf23ec66f36e471ee5b5ab67349485b2.
+//
+// Solidity: event GuardianRemoved(address indexed account, bytes32 indexed hashedOriginDomain, address indexed guardian)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) FilterGuardianRemoved(opts *bind.FilterOpts, account []common.Address, hashedOriginDomain [][32]byte, guardian []common.Address) (*GuardianRecoveryValidatorGuardianRemovedIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+	var guardianRule []interface{}
+	for _, guardianItem := range guardian {
+		guardianRule = append(guardianRule, guardianItem)
+	}
+
+	logs, sub, err := _GuardianRecoveryValidator.contract.FilterLogs(opts, "GuardianRemoved", accountRule, hashedOriginDomainRule, guardianRule)
+	if err != nil {
+		return nil, err
+	}
+	return &GuardianRecoveryValidatorGuardianRemovedIterator{contract: _GuardianRecoveryValidator.contract, event: "GuardianRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchGuardianRemoved is a free log subscription operation binding the contract event 0xb9c57fa4d0e004062979bfe03380ddabcf23ec66f36e471ee5b5ab67349485b2.
+//
+// Solidity: event GuardianRemoved(address indexed account, bytes32 indexed hashedOriginDomain, address indexed guardian)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) WatchGuardianRemoved(opts *bind.WatchOpts, sink chan<- *GuardianRecoveryValidatorGuardianRemoved, account []common.Address, hashedOriginDomain [][32]byte, guardian []common.Address) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+	var guardianRule []interface{}
+	for _, guardianItem := range guardian {
+		guardianRule = append(guardianRule, guardianItem)
+	}
+
+	logs, sub, err := _GuardianRecoveryValidator.contract.WatchLogs(opts, "GuardianRemoved", accountRule, hashedOriginDomainRule, guardianRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GuardianRecoveryValidatorGuardianRemoved)
+				if err := _GuardianRecoveryValidator.contract.UnpackLog(event, "GuardianRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseGuardianRemoved is a log parse operation binding the contract event 0xb9c57fa4d0e004062979bfe03380ddabcf23ec66f36e471ee5b5ab67349485b2.
+//
+// Solidity: event GuardianRemoved(address indexed account, bytes32 indexed hashedOriginDomain, address indexed guardian)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) ParseGuardianRemoved(log types.Log) (*GuardianRecoveryValidatorGuardianRemoved, error) {
+	event := new(GuardianRecoveryValidatorGuardianRemoved)
+	if err := _GuardianRecoveryValidator.contract.UnpackLog(event, "GuardianRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// GuardianRecoveryValidatorHashedOriginDomainDisabledForAccountIterator is returned from FilterHashedOriginDomainDisabledForAccount and is used to iterate over the raw logs and unpacked data for HashedOriginDomainDisabledForAccount events raised by the GuardianRecoveryValidator contract.
+type GuardianRecoveryValidatorHashedOriginDomainDisabledForAccountIterator struct {
+	Event *GuardianRecoveryValidatorHashedOriginDomainDisabledForAccount // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GuardianRecoveryValidatorHashedOriginDomainDisabledForAccountIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GuardianRecoveryValidatorHashedOriginDomainDisabledForAccount)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GuardianRecoveryValidatorHashedOriginDomainDisabledForAccount)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GuardianRecoveryValidatorHashedOriginDomainDisabledForAccountIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GuardianRecoveryValidatorHashedOriginDomainDisabledForAccountIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GuardianRecoveryValidatorHashedOriginDomainDisabledForAccount represents a HashedOriginDomainDisabledForAccount event raised by the GuardianRecoveryValidator contract.
+type GuardianRecoveryValidatorHashedOriginDomainDisabledForAccount struct {
+	Account            common.Address
+	HashedOriginDomain [32]byte
+	Raw                types.Log // Blockchain specific contextual infos
+}
+
+// FilterHashedOriginDomainDisabledForAccount is a free log retrieval operation binding the contract event 0x1373f4151802c1c04091d06c3f13c1948e40afad22bd00382d4702808d0320eb.
+//
+// Solidity: event HashedOriginDomainDisabledForAccount(address indexed account, bytes32 indexed hashedOriginDomain)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) FilterHashedOriginDomainDisabledForAccount(opts *bind.FilterOpts, account []common.Address, hashedOriginDomain [][32]byte) (*GuardianRecoveryValidatorHashedOriginDomainDisabledForAccountIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+
+	logs, sub, err := _GuardianRecoveryValidator.contract.FilterLogs(opts, "HashedOriginDomainDisabledForAccount", accountRule, hashedOriginDomainRule)
+	if err != nil {
+		return nil, err
+	}
+	return &GuardianRecoveryValidatorHashedOriginDomainDisabledForAccountIterator{contract: _GuardianRecoveryValidator.contract, event: "HashedOriginDomainDisabledForAccount", logs: logs, sub: sub}, nil
+}
+
+// WatchHashedOriginDomainDisabledForAccount is a free log subscription operation binding the contract event 0x1373f4151802c1c04091d06c3f13c1948e40afad22bd00382d4702808d0320eb.
+//
+// Solidity: event HashedOriginDomainDisabledForAccount(address indexed account, bytes32 indexed hashedOriginDomain)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) WatchHashedOriginDomainDisabledForAccount(opts *bind.WatchOpts, sink chan<- *GuardianRecoveryValidatorHashedOriginDomainDisabledForAccount, account []common.Address, hashedOriginDomain [][32]byte) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+
+	logs, sub, err := _GuardianRecoveryValidator.contract.WatchLogs(opts, "HashedOriginDomainDisabledForAccount", accountRule, hashedOriginDomainRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GuardianRecoveryValidatorHashedOriginDomainDisabledForAccount)
+				if err := _GuardianRecoveryValidator.contract.UnpackLog(event, "HashedOriginDomainDisabledForAccount", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseHashedOriginDomainDisabledForAccount is a log parse operation binding the contract event 0x1373f4151802c1c04091d06c3f13c1948e40afad22bd00382d4702808d0320eb.
+//
+// Solidity: event HashedOriginDomainDisabledForAccount(address indexed account, bytes32 indexed hashedOriginDomain)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) ParseHashedOriginDomainDisabledForAccount(log types.Log) (*GuardianRecoveryValidatorHashedOriginDomainDisabledForAccount, error) {
+	event := new(GuardianRecoveryValidatorHashedOriginDomainDisabledForAccount)
+	if err := _GuardianRecoveryValidator.contract.UnpackLog(event, "HashedOriginDomainDisabledForAccount", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// GuardianRecoveryValidatorHashedOriginDomainEnabledForAccountIterator is returned from FilterHashedOriginDomainEnabledForAccount and is used to iterate over the raw logs and unpacked data for HashedOriginDomainEnabledForAccount events raised by the GuardianRecoveryValidator contract.
+type GuardianRecoveryValidatorHashedOriginDomainEnabledForAccountIterator struct {
+	Event *GuardianRecoveryValidatorHashedOriginDomainEnabledForAccount // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GuardianRecoveryValidatorHashedOriginDomainEnabledForAccountIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GuardianRecoveryValidatorHashedOriginDomainEnabledForAccount)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GuardianRecoveryValidatorHashedOriginDomainEnabledForAccount)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GuardianRecoveryValidatorHashedOriginDomainEnabledForAccountIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GuardianRecoveryValidatorHashedOriginDomainEnabledForAccountIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GuardianRecoveryValidatorHashedOriginDomainEnabledForAccount represents a HashedOriginDomainEnabledForAccount event raised by the GuardianRecoveryValidator contract.
+type GuardianRecoveryValidatorHashedOriginDomainEnabledForAccount struct {
+	Account            common.Address
+	HashedOriginDomain [32]byte
+	Raw                types.Log // Blockchain specific contextual infos
+}
+
+// FilterHashedOriginDomainEnabledForAccount is a free log retrieval operation binding the contract event 0x49e308297bf7e3373130f54d11e9944d094c586954301b5c7da3b918195c7580.
+//
+// Solidity: event HashedOriginDomainEnabledForAccount(address indexed account, bytes32 indexed hashedOriginDomain)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) FilterHashedOriginDomainEnabledForAccount(opts *bind.FilterOpts, account []common.Address, hashedOriginDomain [][32]byte) (*GuardianRecoveryValidatorHashedOriginDomainEnabledForAccountIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+
+	logs, sub, err := _GuardianRecoveryValidator.contract.FilterLogs(opts, "HashedOriginDomainEnabledForAccount", accountRule, hashedOriginDomainRule)
+	if err != nil {
+		return nil, err
+	}
+	return &GuardianRecoveryValidatorHashedOriginDomainEnabledForAccountIterator{contract: _GuardianRecoveryValidator.contract, event: "HashedOriginDomainEnabledForAccount", logs: logs, sub: sub}, nil
+}
+
+// WatchHashedOriginDomainEnabledForAccount is a free log subscription operation binding the contract event 0x49e308297bf7e3373130f54d11e9944d094c586954301b5c7da3b918195c7580.
+//
+// Solidity: event HashedOriginDomainEnabledForAccount(address indexed account, bytes32 indexed hashedOriginDomain)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) WatchHashedOriginDomainEnabledForAccount(opts *bind.WatchOpts, sink chan<- *GuardianRecoveryValidatorHashedOriginDomainEnabledForAccount, account []common.Address, hashedOriginDomain [][32]byte) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+
+	logs, sub, err := _GuardianRecoveryValidator.contract.WatchLogs(opts, "HashedOriginDomainEnabledForAccount", accountRule, hashedOriginDomainRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GuardianRecoveryValidatorHashedOriginDomainEnabledForAccount)
+				if err := _GuardianRecoveryValidator.contract.UnpackLog(event, "HashedOriginDomainEnabledForAccount", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseHashedOriginDomainEnabledForAccount is a log parse operation binding the contract event 0x49e308297bf7e3373130f54d11e9944d094c586954301b5c7da3b918195c7580.
+//
+// Solidity: event HashedOriginDomainEnabledForAccount(address indexed account, bytes32 indexed hashedOriginDomain)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) ParseHashedOriginDomainEnabledForAccount(log types.Log) (*GuardianRecoveryValidatorHashedOriginDomainEnabledForAccount, error) {
+	event := new(GuardianRecoveryValidatorHashedOriginDomainEnabledForAccount)
+	if err := _GuardianRecoveryValidator.contract.UnpackLog(event, "HashedOriginDomainEnabledForAccount", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// GuardianRecoveryValidatorInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the GuardianRecoveryValidator contract.
+type GuardianRecoveryValidatorInitializedIterator struct {
+	Event *GuardianRecoveryValidatorInitialized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GuardianRecoveryValidatorInitializedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GuardianRecoveryValidatorInitialized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GuardianRecoveryValidatorInitialized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GuardianRecoveryValidatorInitializedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GuardianRecoveryValidatorInitializedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GuardianRecoveryValidatorInitialized represents a Initialized event raised by the GuardianRecoveryValidator contract.
+type GuardianRecoveryValidatorInitialized struct {
+	Version uint8
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterInitialized is a free log retrieval operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) FilterInitialized(opts *bind.FilterOpts) (*GuardianRecoveryValidatorInitializedIterator, error) {
+
+	logs, sub, err := _GuardianRecoveryValidator.contract.FilterLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return &GuardianRecoveryValidatorInitializedIterator{contract: _GuardianRecoveryValidator.contract, event: "Initialized", logs: logs, sub: sub}, nil
+}
+
+// WatchInitialized is a free log subscription operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *GuardianRecoveryValidatorInitialized) (event.Subscription, error) {
+
+	logs, sub, err := _GuardianRecoveryValidator.contract.WatchLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GuardianRecoveryValidatorInitialized)
+				if err := _GuardianRecoveryValidator.contract.UnpackLog(event, "Initialized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseInitialized is a log parse operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) ParseInitialized(log types.Log) (*GuardianRecoveryValidatorInitialized, error) {
+	event := new(GuardianRecoveryValidatorInitialized)
+	if err := _GuardianRecoveryValidator.contract.UnpackLog(event, "Initialized", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// GuardianRecoveryValidatorRecoveryDiscardedIterator is returned from FilterRecoveryDiscarded and is used to iterate over the raw logs and unpacked data for RecoveryDiscarded events raised by the GuardianRecoveryValidator contract.
+type GuardianRecoveryValidatorRecoveryDiscardedIterator struct {
+	Event *GuardianRecoveryValidatorRecoveryDiscarded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GuardianRecoveryValidatorRecoveryDiscardedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GuardianRecoveryValidatorRecoveryDiscarded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GuardianRecoveryValidatorRecoveryDiscarded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GuardianRecoveryValidatorRecoveryDiscardedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GuardianRecoveryValidatorRecoveryDiscardedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GuardianRecoveryValidatorRecoveryDiscarded represents a RecoveryDiscarded event raised by the GuardianRecoveryValidator contract.
+type GuardianRecoveryValidatorRecoveryDiscarded struct {
+	Account            common.Address
+	HashedOriginDomain [32]byte
+	HashedCredentialId [32]byte
+	Raw                types.Log // Blockchain specific contextual infos
+}
+
+// FilterRecoveryDiscarded is a free log retrieval operation binding the contract event 0xa4e8705d9ef0c51657f9c64b028c7199ff3cd3ee5d057d6e1088e64580853d13.
+//
+// Solidity: event RecoveryDiscarded(address indexed account, bytes32 indexed hashedOriginDomain, bytes32 indexed hashedCredentialId)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) FilterRecoveryDiscarded(opts *bind.FilterOpts, account []common.Address, hashedOriginDomain [][32]byte, hashedCredentialId [][32]byte) (*GuardianRecoveryValidatorRecoveryDiscardedIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+	var hashedCredentialIdRule []interface{}
+	for _, hashedCredentialIdItem := range hashedCredentialId {
+		hashedCredentialIdRule = append(hashedCredentialIdRule, hashedCredentialIdItem)
+	}
+
+	logs, sub, err := _GuardianRecoveryValidator.contract.FilterLogs(opts, "RecoveryDiscarded", accountRule, hashedOriginDomainRule, hashedCredentialIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &GuardianRecoveryValidatorRecoveryDiscardedIterator{contract: _GuardianRecoveryValidator.contract, event: "RecoveryDiscarded", logs: logs, sub: sub}, nil
+}
+
+// WatchRecoveryDiscarded is a free log subscription operation binding the contract event 0xa4e8705d9ef0c51657f9c64b028c7199ff3cd3ee5d057d6e1088e64580853d13.
+//
+// Solidity: event RecoveryDiscarded(address indexed account, bytes32 indexed hashedOriginDomain, bytes32 indexed hashedCredentialId)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) WatchRecoveryDiscarded(opts *bind.WatchOpts, sink chan<- *GuardianRecoveryValidatorRecoveryDiscarded, account []common.Address, hashedOriginDomain [][32]byte, hashedCredentialId [][32]byte) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+	var hashedCredentialIdRule []interface{}
+	for _, hashedCredentialIdItem := range hashedCredentialId {
+		hashedCredentialIdRule = append(hashedCredentialIdRule, hashedCredentialIdItem)
+	}
+
+	logs, sub, err := _GuardianRecoveryValidator.contract.WatchLogs(opts, "RecoveryDiscarded", accountRule, hashedOriginDomainRule, hashedCredentialIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GuardianRecoveryValidatorRecoveryDiscarded)
+				if err := _GuardianRecoveryValidator.contract.UnpackLog(event, "RecoveryDiscarded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRecoveryDiscarded is a log parse operation binding the contract event 0xa4e8705d9ef0c51657f9c64b028c7199ff3cd3ee5d057d6e1088e64580853d13.
+//
+// Solidity: event RecoveryDiscarded(address indexed account, bytes32 indexed hashedOriginDomain, bytes32 indexed hashedCredentialId)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) ParseRecoveryDiscarded(log types.Log) (*GuardianRecoveryValidatorRecoveryDiscarded, error) {
+	event := new(GuardianRecoveryValidatorRecoveryDiscarded)
+	if err := _GuardianRecoveryValidator.contract.UnpackLog(event, "RecoveryDiscarded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// GuardianRecoveryValidatorRecoveryFinishedIterator is returned from FilterRecoveryFinished and is used to iterate over the raw logs and unpacked data for RecoveryFinished events raised by the GuardianRecoveryValidator contract.
+type GuardianRecoveryValidatorRecoveryFinishedIterator struct {
+	Event *GuardianRecoveryValidatorRecoveryFinished // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GuardianRecoveryValidatorRecoveryFinishedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GuardianRecoveryValidatorRecoveryFinished)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GuardianRecoveryValidatorRecoveryFinished)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GuardianRecoveryValidatorRecoveryFinishedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GuardianRecoveryValidatorRecoveryFinishedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GuardianRecoveryValidatorRecoveryFinished represents a RecoveryFinished event raised by the GuardianRecoveryValidator contract.
+type GuardianRecoveryValidatorRecoveryFinished struct {
+	Account            common.Address
+	HashedOriginDomain [32]byte
+	HashedCredentialId [32]byte
+	Raw                types.Log // Blockchain specific contextual infos
+}
+
+// FilterRecoveryFinished is a free log retrieval operation binding the contract event 0x122f699d3998d7d483d87a65abbdba44780a412ca03b283c5c6fc45b6d7d94d2.
+//
+// Solidity: event RecoveryFinished(address indexed account, bytes32 indexed hashedOriginDomain, bytes32 indexed hashedCredentialId)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) FilterRecoveryFinished(opts *bind.FilterOpts, account []common.Address, hashedOriginDomain [][32]byte, hashedCredentialId [][32]byte) (*GuardianRecoveryValidatorRecoveryFinishedIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+	var hashedCredentialIdRule []interface{}
+	for _, hashedCredentialIdItem := range hashedCredentialId {
+		hashedCredentialIdRule = append(hashedCredentialIdRule, hashedCredentialIdItem)
+	}
+
+	logs, sub, err := _GuardianRecoveryValidator.contract.FilterLogs(opts, "RecoveryFinished", accountRule, hashedOriginDomainRule, hashedCredentialIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &GuardianRecoveryValidatorRecoveryFinishedIterator{contract: _GuardianRecoveryValidator.contract, event: "RecoveryFinished", logs: logs, sub: sub}, nil
+}
+
+// WatchRecoveryFinished is a free log subscription operation binding the contract event 0x122f699d3998d7d483d87a65abbdba44780a412ca03b283c5c6fc45b6d7d94d2.
+//
+// Solidity: event RecoveryFinished(address indexed account, bytes32 indexed hashedOriginDomain, bytes32 indexed hashedCredentialId)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) WatchRecoveryFinished(opts *bind.WatchOpts, sink chan<- *GuardianRecoveryValidatorRecoveryFinished, account []common.Address, hashedOriginDomain [][32]byte, hashedCredentialId [][32]byte) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+	var hashedCredentialIdRule []interface{}
+	for _, hashedCredentialIdItem := range hashedCredentialId {
+		hashedCredentialIdRule = append(hashedCredentialIdRule, hashedCredentialIdItem)
+	}
+
+	logs, sub, err := _GuardianRecoveryValidator.contract.WatchLogs(opts, "RecoveryFinished", accountRule, hashedOriginDomainRule, hashedCredentialIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GuardianRecoveryValidatorRecoveryFinished)
+				if err := _GuardianRecoveryValidator.contract.UnpackLog(event, "RecoveryFinished", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRecoveryFinished is a log parse operation binding the contract event 0x122f699d3998d7d483d87a65abbdba44780a412ca03b283c5c6fc45b6d7d94d2.
+//
+// Solidity: event RecoveryFinished(address indexed account, bytes32 indexed hashedOriginDomain, bytes32 indexed hashedCredentialId)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) ParseRecoveryFinished(log types.Log) (*GuardianRecoveryValidatorRecoveryFinished, error) {
+	event := new(GuardianRecoveryValidatorRecoveryFinished)
+	if err := _GuardianRecoveryValidator.contract.UnpackLog(event, "RecoveryFinished", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// GuardianRecoveryValidatorRecoveryInitiatedIterator is returned from FilterRecoveryInitiated and is used to iterate over the raw logs and unpacked data for RecoveryInitiated events raised by the GuardianRecoveryValidator contract.
+type GuardianRecoveryValidatorRecoveryInitiatedIterator struct {
+	Event *GuardianRecoveryValidatorRecoveryInitiated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *GuardianRecoveryValidatorRecoveryInitiatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(GuardianRecoveryValidatorRecoveryInitiated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(GuardianRecoveryValidatorRecoveryInitiated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *GuardianRecoveryValidatorRecoveryInitiatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *GuardianRecoveryValidatorRecoveryInitiatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// GuardianRecoveryValidatorRecoveryInitiated represents a RecoveryInitiated event raised by the GuardianRecoveryValidator contract.
+type GuardianRecoveryValidatorRecoveryInitiated struct {
+	Account            common.Address
+	HashedOriginDomain [32]byte
+	HashedCredentialId [32]byte
+	Guardian           common.Address
+	Raw                types.Log // Blockchain specific contextual infos
+}
+
+// FilterRecoveryInitiated is a free log retrieval operation binding the contract event 0x750203e1c6151c9136eca3be6c61d060ea236395244e97c72ee3735c131c3802.
+//
+// Solidity: event RecoveryInitiated(address indexed account, bytes32 indexed hashedOriginDomain, bytes32 indexed hashedCredentialId, address guardian)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) FilterRecoveryInitiated(opts *bind.FilterOpts, account []common.Address, hashedOriginDomain [][32]byte, hashedCredentialId [][32]byte) (*GuardianRecoveryValidatorRecoveryInitiatedIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+	var hashedCredentialIdRule []interface{}
+	for _, hashedCredentialIdItem := range hashedCredentialId {
+		hashedCredentialIdRule = append(hashedCredentialIdRule, hashedCredentialIdItem)
+	}
+
+	logs, sub, err := _GuardianRecoveryValidator.contract.FilterLogs(opts, "RecoveryInitiated", accountRule, hashedOriginDomainRule, hashedCredentialIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &GuardianRecoveryValidatorRecoveryInitiatedIterator{contract: _GuardianRecoveryValidator.contract, event: "RecoveryInitiated", logs: logs, sub: sub}, nil
+}
+
+// WatchRecoveryInitiated is a free log subscription operation binding the contract event 0x750203e1c6151c9136eca3be6c61d060ea236395244e97c72ee3735c131c3802.
+//
+// Solidity: event RecoveryInitiated(address indexed account, bytes32 indexed hashedOriginDomain, bytes32 indexed hashedCredentialId, address guardian)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) WatchRecoveryInitiated(opts *bind.WatchOpts, sink chan<- *GuardianRecoveryValidatorRecoveryInitiated, account []common.Address, hashedOriginDomain [][32]byte, hashedCredentialId [][32]byte) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var hashedOriginDomainRule []interface{}
+	for _, hashedOriginDomainItem := range hashedOriginDomain {
+		hashedOriginDomainRule = append(hashedOriginDomainRule, hashedOriginDomainItem)
+	}
+	var hashedCredentialIdRule []interface{}
+	for _, hashedCredentialIdItem := range hashedCredentialId {
+		hashedCredentialIdRule = append(hashedCredentialIdRule, hashedCredentialIdItem)
+	}
+
+	logs, sub, err := _GuardianRecoveryValidator.contract.WatchLogs(opts, "RecoveryInitiated", accountRule, hashedOriginDomainRule, hashedCredentialIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(GuardianRecoveryValidatorRecoveryInitiated)
+				if err := _GuardianRecoveryValidator.contract.UnpackLog(event, "RecoveryInitiated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRecoveryInitiated is a log parse operation binding the contract event 0x750203e1c6151c9136eca3be6c61d060ea236395244e97c72ee3735c131c3802.
+//
+// Solidity: event RecoveryInitiated(address indexed account, bytes32 indexed hashedOriginDomain, bytes32 indexed hashedCredentialId, address guardian)
+func (_GuardianRecoveryValidator *GuardianRecoveryValidatorFilterer) ParseRecoveryInitiated(log types.Log) (*GuardianRecoveryValidatorRecoveryInitiated, error) {
+	event := new(GuardianRecoveryValidatorRecoveryInitiated)
+	if err := _GuardianRecoveryValidator.contract.UnpackLog(event, "RecoveryInitiated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts/zksyncsso/validators/sessionkeyvalidator/sessionkeyvalidator.go
+++ b/contracts/zksyncsso/validators/sessionkeyvalidator/sessionkeyvalidator.go
@@ -1,0 +1,846 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package sessionkeyvalidator
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// SessionLibCallSpec is an auto generated low-level Go binding around an user-defined struct.
+type SessionLibCallSpec struct {
+	Target         common.Address
+	Selector       [4]byte
+	MaxValuePerUse *big.Int
+	ValueLimit     SessionLibUsageLimit
+	Constraints    []SessionLibConstraint
+}
+
+// SessionLibConstraint is an auto generated low-level Go binding around an user-defined struct.
+type SessionLibConstraint struct {
+	Condition uint8
+	Index     uint64
+	RefValue  [32]byte
+	Limit     SessionLibUsageLimit
+}
+
+// SessionLibLimitState is an auto generated low-level Go binding around an user-defined struct.
+type SessionLibLimitState struct {
+	Remaining *big.Int
+	Target    common.Address
+	Selector  [4]byte
+	Index     *big.Int
+}
+
+// SessionLibSessionSpec is an auto generated low-level Go binding around an user-defined struct.
+type SessionLibSessionSpec struct {
+	Signer           common.Address
+	ExpiresAt        *big.Int
+	FeeLimit         SessionLibUsageLimit
+	CallPolicies     []SessionLibCallSpec
+	TransferPolicies []SessionLibTransferSpec
+}
+
+// SessionLibSessionState is an auto generated low-level Go binding around an user-defined struct.
+type SessionLibSessionState struct {
+	Status        uint8
+	FeesRemaining *big.Int
+	TransferValue []SessionLibLimitState
+	CallValue     []SessionLibLimitState
+	CallParams    []SessionLibLimitState
+}
+
+// SessionLibTransferSpec is an auto generated low-level Go binding around an user-defined struct.
+type SessionLibTransferSpec struct {
+	Target         common.Address
+	MaxValuePerUse *big.Int
+	ValueLimit     SessionLibUsageLimit
+}
+
+// SessionLibUsageLimit is an auto generated low-level Go binding around an user-defined struct.
+type SessionLibUsageLimit struct {
+	LimitType uint8
+	Limit     *big.Int
+	Period    *big.Int
+}
+
+// Transaction is an auto generated low-level Go binding around an user-defined struct.
+type Transaction struct {
+	TxType                 *big.Int
+	From                   *big.Int
+	To                     *big.Int
+	GasLimit               *big.Int
+	GasPerPubdataByteLimit *big.Int
+	MaxFeePerGas           *big.Int
+	MaxPriorityFeePerGas   *big.Int
+	Paymaster              *big.Int
+	Nonce                  *big.Int
+	Value                  *big.Int
+	Reserved               [4]*big.Int
+	Data                   []byte
+	Signature              []byte
+	FactoryDeps            [][32]byte
+	PaymasterInput         []byte
+	ReservedDynamic        []byte
+}
+
+// SessionKeyValidatorMetaData contains all meta data concerning the SessionKeyValidator contract.
+var SessionKeyValidatorMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"ADDRESS_CAST_OVERFLOW\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"input\",\"type\":\"bytes\"}],\"name\":\"INVALID_PAYMASTER_INPUT\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"notInitialized\",\"type\":\"address\"}],\"name\":\"NOT_FROM_INITIALIZED_ACCOUNT\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"chainId\",\"type\":\"uint256\"}],\"name\":\"NO_TIMESTAMP_ASSERTER\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"allowance\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxAllowance\",\"type\":\"uint256\"},{\"internalType\":\"uint64\",\"name\":\"period\",\"type\":\"uint64\"}],\"name\":\"SESSION_ALLOWANCE_EXCEEDED\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"sessionHash\",\"type\":\"bytes32\"}],\"name\":\"SESSION_ALREADY_EXISTS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"},{\"internalType\":\"bytes4\",\"name\":\"selector\",\"type\":\"bytes4\"}],\"name\":\"SESSION_CALL_POLICY_VIOLATED\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"param\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"refValue\",\"type\":\"bytes32\"},{\"internalType\":\"uint8\",\"name\":\"condition\",\"type\":\"uint8\"}],\"name\":\"SESSION_CONDITION_FAILED\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"expiresAt\",\"type\":\"uint256\"}],\"name\":\"SESSION_EXPIRES_TOO_SOON\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"actualLength\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expectedMinimumLength\",\"type\":\"uint256\"}],\"name\":\"SESSION_INVALID_DATA_LENGTH\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"recovered\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"expected\",\"type\":\"address\"}],\"name\":\"SESSION_INVALID_SIGNER\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"lifetimeUsage\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxUsage\",\"type\":\"uint256\"}],\"name\":\"SESSION_LIFETIME_USAGE_EXCEEDED\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"usedValue\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxValuePerUse\",\"type\":\"uint256\"}],\"name\":\"SESSION_MAX_VALUE_EXCEEDED\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"SESSION_NOT_ACTIVE\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"}],\"name\":\"SESSION_TRANSFER_POLICY_VIOLATED\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"SESSION_UNLIMITED_FEES\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"SESSION_ZERO_SIGNER\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"openSessions\",\"type\":\"uint256\"}],\"name\":\"UNINSTALL_WITH_OPEN_SESSIONS\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"sessionHash\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"address\",\"name\":\"signer\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"expiresAt\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"enumSessionLib.LimitType\",\"name\":\"limitType\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"limit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"period\",\"type\":\"uint256\"}],\"internalType\":\"structSessionLib.UsageLimit\",\"name\":\"feeLimit\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"},{\"internalType\":\"bytes4\",\"name\":\"selector\",\"type\":\"bytes4\"},{\"internalType\":\"uint256\",\"name\":\"maxValuePerUse\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"enumSessionLib.LimitType\",\"name\":\"limitType\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"limit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"period\",\"type\":\"uint256\"}],\"internalType\":\"structSessionLib.UsageLimit\",\"name\":\"valueLimit\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"enumSessionLib.Condition\",\"name\":\"condition\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"index\",\"type\":\"uint64\"},{\"internalType\":\"bytes32\",\"name\":\"refValue\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"enumSessionLib.LimitType\",\"name\":\"limitType\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"limit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"period\",\"type\":\"uint256\"}],\"internalType\":\"structSessionLib.UsageLimit\",\"name\":\"limit\",\"type\":\"tuple\"}],\"internalType\":\"structSessionLib.Constraint[]\",\"name\":\"constraints\",\"type\":\"tuple[]\"}],\"internalType\":\"structSessionLib.CallSpec[]\",\"name\":\"callPolicies\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"maxValuePerUse\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"enumSessionLib.LimitType\",\"name\":\"limitType\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"limit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"period\",\"type\":\"uint256\"}],\"internalType\":\"structSessionLib.UsageLimit\",\"name\":\"valueLimit\",\"type\":\"tuple\"}],\"internalType\":\"structSessionLib.TransferSpec[]\",\"name\":\"transferPolicies\",\"type\":\"tuple[]\"}],\"indexed\":false,\"internalType\":\"structSessionLib.SessionSpec\",\"name\":\"sessionSpec\",\"type\":\"tuple\"}],\"name\":\"SessionCreated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"sessionHash\",\"type\":\"bytes32\"}],\"name\":\"SessionRevoked\",\"type\":\"event\"},{\"inputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"signer\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"expiresAt\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"enumSessionLib.LimitType\",\"name\":\"limitType\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"limit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"period\",\"type\":\"uint256\"}],\"internalType\":\"structSessionLib.UsageLimit\",\"name\":\"feeLimit\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"},{\"internalType\":\"bytes4\",\"name\":\"selector\",\"type\":\"bytes4\"},{\"internalType\":\"uint256\",\"name\":\"maxValuePerUse\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"enumSessionLib.LimitType\",\"name\":\"limitType\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"limit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"period\",\"type\":\"uint256\"}],\"internalType\":\"structSessionLib.UsageLimit\",\"name\":\"valueLimit\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"enumSessionLib.Condition\",\"name\":\"condition\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"index\",\"type\":\"uint64\"},{\"internalType\":\"bytes32\",\"name\":\"refValue\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"enumSessionLib.LimitType\",\"name\":\"limitType\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"limit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"period\",\"type\":\"uint256\"}],\"internalType\":\"structSessionLib.UsageLimit\",\"name\":\"limit\",\"type\":\"tuple\"}],\"internalType\":\"structSessionLib.Constraint[]\",\"name\":\"constraints\",\"type\":\"tuple[]\"}],\"internalType\":\"structSessionLib.CallSpec[]\",\"name\":\"callPolicies\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"maxValuePerUse\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"enumSessionLib.LimitType\",\"name\":\"limitType\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"limit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"period\",\"type\":\"uint256\"}],\"internalType\":\"structSessionLib.UsageLimit\",\"name\":\"valueLimit\",\"type\":\"tuple\"}],\"internalType\":\"structSessionLib.TransferSpec[]\",\"name\":\"transferPolicies\",\"type\":\"tuple[]\"}],\"internalType\":\"structSessionLib.SessionSpec\",\"name\":\"sessionSpec\",\"type\":\"tuple\"}],\"name\":\"createSession\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"smartAccount\",\"type\":\"address\"}],\"name\":\"isInitialized\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"onInstall\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"onUninstall\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"sessionHash\",\"type\":\"bytes32\"}],\"name\":\"revokeKey\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32[]\",\"name\":\"sessionHashes\",\"type\":\"bytes32[]\"}],\"name\":\"revokeKeys\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"components\":[{\"internalType\":\"address\",\"name\":\"signer\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"expiresAt\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"enumSessionLib.LimitType\",\"name\":\"limitType\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"limit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"period\",\"type\":\"uint256\"}],\"internalType\":\"structSessionLib.UsageLimit\",\"name\":\"feeLimit\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"},{\"internalType\":\"bytes4\",\"name\":\"selector\",\"type\":\"bytes4\"},{\"internalType\":\"uint256\",\"name\":\"maxValuePerUse\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"enumSessionLib.LimitType\",\"name\":\"limitType\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"limit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"period\",\"type\":\"uint256\"}],\"internalType\":\"structSessionLib.UsageLimit\",\"name\":\"valueLimit\",\"type\":\"tuple\"},{\"components\":[{\"internalType\":\"enumSessionLib.Condition\",\"name\":\"condition\",\"type\":\"uint8\"},{\"internalType\":\"uint64\",\"name\":\"index\",\"type\":\"uint64\"},{\"internalType\":\"bytes32\",\"name\":\"refValue\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"enumSessionLib.LimitType\",\"name\":\"limitType\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"limit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"period\",\"type\":\"uint256\"}],\"internalType\":\"structSessionLib.UsageLimit\",\"name\":\"limit\",\"type\":\"tuple\"}],\"internalType\":\"structSessionLib.Constraint[]\",\"name\":\"constraints\",\"type\":\"tuple[]\"}],\"internalType\":\"structSessionLib.CallSpec[]\",\"name\":\"callPolicies\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"maxValuePerUse\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"enumSessionLib.LimitType\",\"name\":\"limitType\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"limit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"period\",\"type\":\"uint256\"}],\"internalType\":\"structSessionLib.UsageLimit\",\"name\":\"valueLimit\",\"type\":\"tuple\"}],\"internalType\":\"structSessionLib.TransferSpec[]\",\"name\":\"transferPolicies\",\"type\":\"tuple[]\"}],\"internalType\":\"structSessionLib.SessionSpec\",\"name\":\"spec\",\"type\":\"tuple\"}],\"name\":\"sessionState\",\"outputs\":[{\"components\":[{\"internalType\":\"enumSessionLib.Status\",\"name\":\"status\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"feesRemaining\",\"type\":\"uint256\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"remaining\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"},{\"internalType\":\"bytes4\",\"name\":\"selector\",\"type\":\"bytes4\"},{\"internalType\":\"uint256\",\"name\":\"index\",\"type\":\"uint256\"}],\"internalType\":\"structSessionLib.LimitState[]\",\"name\":\"transferValue\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"remaining\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"},{\"internalType\":\"bytes4\",\"name\":\"selector\",\"type\":\"bytes4\"},{\"internalType\":\"uint256\",\"name\":\"index\",\"type\":\"uint256\"}],\"internalType\":\"structSessionLib.LimitState[]\",\"name\":\"callValue\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"remaining\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"},{\"internalType\":\"bytes4\",\"name\":\"selector\",\"type\":\"bytes4\"},{\"internalType\":\"uint256\",\"name\":\"index\",\"type\":\"uint256\"}],\"internalType\":\"structSessionLib.LimitState[]\",\"name\":\"callParams\",\"type\":\"tuple[]\"}],\"internalType\":\"structSessionLib.SessionState\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"sessionHash\",\"type\":\"bytes32\"}],\"name\":\"sessionStatus\",\"outputs\":[{\"internalType\":\"enumSessionLib.Status\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"}],\"name\":\"supportsInterface\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"}],\"name\":\"validateSignature\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"signedHash\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[]\",\"name\":\"factoryDeps\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"reservedDynamic\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"transaction\",\"type\":\"tuple\"}],\"name\":\"validateTransaction\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+}
+
+// SessionKeyValidatorABI is the input ABI used to generate the binding from.
+// Deprecated: Use SessionKeyValidatorMetaData.ABI instead.
+var SessionKeyValidatorABI = SessionKeyValidatorMetaData.ABI
+
+// SessionKeyValidator is an auto generated Go binding around an Ethereum contract.
+type SessionKeyValidator struct {
+	SessionKeyValidatorCaller     // Read-only binding to the contract
+	SessionKeyValidatorTransactor // Write-only binding to the contract
+	SessionKeyValidatorFilterer   // Log filterer for contract events
+}
+
+// SessionKeyValidatorCaller is an auto generated read-only Go binding around an Ethereum contract.
+type SessionKeyValidatorCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// SessionKeyValidatorTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type SessionKeyValidatorTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// SessionKeyValidatorFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type SessionKeyValidatorFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// SessionKeyValidatorSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type SessionKeyValidatorSession struct {
+	Contract     *SessionKeyValidator // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts        // Call options to use throughout this session
+	TransactOpts bind.TransactOpts    // Transaction auth options to use throughout this session
+}
+
+// SessionKeyValidatorCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type SessionKeyValidatorCallerSession struct {
+	Contract *SessionKeyValidatorCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts              // Call options to use throughout this session
+}
+
+// SessionKeyValidatorTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type SessionKeyValidatorTransactorSession struct {
+	Contract     *SessionKeyValidatorTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts              // Transaction auth options to use throughout this session
+}
+
+// SessionKeyValidatorRaw is an auto generated low-level Go binding around an Ethereum contract.
+type SessionKeyValidatorRaw struct {
+	Contract *SessionKeyValidator // Generic contract binding to access the raw methods on
+}
+
+// SessionKeyValidatorCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type SessionKeyValidatorCallerRaw struct {
+	Contract *SessionKeyValidatorCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// SessionKeyValidatorTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type SessionKeyValidatorTransactorRaw struct {
+	Contract *SessionKeyValidatorTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewSessionKeyValidator creates a new instance of SessionKeyValidator, bound to a specific deployed contract.
+func NewSessionKeyValidator(address common.Address, backend bind.ContractBackend) (*SessionKeyValidator, error) {
+	contract, err := bindSessionKeyValidator(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &SessionKeyValidator{SessionKeyValidatorCaller: SessionKeyValidatorCaller{contract: contract}, SessionKeyValidatorTransactor: SessionKeyValidatorTransactor{contract: contract}, SessionKeyValidatorFilterer: SessionKeyValidatorFilterer{contract: contract}}, nil
+}
+
+// NewSessionKeyValidatorCaller creates a new read-only instance of SessionKeyValidator, bound to a specific deployed contract.
+func NewSessionKeyValidatorCaller(address common.Address, caller bind.ContractCaller) (*SessionKeyValidatorCaller, error) {
+	contract, err := bindSessionKeyValidator(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &SessionKeyValidatorCaller{contract: contract}, nil
+}
+
+// NewSessionKeyValidatorTransactor creates a new write-only instance of SessionKeyValidator, bound to a specific deployed contract.
+func NewSessionKeyValidatorTransactor(address common.Address, transactor bind.ContractTransactor) (*SessionKeyValidatorTransactor, error) {
+	contract, err := bindSessionKeyValidator(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &SessionKeyValidatorTransactor{contract: contract}, nil
+}
+
+// NewSessionKeyValidatorFilterer creates a new log filterer instance of SessionKeyValidator, bound to a specific deployed contract.
+func NewSessionKeyValidatorFilterer(address common.Address, filterer bind.ContractFilterer) (*SessionKeyValidatorFilterer, error) {
+	contract, err := bindSessionKeyValidator(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &SessionKeyValidatorFilterer{contract: contract}, nil
+}
+
+// bindSessionKeyValidator binds a generic wrapper to an already deployed contract.
+func bindSessionKeyValidator(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := SessionKeyValidatorMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_SessionKeyValidator *SessionKeyValidatorRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _SessionKeyValidator.Contract.SessionKeyValidatorCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_SessionKeyValidator *SessionKeyValidatorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _SessionKeyValidator.Contract.SessionKeyValidatorTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_SessionKeyValidator *SessionKeyValidatorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _SessionKeyValidator.Contract.SessionKeyValidatorTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_SessionKeyValidator *SessionKeyValidatorCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _SessionKeyValidator.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_SessionKeyValidator *SessionKeyValidatorTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _SessionKeyValidator.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_SessionKeyValidator *SessionKeyValidatorTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _SessionKeyValidator.Contract.contract.Transact(opts, method, params...)
+}
+
+// IsInitialized is a free data retrieval call binding the contract method 0xd60b347f.
+//
+// Solidity: function isInitialized(address smartAccount) view returns(bool)
+func (_SessionKeyValidator *SessionKeyValidatorCaller) IsInitialized(opts *bind.CallOpts, smartAccount common.Address) (bool, error) {
+	var out []interface{}
+	err := _SessionKeyValidator.contract.Call(opts, &out, "isInitialized", smartAccount)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsInitialized is a free data retrieval call binding the contract method 0xd60b347f.
+//
+// Solidity: function isInitialized(address smartAccount) view returns(bool)
+func (_SessionKeyValidator *SessionKeyValidatorSession) IsInitialized(smartAccount common.Address) (bool, error) {
+	return _SessionKeyValidator.Contract.IsInitialized(&_SessionKeyValidator.CallOpts, smartAccount)
+}
+
+// IsInitialized is a free data retrieval call binding the contract method 0xd60b347f.
+//
+// Solidity: function isInitialized(address smartAccount) view returns(bool)
+func (_SessionKeyValidator *SessionKeyValidatorCallerSession) IsInitialized(smartAccount common.Address) (bool, error) {
+	return _SessionKeyValidator.Contract.IsInitialized(&_SessionKeyValidator.CallOpts, smartAccount)
+}
+
+// SessionState is a free data retrieval call binding the contract method 0xb6d75019.
+//
+// Solidity: function sessionState(address account, (address,uint256,(uint8,uint256,uint256),(address,bytes4,uint256,(uint8,uint256,uint256),(uint8,uint64,bytes32,(uint8,uint256,uint256))[])[],(address,uint256,(uint8,uint256,uint256))[]) spec) view returns((uint8,uint256,(uint256,address,bytes4,uint256)[],(uint256,address,bytes4,uint256)[],(uint256,address,bytes4,uint256)[]))
+func (_SessionKeyValidator *SessionKeyValidatorCaller) SessionState(opts *bind.CallOpts, account common.Address, spec SessionLibSessionSpec) (SessionLibSessionState, error) {
+	var out []interface{}
+	err := _SessionKeyValidator.contract.Call(opts, &out, "sessionState", account, spec)
+
+	if err != nil {
+		return *new(SessionLibSessionState), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(SessionLibSessionState)).(*SessionLibSessionState)
+
+	return out0, err
+
+}
+
+// SessionState is a free data retrieval call binding the contract method 0xb6d75019.
+//
+// Solidity: function sessionState(address account, (address,uint256,(uint8,uint256,uint256),(address,bytes4,uint256,(uint8,uint256,uint256),(uint8,uint64,bytes32,(uint8,uint256,uint256))[])[],(address,uint256,(uint8,uint256,uint256))[]) spec) view returns((uint8,uint256,(uint256,address,bytes4,uint256)[],(uint256,address,bytes4,uint256)[],(uint256,address,bytes4,uint256)[]))
+func (_SessionKeyValidator *SessionKeyValidatorSession) SessionState(account common.Address, spec SessionLibSessionSpec) (SessionLibSessionState, error) {
+	return _SessionKeyValidator.Contract.SessionState(&_SessionKeyValidator.CallOpts, account, spec)
+}
+
+// SessionState is a free data retrieval call binding the contract method 0xb6d75019.
+//
+// Solidity: function sessionState(address account, (address,uint256,(uint8,uint256,uint256),(address,bytes4,uint256,(uint8,uint256,uint256),(uint8,uint64,bytes32,(uint8,uint256,uint256))[])[],(address,uint256,(uint8,uint256,uint256))[]) spec) view returns((uint8,uint256,(uint256,address,bytes4,uint256)[],(uint256,address,bytes4,uint256)[],(uint256,address,bytes4,uint256)[]))
+func (_SessionKeyValidator *SessionKeyValidatorCallerSession) SessionState(account common.Address, spec SessionLibSessionSpec) (SessionLibSessionState, error) {
+	return _SessionKeyValidator.Contract.SessionState(&_SessionKeyValidator.CallOpts, account, spec)
+}
+
+// SessionStatus is a free data retrieval call binding the contract method 0x59130708.
+//
+// Solidity: function sessionStatus(address account, bytes32 sessionHash) view returns(uint8)
+func (_SessionKeyValidator *SessionKeyValidatorCaller) SessionStatus(opts *bind.CallOpts, account common.Address, sessionHash [32]byte) (uint8, error) {
+	var out []interface{}
+	err := _SessionKeyValidator.contract.Call(opts, &out, "sessionStatus", account, sessionHash)
+
+	if err != nil {
+		return *new(uint8), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint8)).(*uint8)
+
+	return out0, err
+
+}
+
+// SessionStatus is a free data retrieval call binding the contract method 0x59130708.
+//
+// Solidity: function sessionStatus(address account, bytes32 sessionHash) view returns(uint8)
+func (_SessionKeyValidator *SessionKeyValidatorSession) SessionStatus(account common.Address, sessionHash [32]byte) (uint8, error) {
+	return _SessionKeyValidator.Contract.SessionStatus(&_SessionKeyValidator.CallOpts, account, sessionHash)
+}
+
+// SessionStatus is a free data retrieval call binding the contract method 0x59130708.
+//
+// Solidity: function sessionStatus(address account, bytes32 sessionHash) view returns(uint8)
+func (_SessionKeyValidator *SessionKeyValidatorCallerSession) SessionStatus(account common.Address, sessionHash [32]byte) (uint8, error) {
+	return _SessionKeyValidator.Contract.SessionStatus(&_SessionKeyValidator.CallOpts, account, sessionHash)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) pure returns(bool)
+func (_SessionKeyValidator *SessionKeyValidatorCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _SessionKeyValidator.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) pure returns(bool)
+func (_SessionKeyValidator *SessionKeyValidatorSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _SessionKeyValidator.Contract.SupportsInterface(&_SessionKeyValidator.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) pure returns(bool)
+func (_SessionKeyValidator *SessionKeyValidatorCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _SessionKeyValidator.Contract.SupportsInterface(&_SessionKeyValidator.CallOpts, interfaceId)
+}
+
+// ValidateSignature is a free data retrieval call binding the contract method 0x333daf92.
+//
+// Solidity: function validateSignature(bytes32 , bytes ) pure returns(bool)
+func (_SessionKeyValidator *SessionKeyValidatorCaller) ValidateSignature(opts *bind.CallOpts, arg0 [32]byte, arg1 []byte) (bool, error) {
+	var out []interface{}
+	err := _SessionKeyValidator.contract.Call(opts, &out, "validateSignature", arg0, arg1)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// ValidateSignature is a free data retrieval call binding the contract method 0x333daf92.
+//
+// Solidity: function validateSignature(bytes32 , bytes ) pure returns(bool)
+func (_SessionKeyValidator *SessionKeyValidatorSession) ValidateSignature(arg0 [32]byte, arg1 []byte) (bool, error) {
+	return _SessionKeyValidator.Contract.ValidateSignature(&_SessionKeyValidator.CallOpts, arg0, arg1)
+}
+
+// ValidateSignature is a free data retrieval call binding the contract method 0x333daf92.
+//
+// Solidity: function validateSignature(bytes32 , bytes ) pure returns(bool)
+func (_SessionKeyValidator *SessionKeyValidatorCallerSession) ValidateSignature(arg0 [32]byte, arg1 []byte) (bool, error) {
+	return _SessionKeyValidator.Contract.ValidateSignature(&_SessionKeyValidator.CallOpts, arg0, arg1)
+}
+
+// CreateSession is a paid mutator transaction binding the contract method 0x5a0694d2.
+//
+// Solidity: function createSession((address,uint256,(uint8,uint256,uint256),(address,bytes4,uint256,(uint8,uint256,uint256),(uint8,uint64,bytes32,(uint8,uint256,uint256))[])[],(address,uint256,(uint8,uint256,uint256))[]) sessionSpec) returns()
+func (_SessionKeyValidator *SessionKeyValidatorTransactor) CreateSession(opts *bind.TransactOpts, sessionSpec SessionLibSessionSpec) (*types.Transaction, error) {
+	return _SessionKeyValidator.contract.Transact(opts, "createSession", sessionSpec)
+}
+
+// CreateSession is a paid mutator transaction binding the contract method 0x5a0694d2.
+//
+// Solidity: function createSession((address,uint256,(uint8,uint256,uint256),(address,bytes4,uint256,(uint8,uint256,uint256),(uint8,uint64,bytes32,(uint8,uint256,uint256))[])[],(address,uint256,(uint8,uint256,uint256))[]) sessionSpec) returns()
+func (_SessionKeyValidator *SessionKeyValidatorSession) CreateSession(sessionSpec SessionLibSessionSpec) (*types.Transaction, error) {
+	return _SessionKeyValidator.Contract.CreateSession(&_SessionKeyValidator.TransactOpts, sessionSpec)
+}
+
+// CreateSession is a paid mutator transaction binding the contract method 0x5a0694d2.
+//
+// Solidity: function createSession((address,uint256,(uint8,uint256,uint256),(address,bytes4,uint256,(uint8,uint256,uint256),(uint8,uint64,bytes32,(uint8,uint256,uint256))[])[],(address,uint256,(uint8,uint256,uint256))[]) sessionSpec) returns()
+func (_SessionKeyValidator *SessionKeyValidatorTransactorSession) CreateSession(sessionSpec SessionLibSessionSpec) (*types.Transaction, error) {
+	return _SessionKeyValidator.Contract.CreateSession(&_SessionKeyValidator.TransactOpts, sessionSpec)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_SessionKeyValidator *SessionKeyValidatorTransactor) OnInstall(opts *bind.TransactOpts, data []byte) (*types.Transaction, error) {
+	return _SessionKeyValidator.contract.Transact(opts, "onInstall", data)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_SessionKeyValidator *SessionKeyValidatorSession) OnInstall(data []byte) (*types.Transaction, error) {
+	return _SessionKeyValidator.Contract.OnInstall(&_SessionKeyValidator.TransactOpts, data)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_SessionKeyValidator *SessionKeyValidatorTransactorSession) OnInstall(data []byte) (*types.Transaction, error) {
+	return _SessionKeyValidator.Contract.OnInstall(&_SessionKeyValidator.TransactOpts, data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_SessionKeyValidator *SessionKeyValidatorTransactor) OnUninstall(opts *bind.TransactOpts, data []byte) (*types.Transaction, error) {
+	return _SessionKeyValidator.contract.Transact(opts, "onUninstall", data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_SessionKeyValidator *SessionKeyValidatorSession) OnUninstall(data []byte) (*types.Transaction, error) {
+	return _SessionKeyValidator.Contract.OnUninstall(&_SessionKeyValidator.TransactOpts, data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_SessionKeyValidator *SessionKeyValidatorTransactorSession) OnUninstall(data []byte) (*types.Transaction, error) {
+	return _SessionKeyValidator.Contract.OnUninstall(&_SessionKeyValidator.TransactOpts, data)
+}
+
+// RevokeKey is a paid mutator transaction binding the contract method 0x572f2210.
+//
+// Solidity: function revokeKey(bytes32 sessionHash) returns()
+func (_SessionKeyValidator *SessionKeyValidatorTransactor) RevokeKey(opts *bind.TransactOpts, sessionHash [32]byte) (*types.Transaction, error) {
+	return _SessionKeyValidator.contract.Transact(opts, "revokeKey", sessionHash)
+}
+
+// RevokeKey is a paid mutator transaction binding the contract method 0x572f2210.
+//
+// Solidity: function revokeKey(bytes32 sessionHash) returns()
+func (_SessionKeyValidator *SessionKeyValidatorSession) RevokeKey(sessionHash [32]byte) (*types.Transaction, error) {
+	return _SessionKeyValidator.Contract.RevokeKey(&_SessionKeyValidator.TransactOpts, sessionHash)
+}
+
+// RevokeKey is a paid mutator transaction binding the contract method 0x572f2210.
+//
+// Solidity: function revokeKey(bytes32 sessionHash) returns()
+func (_SessionKeyValidator *SessionKeyValidatorTransactorSession) RevokeKey(sessionHash [32]byte) (*types.Transaction, error) {
+	return _SessionKeyValidator.Contract.RevokeKey(&_SessionKeyValidator.TransactOpts, sessionHash)
+}
+
+// RevokeKeys is a paid mutator transaction binding the contract method 0x3ec59279.
+//
+// Solidity: function revokeKeys(bytes32[] sessionHashes) returns()
+func (_SessionKeyValidator *SessionKeyValidatorTransactor) RevokeKeys(opts *bind.TransactOpts, sessionHashes [][32]byte) (*types.Transaction, error) {
+	return _SessionKeyValidator.contract.Transact(opts, "revokeKeys", sessionHashes)
+}
+
+// RevokeKeys is a paid mutator transaction binding the contract method 0x3ec59279.
+//
+// Solidity: function revokeKeys(bytes32[] sessionHashes) returns()
+func (_SessionKeyValidator *SessionKeyValidatorSession) RevokeKeys(sessionHashes [][32]byte) (*types.Transaction, error) {
+	return _SessionKeyValidator.Contract.RevokeKeys(&_SessionKeyValidator.TransactOpts, sessionHashes)
+}
+
+// RevokeKeys is a paid mutator transaction binding the contract method 0x3ec59279.
+//
+// Solidity: function revokeKeys(bytes32[] sessionHashes) returns()
+func (_SessionKeyValidator *SessionKeyValidatorTransactorSession) RevokeKeys(sessionHashes [][32]byte) (*types.Transaction, error) {
+	return _SessionKeyValidator.Contract.RevokeKeys(&_SessionKeyValidator.TransactOpts, sessionHashes)
+}
+
+// ValidateTransaction is a paid mutator transaction binding the contract method 0xbf1733f9.
+//
+// Solidity: function validateTransaction(bytes32 signedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) returns(bool)
+func (_SessionKeyValidator *SessionKeyValidatorTransactor) ValidateTransaction(opts *bind.TransactOpts, signedHash [32]byte, transaction Transaction) (*types.Transaction, error) {
+	return _SessionKeyValidator.contract.Transact(opts, "validateTransaction", signedHash, transaction)
+}
+
+// ValidateTransaction is a paid mutator transaction binding the contract method 0xbf1733f9.
+//
+// Solidity: function validateTransaction(bytes32 signedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) returns(bool)
+func (_SessionKeyValidator *SessionKeyValidatorSession) ValidateTransaction(signedHash [32]byte, transaction Transaction) (*types.Transaction, error) {
+	return _SessionKeyValidator.Contract.ValidateTransaction(&_SessionKeyValidator.TransactOpts, signedHash, transaction)
+}
+
+// ValidateTransaction is a paid mutator transaction binding the contract method 0xbf1733f9.
+//
+// Solidity: function validateTransaction(bytes32 signedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) returns(bool)
+func (_SessionKeyValidator *SessionKeyValidatorTransactorSession) ValidateTransaction(signedHash [32]byte, transaction Transaction) (*types.Transaction, error) {
+	return _SessionKeyValidator.Contract.ValidateTransaction(&_SessionKeyValidator.TransactOpts, signedHash, transaction)
+}
+
+// SessionKeyValidatorSessionCreatedIterator is returned from FilterSessionCreated and is used to iterate over the raw logs and unpacked data for SessionCreated events raised by the SessionKeyValidator contract.
+type SessionKeyValidatorSessionCreatedIterator struct {
+	Event *SessionKeyValidatorSessionCreated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *SessionKeyValidatorSessionCreatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(SessionKeyValidatorSessionCreated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(SessionKeyValidatorSessionCreated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *SessionKeyValidatorSessionCreatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *SessionKeyValidatorSessionCreatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// SessionKeyValidatorSessionCreated represents a SessionCreated event raised by the SessionKeyValidator contract.
+type SessionKeyValidatorSessionCreated struct {
+	Account     common.Address
+	SessionHash [32]byte
+	SessionSpec SessionLibSessionSpec
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterSessionCreated is a free log retrieval operation binding the contract event 0x225b7c57a9711566a3a2dabe5ba5d2c5965272461cd8af89883376ecb2f69ac4.
+//
+// Solidity: event SessionCreated(address indexed account, bytes32 indexed sessionHash, (address,uint256,(uint8,uint256,uint256),(address,bytes4,uint256,(uint8,uint256,uint256),(uint8,uint64,bytes32,(uint8,uint256,uint256))[])[],(address,uint256,(uint8,uint256,uint256))[]) sessionSpec)
+func (_SessionKeyValidator *SessionKeyValidatorFilterer) FilterSessionCreated(opts *bind.FilterOpts, account []common.Address, sessionHash [][32]byte) (*SessionKeyValidatorSessionCreatedIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var sessionHashRule []interface{}
+	for _, sessionHashItem := range sessionHash {
+		sessionHashRule = append(sessionHashRule, sessionHashItem)
+	}
+
+	logs, sub, err := _SessionKeyValidator.contract.FilterLogs(opts, "SessionCreated", accountRule, sessionHashRule)
+	if err != nil {
+		return nil, err
+	}
+	return &SessionKeyValidatorSessionCreatedIterator{contract: _SessionKeyValidator.contract, event: "SessionCreated", logs: logs, sub: sub}, nil
+}
+
+// WatchSessionCreated is a free log subscription operation binding the contract event 0x225b7c57a9711566a3a2dabe5ba5d2c5965272461cd8af89883376ecb2f69ac4.
+//
+// Solidity: event SessionCreated(address indexed account, bytes32 indexed sessionHash, (address,uint256,(uint8,uint256,uint256),(address,bytes4,uint256,(uint8,uint256,uint256),(uint8,uint64,bytes32,(uint8,uint256,uint256))[])[],(address,uint256,(uint8,uint256,uint256))[]) sessionSpec)
+func (_SessionKeyValidator *SessionKeyValidatorFilterer) WatchSessionCreated(opts *bind.WatchOpts, sink chan<- *SessionKeyValidatorSessionCreated, account []common.Address, sessionHash [][32]byte) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var sessionHashRule []interface{}
+	for _, sessionHashItem := range sessionHash {
+		sessionHashRule = append(sessionHashRule, sessionHashItem)
+	}
+
+	logs, sub, err := _SessionKeyValidator.contract.WatchLogs(opts, "SessionCreated", accountRule, sessionHashRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(SessionKeyValidatorSessionCreated)
+				if err := _SessionKeyValidator.contract.UnpackLog(event, "SessionCreated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSessionCreated is a log parse operation binding the contract event 0x225b7c57a9711566a3a2dabe5ba5d2c5965272461cd8af89883376ecb2f69ac4.
+//
+// Solidity: event SessionCreated(address indexed account, bytes32 indexed sessionHash, (address,uint256,(uint8,uint256,uint256),(address,bytes4,uint256,(uint8,uint256,uint256),(uint8,uint64,bytes32,(uint8,uint256,uint256))[])[],(address,uint256,(uint8,uint256,uint256))[]) sessionSpec)
+func (_SessionKeyValidator *SessionKeyValidatorFilterer) ParseSessionCreated(log types.Log) (*SessionKeyValidatorSessionCreated, error) {
+	event := new(SessionKeyValidatorSessionCreated)
+	if err := _SessionKeyValidator.contract.UnpackLog(event, "SessionCreated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// SessionKeyValidatorSessionRevokedIterator is returned from FilterSessionRevoked and is used to iterate over the raw logs and unpacked data for SessionRevoked events raised by the SessionKeyValidator contract.
+type SessionKeyValidatorSessionRevokedIterator struct {
+	Event *SessionKeyValidatorSessionRevoked // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *SessionKeyValidatorSessionRevokedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(SessionKeyValidatorSessionRevoked)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(SessionKeyValidatorSessionRevoked)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *SessionKeyValidatorSessionRevokedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *SessionKeyValidatorSessionRevokedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// SessionKeyValidatorSessionRevoked represents a SessionRevoked event raised by the SessionKeyValidator contract.
+type SessionKeyValidatorSessionRevoked struct {
+	Account     common.Address
+	SessionHash [32]byte
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterSessionRevoked is a free log retrieval operation binding the contract event 0x006be5f629d8df9f032986474cfc3bfc82c9b1cd74dcb2fcb5b3d48f98a50024.
+//
+// Solidity: event SessionRevoked(address indexed account, bytes32 indexed sessionHash)
+func (_SessionKeyValidator *SessionKeyValidatorFilterer) FilterSessionRevoked(opts *bind.FilterOpts, account []common.Address, sessionHash [][32]byte) (*SessionKeyValidatorSessionRevokedIterator, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var sessionHashRule []interface{}
+	for _, sessionHashItem := range sessionHash {
+		sessionHashRule = append(sessionHashRule, sessionHashItem)
+	}
+
+	logs, sub, err := _SessionKeyValidator.contract.FilterLogs(opts, "SessionRevoked", accountRule, sessionHashRule)
+	if err != nil {
+		return nil, err
+	}
+	return &SessionKeyValidatorSessionRevokedIterator{contract: _SessionKeyValidator.contract, event: "SessionRevoked", logs: logs, sub: sub}, nil
+}
+
+// WatchSessionRevoked is a free log subscription operation binding the contract event 0x006be5f629d8df9f032986474cfc3bfc82c9b1cd74dcb2fcb5b3d48f98a50024.
+//
+// Solidity: event SessionRevoked(address indexed account, bytes32 indexed sessionHash)
+func (_SessionKeyValidator *SessionKeyValidatorFilterer) WatchSessionRevoked(opts *bind.WatchOpts, sink chan<- *SessionKeyValidatorSessionRevoked, account []common.Address, sessionHash [][32]byte) (event.Subscription, error) {
+
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var sessionHashRule []interface{}
+	for _, sessionHashItem := range sessionHash {
+		sessionHashRule = append(sessionHashRule, sessionHashItem)
+	}
+
+	logs, sub, err := _SessionKeyValidator.contract.WatchLogs(opts, "SessionRevoked", accountRule, sessionHashRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(SessionKeyValidatorSessionRevoked)
+				if err := _SessionKeyValidator.contract.UnpackLog(event, "SessionRevoked", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSessionRevoked is a log parse operation binding the contract event 0x006be5f629d8df9f032986474cfc3bfc82c9b1cd74dcb2fcb5b3d48f98a50024.
+//
+// Solidity: event SessionRevoked(address indexed account, bytes32 indexed sessionHash)
+func (_SessionKeyValidator *SessionKeyValidatorFilterer) ParseSessionRevoked(log types.Log) (*SessionKeyValidatorSessionRevoked, error) {
+	event := new(SessionKeyValidatorSessionRevoked)
+	if err := _SessionKeyValidator.contract.UnpackLog(event, "SessionRevoked", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/contracts/zksyncsso/validators/webauthvalidator/webauthvalidator.go
+++ b/contracts/zksyncsso/validators/webauthvalidator/webauthvalidator.go
@@ -1,0 +1,732 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package webauthvalidator
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// Transaction is an auto generated low-level Go binding around an user-defined struct.
+type Transaction struct {
+	TxType                 *big.Int
+	From                   *big.Int
+	To                     *big.Int
+	GasLimit               *big.Int
+	GasPerPubdataByteLimit *big.Int
+	MaxFeePerGas           *big.Int
+	MaxPriorityFeePerGas   *big.Int
+	Paymaster              *big.Int
+	Nonce                  *big.Int
+	Value                  *big.Int
+	Reserved               [4]*big.Int
+	Data                   []byte
+	Signature              []byte
+	FactoryDeps            [][32]byte
+	PaymasterInput         []byte
+	ReservedDynamic        []byte
+}
+
+// WebAuthValidatorMetaData contains all meta data concerning the WebAuthValidator contract.
+var WebAuthValidatorMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[],\"name\":\"ACCOUNT_EXISTS\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"BAD_CREDENTIAL_ID_LENGTH\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"BAD_DOMAIN_LENGTH\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"EMPTY_KEY\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"KEY_EXISTS\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"NOT_KEY_OWNER\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"keyOwner\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"originDomain\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"credentialId\",\"type\":\"bytes\"}],\"name\":\"PasskeyCreated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"keyOwner\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"originDomain\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"bytes\",\"name\":\"credentialId\",\"type\":\"bytes\"}],\"name\":\"PasskeyRemoved\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"credentialId\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[2]\",\"name\":\"rawPublicKey\",\"type\":\"bytes32[2]\"},{\"internalType\":\"string\",\"name\":\"originDomain\",\"type\":\"string\"}],\"name\":\"addValidationKey\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"originDomain\",\"type\":\"string\"},{\"internalType\":\"bytes\",\"name\":\"credentialId\",\"type\":\"bytes\"},{\"internalType\":\"address\",\"name\":\"accountAddress\",\"type\":\"address\"}],\"name\":\"getAccountKey\",\"outputs\":[{\"internalType\":\"bytes32[2]\",\"name\":\"\",\"type\":\"bytes32[2]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"onInstall\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"onUninstall\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"originDomain\",\"type\":\"string\"},{\"internalType\":\"bytes\",\"name\":\"credentialId\",\"type\":\"bytes\"}],\"name\":\"registeredAddress\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"accountAddress\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes\",\"name\":\"credentialId\",\"type\":\"bytes\"},{\"internalType\":\"string\",\"name\":\"domain\",\"type\":\"string\"}],\"name\":\"removeValidationKey\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes4\",\"name\":\"interfaceId\",\"type\":\"bytes4\"}],\"name\":\"supportsInterface\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"signedHash\",\"type\":\"bytes32\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"}],\"name\":\"validateSignature\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"signedHash\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"txType\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"from\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"to\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasPerPubdataByteLimit\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPriorityFeePerGas\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"paymaster\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256[4]\",\"name\":\"reserved\",\"type\":\"uint256[4]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"bytes32[]\",\"name\":\"factoryDeps\",\"type\":\"bytes32[]\"},{\"internalType\":\"bytes\",\"name\":\"paymasterInput\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"reservedDynamic\",\"type\":\"bytes\"}],\"internalType\":\"structTransaction\",\"name\":\"transaction\",\"type\":\"tuple\"}],\"name\":\"validateTransaction\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+}
+
+// WebAuthValidatorABI is the input ABI used to generate the binding from.
+// Deprecated: Use WebAuthValidatorMetaData.ABI instead.
+var WebAuthValidatorABI = WebAuthValidatorMetaData.ABI
+
+// WebAuthValidator is an auto generated Go binding around an Ethereum contract.
+type WebAuthValidator struct {
+	WebAuthValidatorCaller     // Read-only binding to the contract
+	WebAuthValidatorTransactor // Write-only binding to the contract
+	WebAuthValidatorFilterer   // Log filterer for contract events
+}
+
+// WebAuthValidatorCaller is an auto generated read-only Go binding around an Ethereum contract.
+type WebAuthValidatorCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// WebAuthValidatorTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type WebAuthValidatorTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// WebAuthValidatorFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type WebAuthValidatorFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// WebAuthValidatorSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type WebAuthValidatorSession struct {
+	Contract     *WebAuthValidator // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// WebAuthValidatorCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type WebAuthValidatorCallerSession struct {
+	Contract *WebAuthValidatorCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts           // Call options to use throughout this session
+}
+
+// WebAuthValidatorTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type WebAuthValidatorTransactorSession struct {
+	Contract     *WebAuthValidatorTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts           // Transaction auth options to use throughout this session
+}
+
+// WebAuthValidatorRaw is an auto generated low-level Go binding around an Ethereum contract.
+type WebAuthValidatorRaw struct {
+	Contract *WebAuthValidator // Generic contract binding to access the raw methods on
+}
+
+// WebAuthValidatorCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type WebAuthValidatorCallerRaw struct {
+	Contract *WebAuthValidatorCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// WebAuthValidatorTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type WebAuthValidatorTransactorRaw struct {
+	Contract *WebAuthValidatorTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewWebAuthValidator creates a new instance of WebAuthValidator, bound to a specific deployed contract.
+func NewWebAuthValidator(address common.Address, backend bind.ContractBackend) (*WebAuthValidator, error) {
+	contract, err := bindWebAuthValidator(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &WebAuthValidator{WebAuthValidatorCaller: WebAuthValidatorCaller{contract: contract}, WebAuthValidatorTransactor: WebAuthValidatorTransactor{contract: contract}, WebAuthValidatorFilterer: WebAuthValidatorFilterer{contract: contract}}, nil
+}
+
+// NewWebAuthValidatorCaller creates a new read-only instance of WebAuthValidator, bound to a specific deployed contract.
+func NewWebAuthValidatorCaller(address common.Address, caller bind.ContractCaller) (*WebAuthValidatorCaller, error) {
+	contract, err := bindWebAuthValidator(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &WebAuthValidatorCaller{contract: contract}, nil
+}
+
+// NewWebAuthValidatorTransactor creates a new write-only instance of WebAuthValidator, bound to a specific deployed contract.
+func NewWebAuthValidatorTransactor(address common.Address, transactor bind.ContractTransactor) (*WebAuthValidatorTransactor, error) {
+	contract, err := bindWebAuthValidator(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &WebAuthValidatorTransactor{contract: contract}, nil
+}
+
+// NewWebAuthValidatorFilterer creates a new log filterer instance of WebAuthValidator, bound to a specific deployed contract.
+func NewWebAuthValidatorFilterer(address common.Address, filterer bind.ContractFilterer) (*WebAuthValidatorFilterer, error) {
+	contract, err := bindWebAuthValidator(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &WebAuthValidatorFilterer{contract: contract}, nil
+}
+
+// bindWebAuthValidator binds a generic wrapper to an already deployed contract.
+func bindWebAuthValidator(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := WebAuthValidatorMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_WebAuthValidator *WebAuthValidatorRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _WebAuthValidator.Contract.WebAuthValidatorCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_WebAuthValidator *WebAuthValidatorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _WebAuthValidator.Contract.WebAuthValidatorTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_WebAuthValidator *WebAuthValidatorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _WebAuthValidator.Contract.WebAuthValidatorTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_WebAuthValidator *WebAuthValidatorCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _WebAuthValidator.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_WebAuthValidator *WebAuthValidatorTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _WebAuthValidator.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_WebAuthValidator *WebAuthValidatorTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _WebAuthValidator.Contract.contract.Transact(opts, method, params...)
+}
+
+// GetAccountKey is a free data retrieval call binding the contract method 0x80c904d6.
+//
+// Solidity: function getAccountKey(string originDomain, bytes credentialId, address accountAddress) view returns(bytes32[2])
+func (_WebAuthValidator *WebAuthValidatorCaller) GetAccountKey(opts *bind.CallOpts, originDomain string, credentialId []byte, accountAddress common.Address) ([2][32]byte, error) {
+	var out []interface{}
+	err := _WebAuthValidator.contract.Call(opts, &out, "getAccountKey", originDomain, credentialId, accountAddress)
+
+	if err != nil {
+		return *new([2][32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([2][32]byte)).(*[2][32]byte)
+
+	return out0, err
+
+}
+
+// GetAccountKey is a free data retrieval call binding the contract method 0x80c904d6.
+//
+// Solidity: function getAccountKey(string originDomain, bytes credentialId, address accountAddress) view returns(bytes32[2])
+func (_WebAuthValidator *WebAuthValidatorSession) GetAccountKey(originDomain string, credentialId []byte, accountAddress common.Address) ([2][32]byte, error) {
+	return _WebAuthValidator.Contract.GetAccountKey(&_WebAuthValidator.CallOpts, originDomain, credentialId, accountAddress)
+}
+
+// GetAccountKey is a free data retrieval call binding the contract method 0x80c904d6.
+//
+// Solidity: function getAccountKey(string originDomain, bytes credentialId, address accountAddress) view returns(bytes32[2])
+func (_WebAuthValidator *WebAuthValidatorCallerSession) GetAccountKey(originDomain string, credentialId []byte, accountAddress common.Address) ([2][32]byte, error) {
+	return _WebAuthValidator.Contract.GetAccountKey(&_WebAuthValidator.CallOpts, originDomain, credentialId, accountAddress)
+}
+
+// RegisteredAddress is a free data retrieval call binding the contract method 0x90c0af30.
+//
+// Solidity: function registeredAddress(string originDomain, bytes credentialId) view returns(address accountAddress)
+func (_WebAuthValidator *WebAuthValidatorCaller) RegisteredAddress(opts *bind.CallOpts, originDomain string, credentialId []byte) (common.Address, error) {
+	var out []interface{}
+	err := _WebAuthValidator.contract.Call(opts, &out, "registeredAddress", originDomain, credentialId)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// RegisteredAddress is a free data retrieval call binding the contract method 0x90c0af30.
+//
+// Solidity: function registeredAddress(string originDomain, bytes credentialId) view returns(address accountAddress)
+func (_WebAuthValidator *WebAuthValidatorSession) RegisteredAddress(originDomain string, credentialId []byte) (common.Address, error) {
+	return _WebAuthValidator.Contract.RegisteredAddress(&_WebAuthValidator.CallOpts, originDomain, credentialId)
+}
+
+// RegisteredAddress is a free data retrieval call binding the contract method 0x90c0af30.
+//
+// Solidity: function registeredAddress(string originDomain, bytes credentialId) view returns(address accountAddress)
+func (_WebAuthValidator *WebAuthValidatorCallerSession) RegisteredAddress(originDomain string, credentialId []byte) (common.Address, error) {
+	return _WebAuthValidator.Contract.RegisteredAddress(&_WebAuthValidator.CallOpts, originDomain, credentialId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) pure returns(bool)
+func (_WebAuthValidator *WebAuthValidatorCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _WebAuthValidator.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) pure returns(bool)
+func (_WebAuthValidator *WebAuthValidatorSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _WebAuthValidator.Contract.SupportsInterface(&_WebAuthValidator.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) pure returns(bool)
+func (_WebAuthValidator *WebAuthValidatorCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _WebAuthValidator.Contract.SupportsInterface(&_WebAuthValidator.CallOpts, interfaceId)
+}
+
+// ValidateSignature is a free data retrieval call binding the contract method 0x333daf92.
+//
+// Solidity: function validateSignature(bytes32 signedHash, bytes signature) view returns(bool)
+func (_WebAuthValidator *WebAuthValidatorCaller) ValidateSignature(opts *bind.CallOpts, signedHash [32]byte, signature []byte) (bool, error) {
+	var out []interface{}
+	err := _WebAuthValidator.contract.Call(opts, &out, "validateSignature", signedHash, signature)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// ValidateSignature is a free data retrieval call binding the contract method 0x333daf92.
+//
+// Solidity: function validateSignature(bytes32 signedHash, bytes signature) view returns(bool)
+func (_WebAuthValidator *WebAuthValidatorSession) ValidateSignature(signedHash [32]byte, signature []byte) (bool, error) {
+	return _WebAuthValidator.Contract.ValidateSignature(&_WebAuthValidator.CallOpts, signedHash, signature)
+}
+
+// ValidateSignature is a free data retrieval call binding the contract method 0x333daf92.
+//
+// Solidity: function validateSignature(bytes32 signedHash, bytes signature) view returns(bool)
+func (_WebAuthValidator *WebAuthValidatorCallerSession) ValidateSignature(signedHash [32]byte, signature []byte) (bool, error) {
+	return _WebAuthValidator.Contract.ValidateSignature(&_WebAuthValidator.CallOpts, signedHash, signature)
+}
+
+// ValidateTransaction is a free data retrieval call binding the contract method 0xbf1733f9.
+//
+// Solidity: function validateTransaction(bytes32 signedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) view returns(bool)
+func (_WebAuthValidator *WebAuthValidatorCaller) ValidateTransaction(opts *bind.CallOpts, signedHash [32]byte, transaction Transaction) (bool, error) {
+	var out []interface{}
+	err := _WebAuthValidator.contract.Call(opts, &out, "validateTransaction", signedHash, transaction)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// ValidateTransaction is a free data retrieval call binding the contract method 0xbf1733f9.
+//
+// Solidity: function validateTransaction(bytes32 signedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) view returns(bool)
+func (_WebAuthValidator *WebAuthValidatorSession) ValidateTransaction(signedHash [32]byte, transaction Transaction) (bool, error) {
+	return _WebAuthValidator.Contract.ValidateTransaction(&_WebAuthValidator.CallOpts, signedHash, transaction)
+}
+
+// ValidateTransaction is a free data retrieval call binding the contract method 0xbf1733f9.
+//
+// Solidity: function validateTransaction(bytes32 signedHash, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,bytes32[],bytes,bytes) transaction) view returns(bool)
+func (_WebAuthValidator *WebAuthValidatorCallerSession) ValidateTransaction(signedHash [32]byte, transaction Transaction) (bool, error) {
+	return _WebAuthValidator.Contract.ValidateTransaction(&_WebAuthValidator.CallOpts, signedHash, transaction)
+}
+
+// AddValidationKey is a paid mutator transaction binding the contract method 0x8f5bc2af.
+//
+// Solidity: function addValidationKey(bytes credentialId, bytes32[2] rawPublicKey, string originDomain) returns()
+func (_WebAuthValidator *WebAuthValidatorTransactor) AddValidationKey(opts *bind.TransactOpts, credentialId []byte, rawPublicKey [2][32]byte, originDomain string) (*types.Transaction, error) {
+	return _WebAuthValidator.contract.Transact(opts, "addValidationKey", credentialId, rawPublicKey, originDomain)
+}
+
+// AddValidationKey is a paid mutator transaction binding the contract method 0x8f5bc2af.
+//
+// Solidity: function addValidationKey(bytes credentialId, bytes32[2] rawPublicKey, string originDomain) returns()
+func (_WebAuthValidator *WebAuthValidatorSession) AddValidationKey(credentialId []byte, rawPublicKey [2][32]byte, originDomain string) (*types.Transaction, error) {
+	return _WebAuthValidator.Contract.AddValidationKey(&_WebAuthValidator.TransactOpts, credentialId, rawPublicKey, originDomain)
+}
+
+// AddValidationKey is a paid mutator transaction binding the contract method 0x8f5bc2af.
+//
+// Solidity: function addValidationKey(bytes credentialId, bytes32[2] rawPublicKey, string originDomain) returns()
+func (_WebAuthValidator *WebAuthValidatorTransactorSession) AddValidationKey(credentialId []byte, rawPublicKey [2][32]byte, originDomain string) (*types.Transaction, error) {
+	return _WebAuthValidator.Contract.AddValidationKey(&_WebAuthValidator.TransactOpts, credentialId, rawPublicKey, originDomain)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_WebAuthValidator *WebAuthValidatorTransactor) OnInstall(opts *bind.TransactOpts, data []byte) (*types.Transaction, error) {
+	return _WebAuthValidator.contract.Transact(opts, "onInstall", data)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_WebAuthValidator *WebAuthValidatorSession) OnInstall(data []byte) (*types.Transaction, error) {
+	return _WebAuthValidator.Contract.OnInstall(&_WebAuthValidator.TransactOpts, data)
+}
+
+// OnInstall is a paid mutator transaction binding the contract method 0x6d61fe70.
+//
+// Solidity: function onInstall(bytes data) returns()
+func (_WebAuthValidator *WebAuthValidatorTransactorSession) OnInstall(data []byte) (*types.Transaction, error) {
+	return _WebAuthValidator.Contract.OnInstall(&_WebAuthValidator.TransactOpts, data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_WebAuthValidator *WebAuthValidatorTransactor) OnUninstall(opts *bind.TransactOpts, data []byte) (*types.Transaction, error) {
+	return _WebAuthValidator.contract.Transact(opts, "onUninstall", data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_WebAuthValidator *WebAuthValidatorSession) OnUninstall(data []byte) (*types.Transaction, error) {
+	return _WebAuthValidator.Contract.OnUninstall(&_WebAuthValidator.TransactOpts, data)
+}
+
+// OnUninstall is a paid mutator transaction binding the contract method 0x8a91b0e3.
+//
+// Solidity: function onUninstall(bytes data) returns()
+func (_WebAuthValidator *WebAuthValidatorTransactorSession) OnUninstall(data []byte) (*types.Transaction, error) {
+	return _WebAuthValidator.Contract.OnUninstall(&_WebAuthValidator.TransactOpts, data)
+}
+
+// RemoveValidationKey is a paid mutator transaction binding the contract method 0x59be375f.
+//
+// Solidity: function removeValidationKey(bytes credentialId, string domain) returns()
+func (_WebAuthValidator *WebAuthValidatorTransactor) RemoveValidationKey(opts *bind.TransactOpts, credentialId []byte, domain string) (*types.Transaction, error) {
+	return _WebAuthValidator.contract.Transact(opts, "removeValidationKey", credentialId, domain)
+}
+
+// RemoveValidationKey is a paid mutator transaction binding the contract method 0x59be375f.
+//
+// Solidity: function removeValidationKey(bytes credentialId, string domain) returns()
+func (_WebAuthValidator *WebAuthValidatorSession) RemoveValidationKey(credentialId []byte, domain string) (*types.Transaction, error) {
+	return _WebAuthValidator.Contract.RemoveValidationKey(&_WebAuthValidator.TransactOpts, credentialId, domain)
+}
+
+// RemoveValidationKey is a paid mutator transaction binding the contract method 0x59be375f.
+//
+// Solidity: function removeValidationKey(bytes credentialId, string domain) returns()
+func (_WebAuthValidator *WebAuthValidatorTransactorSession) RemoveValidationKey(credentialId []byte, domain string) (*types.Transaction, error) {
+	return _WebAuthValidator.Contract.RemoveValidationKey(&_WebAuthValidator.TransactOpts, credentialId, domain)
+}
+
+// WebAuthValidatorPasskeyCreatedIterator is returned from FilterPasskeyCreated and is used to iterate over the raw logs and unpacked data for PasskeyCreated events raised by the WebAuthValidator contract.
+type WebAuthValidatorPasskeyCreatedIterator struct {
+	Event *WebAuthValidatorPasskeyCreated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *WebAuthValidatorPasskeyCreatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(WebAuthValidatorPasskeyCreated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(WebAuthValidatorPasskeyCreated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *WebAuthValidatorPasskeyCreatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *WebAuthValidatorPasskeyCreatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// WebAuthValidatorPasskeyCreated represents a PasskeyCreated event raised by the WebAuthValidator contract.
+type WebAuthValidatorPasskeyCreated struct {
+	KeyOwner     common.Address
+	OriginDomain string
+	CredentialId []byte
+	Raw          types.Log // Blockchain specific contextual infos
+}
+
+// FilterPasskeyCreated is a free log retrieval operation binding the contract event 0x3c6e30f99b4a1e8aae9cdcfbc2d6683bf8347bb160ae280eb95513567c07b473.
+//
+// Solidity: event PasskeyCreated(address indexed keyOwner, string originDomain, bytes credentialId)
+func (_WebAuthValidator *WebAuthValidatorFilterer) FilterPasskeyCreated(opts *bind.FilterOpts, keyOwner []common.Address) (*WebAuthValidatorPasskeyCreatedIterator, error) {
+
+	var keyOwnerRule []interface{}
+	for _, keyOwnerItem := range keyOwner {
+		keyOwnerRule = append(keyOwnerRule, keyOwnerItem)
+	}
+
+	logs, sub, err := _WebAuthValidator.contract.FilterLogs(opts, "PasskeyCreated", keyOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &WebAuthValidatorPasskeyCreatedIterator{contract: _WebAuthValidator.contract, event: "PasskeyCreated", logs: logs, sub: sub}, nil
+}
+
+// WatchPasskeyCreated is a free log subscription operation binding the contract event 0x3c6e30f99b4a1e8aae9cdcfbc2d6683bf8347bb160ae280eb95513567c07b473.
+//
+// Solidity: event PasskeyCreated(address indexed keyOwner, string originDomain, bytes credentialId)
+func (_WebAuthValidator *WebAuthValidatorFilterer) WatchPasskeyCreated(opts *bind.WatchOpts, sink chan<- *WebAuthValidatorPasskeyCreated, keyOwner []common.Address) (event.Subscription, error) {
+
+	var keyOwnerRule []interface{}
+	for _, keyOwnerItem := range keyOwner {
+		keyOwnerRule = append(keyOwnerRule, keyOwnerItem)
+	}
+
+	logs, sub, err := _WebAuthValidator.contract.WatchLogs(opts, "PasskeyCreated", keyOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(WebAuthValidatorPasskeyCreated)
+				if err := _WebAuthValidator.contract.UnpackLog(event, "PasskeyCreated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePasskeyCreated is a log parse operation binding the contract event 0x3c6e30f99b4a1e8aae9cdcfbc2d6683bf8347bb160ae280eb95513567c07b473.
+//
+// Solidity: event PasskeyCreated(address indexed keyOwner, string originDomain, bytes credentialId)
+func (_WebAuthValidator *WebAuthValidatorFilterer) ParsePasskeyCreated(log types.Log) (*WebAuthValidatorPasskeyCreated, error) {
+	event := new(WebAuthValidatorPasskeyCreated)
+	if err := _WebAuthValidator.contract.UnpackLog(event, "PasskeyCreated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// WebAuthValidatorPasskeyRemovedIterator is returned from FilterPasskeyRemoved and is used to iterate over the raw logs and unpacked data for PasskeyRemoved events raised by the WebAuthValidator contract.
+type WebAuthValidatorPasskeyRemovedIterator struct {
+	Event *WebAuthValidatorPasskeyRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *WebAuthValidatorPasskeyRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(WebAuthValidatorPasskeyRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(WebAuthValidatorPasskeyRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *WebAuthValidatorPasskeyRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *WebAuthValidatorPasskeyRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// WebAuthValidatorPasskeyRemoved represents a PasskeyRemoved event raised by the WebAuthValidator contract.
+type WebAuthValidatorPasskeyRemoved struct {
+	KeyOwner     common.Address
+	OriginDomain string
+	CredentialId []byte
+	Raw          types.Log // Blockchain specific contextual infos
+}
+
+// FilterPasskeyRemoved is a free log retrieval operation binding the contract event 0x60a29a47798fec901f6df6fe2a86177130b82aecf219f6c7960182b8a0627636.
+//
+// Solidity: event PasskeyRemoved(address indexed keyOwner, string originDomain, bytes credentialId)
+func (_WebAuthValidator *WebAuthValidatorFilterer) FilterPasskeyRemoved(opts *bind.FilterOpts, keyOwner []common.Address) (*WebAuthValidatorPasskeyRemovedIterator, error) {
+
+	var keyOwnerRule []interface{}
+	for _, keyOwnerItem := range keyOwner {
+		keyOwnerRule = append(keyOwnerRule, keyOwnerItem)
+	}
+
+	logs, sub, err := _WebAuthValidator.contract.FilterLogs(opts, "PasskeyRemoved", keyOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &WebAuthValidatorPasskeyRemovedIterator{contract: _WebAuthValidator.contract, event: "PasskeyRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchPasskeyRemoved is a free log subscription operation binding the contract event 0x60a29a47798fec901f6df6fe2a86177130b82aecf219f6c7960182b8a0627636.
+//
+// Solidity: event PasskeyRemoved(address indexed keyOwner, string originDomain, bytes credentialId)
+func (_WebAuthValidator *WebAuthValidatorFilterer) WatchPasskeyRemoved(opts *bind.WatchOpts, sink chan<- *WebAuthValidatorPasskeyRemoved, keyOwner []common.Address) (event.Subscription, error) {
+
+	var keyOwnerRule []interface{}
+	for _, keyOwnerItem := range keyOwner {
+		keyOwnerRule = append(keyOwnerRule, keyOwnerItem)
+	}
+
+	logs, sub, err := _WebAuthValidator.contract.WatchLogs(opts, "PasskeyRemoved", keyOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(WebAuthValidatorPasskeyRemoved)
+				if err := _WebAuthValidator.contract.UnpackLog(event, "PasskeyRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePasskeyRemoved is a log parse operation binding the contract event 0x60a29a47798fec901f6df6fe2a86177130b82aecf219f6c7960182b8a0627636.
+//
+// Solidity: event PasskeyRemoved(address indexed keyOwner, string originDomain, bytes credentialId)
+func (_WebAuthValidator *WebAuthValidatorFilterer) ParsePasskeyRemoved(log types.Log) (*WebAuthValidatorPasskeyRemoved, error) {
+	event := new(WebAuthValidatorPasskeyRemoved)
+	if err := _WebAuthValidator.contract.UnpackLog(event, "PasskeyRemoved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/scripts/zksync-sso/entrypoint-abi.sh
+++ b/scripts/zksync-sso/entrypoint-abi.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+echo "Install required tools"
+
+apt-get update && apt-get install -y jq
+corepack enable
+corepack prepare pnpm@latest --activate
+
+
+echo "Clone the matter-labs/zksync-sso-clave-contracts repository"
+git clone --depth 1 --single-branch --branch main https://github.com/matter-labs/zksync-sso-clave-contracts.git
+
+pushd zksync-sso-clave-contracts || exit 1
+
+echo "Install dependencies"
+pnpm install
+
+echo "Building smart contracts"
+pnpm build
+
+echo "Extracting ABI"
+SRC_DIR="./artifacts-zk/src"
+OUT_DIR="/abi"
+# Move all *.json one level up because it has structure like ./AAFactory.sol/AAFactory.json
+find "$SRC_DIR" -type f -name "*.json" ! -name "*.dbg.json" | while read -r file; do
+    dest_dir=$(dirname "$file")       # /$SRC_DIR/<intermediate_path>/AccountProxy.sol
+    dest_dir=$(dirname "$dest_dir")   # /$SRC_DIR/<intermediate_path>
+    mv $file $dest_dir
+done
+
+# Find all *.json files excluding *.dbg.json
+find "$SRC_DIR" -type f -name "*.json" ! -name "*.dbg.json" | while read -r file; do
+    # Get relative path
+    rel_path="${file#$SRC_DIR/}"
+
+    # Compute destination path
+    dest_path="$OUT_DIR/$rel_path" # like /abi/zksso/AAFactory.json
+
+    # Create destination directory if needed
+    mkdir -p "$(dirname "$dest_path")"
+
+    # Output file content, extract ABI only
+    jq '.abi' "$file" > $dest_path
+done

--- a/scripts/zksync-sso/entrypoint-contracts.sh
+++ b/scripts/zksync-sso/entrypoint-contracts.sh
@@ -1,0 +1,28 @@
+#!/bin/ash
+
+SRC_DIR="/abi"
+OUT_DIR="/contracts/zksyncsso"
+
+# Find all *.json files excluding *.dbg.json
+find "$SRC_DIR" -type f -name "*.json" ! -name "*.dbg.json" | while read -r file; do
+    # Get relative path
+    rel_path="${file#$SRC_DIR/}"  # like zksso/interfaces/IGuardianRecoveryValidator.json
+
+    file_name="${rel_path##*/}"       # IGuardianRecoveryValidator.json - file name
+    file_name="${file_name%.*}"        # IGuardianRecoveryValidator - strip extension
+    file_name_lowercase=$(echo "$file_name" | tr '[:upper:]' '[:lower:]') # iguardianrecoveryvalidator - to lowercase
+
+    base_dir=$(dirname "$rel_path")  # zksso/interfaces/
+
+    out_go_dir="$OUT_DIR"/"$base_dir"/"$file_name_lowercase" # zksso/interfaces/iguardianrecoveryvalidator
+    out_go_filepath="$out_go_dir"/"$file_name_lowercase".go  # zksso/interfaces/iguardianrecoveryvalidator/iguardianrecoveryvalidator.go
+
+    mkdir -p "$out_go_dir"
+
+    abigen  \
+      --abi "$file" \
+      --out "$out_go_filepath" \
+      --pkg "$file_name_lowercase" \
+      --type "$file_name"
+
+done

--- a/scripts/zksync-sso/execute.sh
+++ b/scripts/zksync-sso/execute.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -x  # or set -ex for error + command trace
+
+# Fetch the contracts from https://github.com/matter-labs/zksync-sso-clave-contracts
+# and generates ABI json files and puts them in abi folder.
+chmod +x entrypoint-abi.sh
+docker create --name fetch-abi-zksso --entrypoint /usr/local/bin/entrypoint-abi.sh node:23
+docker cp entrypoint-abi.sh fetch-abi-zksso:/usr/local/bin/entrypoint-abi.sh
+docker start -i fetch-abi-zksso
+mkdir -p ../../abi/zksso
+docker cp fetch-abi-zksso:/abi/. ../../abi/zksso
+docker rm fetch-abi-zksso
+
+# Generates go bindings from abi folder using abigen tool
+# and puts them in contracts folder.
+chmod +x entrypoint-contracts.sh
+docker create -it --name generate-go-contracts-zksso --entrypoint /usr/local/bin/entrypoint-contracts.sh ethereum/client-go:alltools-v1.15.7
+docker cp entrypoint-contracts.sh generate-go-contracts-zksso:/usr/local/bin/entrypoint-contracts.sh
+docker cp ../../abi/zksso generate-go-contracts-zksso:/abi
+docker start -i generate-go-contracts-zksso
+docker cp generate-go-contracts-zksso:/contracts/. ../../contracts
+docker rm generate-go-contracts-zksso


### PR DESCRIPTION
We use new feature of ZK Sync, named ZKsync SSO. I'm a Golang developer involved in this project. We lack of Golang smart contract wrappers for ZKsync SSO. So I created script to generate Golang wrappers of ZKsync SSO smart contracts using abigen and original Hardhat project of ZKsync SSO. All is run using docker.


# What :computer: 
* Makefile was changed, added "generate-contracts-zksso" target to call  "scripts/zksync-sso/execute.sh".
* New Shell script "scripts/zksync-sso/execute.sh" does two things: 

1. Downloads ZK Sync SSO project inside docker, runs it, performs copying of ABI JSON files from docker to local disk. 
2. Run another docker to run abigen utility to generate Golang files from ABI JSON, and copy it to "contracts/zksyncsso" dir. This dir is also included into this MR/PR.

* All other *.go files are autogenerated by this script. 

# Why :hand:
* New Smart Contracts of ZKsync SSO project is currently missing in this repo.
* We extensevely use ZKsync SSO for Golang development.

# Evidence :camera:
Included screenshots of successfull generation:
<img width="1361" alt="image" src="https://github.com/user-attachments/assets/9ebafcef-6b30-449d-be16-da00b4db84df" />


