### PR TITLE
Use Signer instead of *ECDSASigner

### DIFF
--- a/accounts/signer.go
+++ b/accounts/signer.go
@@ -16,6 +16,10 @@ import (
 
 // Signer provides support for signing various types of payloads using some kind of secret.
 type Signer interface {
+	PrivateKey() *ecdsa.PrivateKey
+	Address() common.Address
+	ChainID() *big.Int
+
 	// SignMessage sings an arbitrary message.
 	SignMessage(ctx context.Context, message []byte) ([]byte, error)
 	// SignTransaction signs the given transaction.

--- a/accounts/util.go
+++ b/accounts/util.go
@@ -50,7 +50,7 @@ func ensureTransactOpts(auth *TransactOpts) *TransactOpts {
 	return auth
 }
 
-func newTransactorWithSigner(signer *ECDSASigner, chainID *big.Int) (*bind.TransactOpts, error) {
+func newTransactorWithSigner(signer Signer, chainID *big.Int) (*bind.TransactOpts, error) {
 	if chainID == nil {
 		return nil, bind.ErrNoChainID
 	}

--- a/accounts/wallet.go
+++ b/accounts/wallet.go
@@ -41,7 +41,7 @@ func NewWallet(rawPrivateKey []byte, clientL2 *clients.Client, clientL1 *ethclie
 // require communication with the network.
 // A runner that contains only a signer can be configured to communicate with L2 and L1 networks by
 // using Wallet.Connect and Wallet.ConnectL1, respectively.
-func NewWalletFromSigner(signer *ECDSASigner, clientL2 *clients.Client, clientL1 *ethclient.Client) (*Wallet, error) {
+func NewWalletFromSigner(signer Signer, clientL2 *clients.Client, clientL1 *ethclient.Client) (*Wallet, error) {
 	if signer == nil {
 		return nil, errors.New("signer must be provided")
 	}

--- a/accounts/wallet_l1.go
+++ b/accounts/wallet_l1.go
@@ -56,7 +56,7 @@ func NewWalletL1(rawPrivateKey []byte, clientL1 *ethclient.Client, clientL2 *cli
 }
 
 // NewWalletL1FromSigner creates an instance of WalletL1 associated with the account provided by the signer.
-func NewWalletL1FromSigner(signer *ECDSASigner, clientL1 *ethclient.Client, clientL2 *clients.Client) (*WalletL1, error) {
+func NewWalletL1FromSigner(signer Signer, clientL1 *ethclient.Client, clientL2 *clients.Client) (*WalletL1, error) {
 	if signer == nil {
 		return nil, errors.New("signer is not provided")
 	} else if clientL1 == nil {
@@ -103,7 +103,7 @@ func NewWalletL1FromSigner(signer *ECDSASigner, clientL1 *ethclient.Client, clie
 
 // NewWalletL1FromSignerAndCache creates an instance of WalletL1 associated with the account provided by the signer with cache.
 // The cache is optional and if it is not provided, new empty cache is used.
-func NewWalletL1FromSignerAndCache(signer *ECDSASigner, clientL1 *ethclient.Client, clientL2 *clients.Client, cache *Cache) (*WalletL1, error) {
+func NewWalletL1FromSignerAndCache(signer Signer, clientL1 *ethclient.Client, clientL2 *clients.Client, cache *Cache) (*WalletL1, error) {
 	if signer == nil {
 		return nil, errors.New("signer is not provided")
 	} else if clientL1 == nil {

--- a/accounts/wallet_l2.go
+++ b/accounts/wallet_l2.go
@@ -24,7 +24,7 @@ import (
 // L2 network for the associated account.
 type WalletL2 struct {
 	client *clients.Client
-	signer *ECDSASigner
+	signer Signer
 	auth   *bind.TransactOpts
 	cache  *Cache
 }
@@ -69,7 +69,7 @@ func NewWalletL2FromSigner(signer *ECDSASigner, client *clients.Client) (*Wallet
 // The clientL2 can be optional and if it is not provided, only WalletL2.SignTransaction,
 // WalletL2.Address, WalletL2.Signer can be performed, as the rest of the
 // functionalities require communication to the network.
-func NewWalletL2FromSignerAndCache(signer *ECDSASigner, client *clients.Client, cache *Cache) (*WalletL2, error) {
+func NewWalletL2FromSignerAndCache(signer Signer, client *clients.Client, cache *Cache) (*WalletL2, error) {
 	if client == nil {
 		return &WalletL2{signer: signer}, nil
 	}
@@ -98,7 +98,7 @@ func (w *WalletL2) Address() common.Address {
 }
 
 // Signer returns the signer of the associated account.
-func (w *WalletL2) Signer() *ECDSASigner {
+func (w *WalletL2) Signer() Signer {
 	return w.signer
 }
 


### PR DESCRIPTION
# What :computer: 
* Use `Signer interface` for `Wallet` arguments, instead of `ECDSASigner struct`

# Why :hand:
* This allows to use the SDK with different implementations of `Signer`, e.g.: with AWS KMS
